### PR TITLE
add CHANGELOG.md to defaultHashIgnores in tree-view-for-tests

### DIFF
--- a/packages/tree-view-for-tests/package.json
+++ b/packages/tree-view-for-tests/package.json
@@ -2,8 +2,7 @@
   "name": "tree-view-for-tests",
   "version": "1.0.0",
   "main": "src/index.ts",
-  "author": "Sunil Pai",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "private": true,
   "dependencies": {
     "@emotion/hash": "^0.8.0",

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -9,7 +9,7 @@ test('it can serialise a folder', () => {
     .toMatchInlineSnapshot(`
     "create-modular-react-app
     ├─ .npmignore #1rstiru
-    ├─ CHANGELOG.md #1o6jxmo
+    ├─ CHANGELOG.md
     ├─ README.md #r0jsfd
     ├─ package.json
     ├─ src

--- a/packages/tree-view-for-tests/src/index.ts
+++ b/packages/tree-view-for-tests/src/index.ts
@@ -14,8 +14,9 @@ const defaultHashIgnores = [
   // of some packages when making a repository
   'yarn.lock',
   'package-lock.json',
-  // adding package.json files since versions within these get bumped
+  // adding package.json/CHANGELOG.md files since they change on releases
   'package.json',
+  'CHANGELOG.md',
 ];
 
 function tree(


### PR DESCRIPTION
Much like we ignore the hash for package.json when generating a tree in snapshot tests, this PR adds CHANGELOG.md as well to the ignore list. Otherwise, every time we do a release, the hash on the changelog changes and breaks our tests/builds.