### PR TITLE
modular.tsconfig

### DIFF
--- a/.changeset/early-rings-sing.md
+++ b/.changeset/early-rings-sing.md
@@ -1,0 +1,5 @@
+---
+'modular.tsconfig': minor
+---
+
+Create modular.tsconfig, a standard tsconfig for modular project

--- a/packages/modular.tsconfig/README.md
+++ b/packages/modular.tsconfig/README.md
@@ -1,0 +1,6 @@
+## modular.tsconfig
+
+This is a standard
+[tsconfig](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html)
+package, made for usage by [modular](https://github.com/jpmorganchase/modular)
+projects.

--- a/packages/modular.tsconfig/modular.tsconfig.json
+++ b/packages/modular.tsconfig/modular.tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  }
+}

--- a/packages/modular.tsconfig/modular.tsconfig.json
+++ b/packages/modular.tsconfig/modular.tsconfig.json
@@ -8,6 +8,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/packages/modular.tsconfig/package.json
+++ b/packages/modular.tsconfig/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "modular.tsconfig",
+  "version": "1.0.0",
+  "main": "modular.tsconfig.json",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
Fixes https://github.com/jpmorganchase/modular/issues/60

This creates a new package, `modular.tsconfig`, for usage with modular projects. We can iterate on this, and further improve it later. The benefit is that we can make meaningful changes and propagate them to consumers.

This PR does _not_ make changes to `create-modular-react-app` to use this just yet, because we'll have to publish this first before we can use it in tests, so I've punted on that for the next PR.

(PS: Much like jest/babel/etc configs, would've been nice if we could hide this and prevent changes altogether, but I don't think the community/ecosystem is mature enough for that yet. We'll tackle that at some point)