### PR TITLE
Split up GitHub Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js #${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v1
-        # with:
-        #   node-version: ${{ matrix.node-version }}
+        with:
+          node-version: 12.x
       - run: yarn
       - run: yarn --cwd examples/app-host install
       - run: npx prettier --check .


### PR DESCRIPTION
Supersedes #18

## Why

To run linting (called it `test_static` based on https://github.com/mui-org/material-ui/blob/ae3c25193bf666ab9c8ca194f35fe200cc5d8504/.circleci/config.yml#L104 because it's not just linting but includes other types of static analysis such as type checking) and test stages in parallel.