### PR TITLE
expose basic modular list command

### DIFF
--- a/.changeset/empty-carpets-beam.md
+++ b/.changeset/empty-carpets-beam.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+Addition of a modular list command for reviewing the current available packages


### PR DESCRIPTION
Expose a basic modular list command - for now just the same as ``ls`` with a pretty boring implementation as there's no support for anything outside of ``packages/*`` but could be extended later on. 