### PR TITLE
remove cra-template-modular-typescript from changeset

### DIFF
--- a/.changeset/wild-geese-wink.md
+++ b/.changeset/wild-geese-wink.md
@@ -1,5 +1,4 @@
 ---
-'cra-template-modular-typescript': minor
 'modular-scripts': minor
 ---
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,10 +87,7 @@ module.exports = {
     },
     {
       // Disable rules within templates that are fired erroneously.
-      files: [
-        'packages/cra-template-modular-typescript/**/*.{ts,tsx}',
-        'packages/create-modular-react-app/template/**/*.{ts,tsx}',
-      ],
+      files: ['packages/create-modular-react-app/template/**/*.{ts,tsx}'],
       rules: {
         '@typescript-eslint/no-unsafe-assignment': OFF,
         '@typescript-eslint/no-unsafe-call': OFF,


### PR DESCRIPTION
I'm trying to do a release, and it's failing because it's expecting a build on cra-template-modular-typescript (which was removed in https://github.com/jpmorganchase/modular/pull/132). This PR removes that intention from the one changeset that refers to it. 