### PR TITLE
fixes as recommended by manypkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "modular",
   "private": true,
   "workspaces": [
     "packages/*",
@@ -15,7 +16,7 @@
     "e2e:docker": "./e2e-tests/run-tests-in-docker.sh",
     "build": "yarn workspace create-modular-react-app build && yarn workspace modular-scripts build && yarn workspace esm-dependency-checker build"
   },
-  "devDependencies": {
+  "dependencies": {
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.9.4",
@@ -30,18 +31,18 @@
     "@types/react-dom": "^16.9.8",
     "@types/testing-library__jest-dom": "^5.9.1",
     "@types/testing-library__react": "^10.2.0",
-    "@typescript-eslint/eslint-plugin": "^3.0.1",
-    "@typescript-eslint/parser": "^3.0.1",
+    "@typescript-eslint/eslint-plugin": "^3.5.0",
+    "@typescript-eslint/parser": "^3.5.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.0.1",
     "confusing-browser-globals": "^1.0.9",
     "eslint": "^7.1.0",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jest": "^23.13.1",
     "eslint-plugin-jest-dom": "^2.1.0",
     "eslint-plugin-react": "^7.20.0",
-    "eslint-plugin-react-hooks": "^4.0.2",
+    "eslint-plugin-react-hooks": "^4.0.5",
     "eslint-plugin-testing-library": "^3.1.3",
     "husky": "^4.2.5",
     "jest": "^26.0.1",

--- a/packages/create-modular-react-app/src/cli.ts
+++ b/packages/create-modular-react-app/src/cli.ts
@@ -107,14 +107,7 @@ function createModularApp() {
 
   execSync(
     'yarnpkg',
-    [
-      'add',
-      '-W',
-      '--dev',
-      'prettier',
-      'modular-scripts',
-      'eslint-config-modular-app',
-    ],
+    ['add', '-W', 'prettier', 'modular-scripts', 'eslint-config-modular-app'],
     { cwd: newModularRoot },
   );
 

--- a/packages/esm-dependency-checker/package.json
+++ b/packages/esm-dependency-checker/package.json
@@ -18,7 +18,7 @@
     "@babel/parser": "^7.10.2",
     "@babel/traverse": "^7.10.1",
     "@yarnpkg/lockfile": "^1.1.0",
-    "chalk": "^4.0.0",
+    "chalk": "^4.1.0",
     "execa": "^4.0.2",
     "globby": "^11.0.0",
     "meow": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2468,7 +2468,7 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/eslint-plugin@^3.0.1", "@typescript-eslint/eslint-plugin@^3.5.0":
+"@typescript-eslint/eslint-plugin@^3.5.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.5.0.tgz#e7736e0808b5fb947a5f9dd949ae6736a7226b84"
   integrity sha512-m4erZ8AkSjoIUOf8s4k2V1xdL2c1Vy0D3dN6/jC9d7+nEqjY3gxXCkgi3gW/GAxPaA4hV8biaCoTVdQmfAeTCQ==
@@ -2511,7 +2511,7 @@
     "@typescript-eslint/typescript-estree" "2.34.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/parser@^3.0.1", "@typescript-eslint/parser@^3.5.0":
+"@typescript-eslint/parser@^3.5.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.5.0.tgz#9ff8c11877c48df24e10e19d7bf542ee0359500d"
   integrity sha512-sU07VbYB70WZHtgOjH/qfAp1+OwaWgrvD1Km1VXqRpcVxt971PMTU7gJtlrCje0M+Sdz7xKAbtiyIu+Y6QdnVA==
@@ -6049,7 +6049,7 @@ eslint-plugin-import@2.20.1:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
-eslint-plugin-import@^2.20.2, eslint-plugin-import@^2.22.0:
+eslint-plugin-import@^2.22.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
   integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
@@ -6119,7 +6119,7 @@ eslint-plugin-react-hooks@^1.6.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
   integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
 
-eslint-plugin-react-hooks@^4.0.2, eslint-plugin-react-hooks@^4.0.5:
+eslint-plugin-react-hooks@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.5.tgz#4879003aa38e5d05d0312175beb6e4a1f617bfcf"
   integrity sha512-3YLSjoArsE2rUwL8li4Yxx1SUg3DQWp+78N3bcJQGWVZckcp+yeQGsap/MSq05+thJk57o+Ww4PtZukXGL02TQ==


### PR DESCRIPTION
ran `npx @manypkg/cli check` and it output these warnings -

```
☔️ error esm-dependency-checker has a dependency on chalk@^4.0.0 but the highest range in the repo is ^4.1.0, the range should be set to ^4.1.0
☔️ error undefined has a dependency on @typescript-eslint/eslint-plugin@^3.0.1 but the highest range in the repo is ^3.5.0, the range should be set to ^3.5.0
☔️ error undefined has a dependency on @typescript-eslint/parser@^3.0.1 but the highest range in the repo is ^3.5.0, the range should be set to ^3.5.0
☔️ error undefined has a dependency on eslint-plugin-import@^2.20.2 but the highest range in the repo is ^2.22.0, the range should be set to ^2.22.0
☔️ error undefined has a dependency on eslint-plugin-react-hooks@^4.0.2 but the highest range in the repo is ^4.0.5, the range should be set to ^4.0.5
☔️ error The package at "/Users/F684320/code/modular" does not have a name
☔️ error the root package.json contains devDependencies, this is disallowed as devDependencies vs dependencies in a private package does not affect anything and creates confusion.
```

Then I ran `npx @manypkg/cli fix` and it fixed the problems.

---

I also fixed a similar issue in the generated repo, where the root `devDependencies` should actually be `dependencies`.