### PR TITLE
migrate test command to jest directly

### DIFF
--- a/.changeset/witty-foxes-punch.md
+++ b/.changeset/witty-foxes-punch.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Run jest manually, instead of using react-scripts to do so.

--- a/packages/modular-scripts/craco.config.js
+++ b/packages/modular-scripts/craco.config.js
@@ -85,6 +85,9 @@ module.exports = {
         testMatch: ['<rootDir>/*/src/**/*.{spec,test}.{js,ts,tsx}'],
         coverageDirectory: path.resolve(modularRoot, 'coverage'),
         collectCoverageFrom: ['<rootDir>/*/src/**/*.{js,ts,tsx}', '!**/*.d.ts'],
+        setupFiles: jestConfig.setupFiles.concat([
+          require.resolve('./jest-setupFiles.js'),
+        ]),
         setupFilesAfterEnv: glob.sync(
           `${absoluteModularGlobalConfigsPath}/setupTests.{js,ts,tsx}`,
           {

--- a/packages/modular-scripts/craco.config.js
+++ b/packages/modular-scripts/craco.config.js
@@ -86,7 +86,7 @@ module.exports = {
         coverageDirectory: path.resolve(modularRoot, 'coverage'),
         collectCoverageFrom: ['<rootDir>/*/src/**/*.{js,ts,tsx}', '!**/*.d.ts'],
         setupFiles: jestConfig.setupFiles.concat([
-          require.resolve('./jest-setupFiles.js'),
+          path.join(__dirname, './jest-setupFiles.js'),
         ]),
         setupFilesAfterEnv: glob.sync(
           `${absoluteModularGlobalConfigsPath}/setupTests.{js,ts,tsx}`,

--- a/packages/modular-scripts/jest-config.js
+++ b/packages/modular-scripts/jest-config.js
@@ -1,0 +1,4 @@
+const { createJestConfig } = require('@craco/craco');
+const cracoConfig = require('./craco.config.js');
+
+module.exports = createJestConfig(cracoConfig);

--- a/packages/modular-scripts/jest-config.js
+++ b/packages/modular-scripts/jest-config.js
@@ -1,4 +1,9 @@
+// We run jest by ourselves instead of using CRA's test runner because it assumes
+// that we're running from the context of an app, wherewas we're running the context
+// of a monorepo. Owning the runner then gives us the opportunity to generate
+// coverage reports correctly across workspaces, etc.
+
 const { createJestConfig } = require('@craco/craco');
 const cracoConfig = require('./craco.config.js');
-
-module.exports = createJestConfig(cracoConfig);
+const jestConfig = createJestConfig(cracoConfig);
+module.exports = jestConfig;

--- a/packages/modular-scripts/jest-setupFiles.js
+++ b/packages/modular-scripts/jest-setupFiles.js
@@ -1,0 +1,15 @@
+// We run jest by ourselves instead of using CRA's test runner because it assumes
+// that we're running from the context of an app, wherewas we're running the context
+// of a monorepo. Owning the runner then gives us the opportunity to generate
+// coverage reports correctly across workspaces, etc.
+
+// https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/scripts/test.js
+
+require('react-scripts/config/env');
+
+const verifyPackageTree = require('react-scripts/scripts/utils/verifyPackageTree');
+if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
+  verifyPackageTree();
+}
+
+// Unlike CRA, let's NOT verify typescript config when running tests.

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -42,6 +42,7 @@ function getBrowser() {
 function modular(str: string, opts: Record<string, unknown> = {}) {
   return execa('yarnpkg', ['modular', ...str.split(' ')], {
     cwd: modularRoot,
+    cleanup: true,
     ...opts,
   });
 }
@@ -151,7 +152,7 @@ afterAll(() => {
   rimraf.sync(path.join(packagesPath, 'sample-view'));
   rimraf.sync(path.join(packagesPath, 'sample-package'));
   // run yarn so yarn.lock gets reset
-  return execa('yarnpkg', [], {
+  return execa.sync('yarnpkg', [], {
     cwd: modularRoot,
   });
 });
@@ -268,16 +269,16 @@ describe('modular-scripts', () => {
   it('can execute tests', async () => {
     // skipping this because it leaves hanging tasks in CI
     // probably related to https://github.com/jpmorganchase/modular/issues/54
-    if (process.env.CI) {
-      return;
-    }
-    const output = await modular('test sample-app sample-package sample-view', {
-      all: true,
-      reject: false,
-      env: {
-        CI: 'true',
+    const output = await modular(
+      'test sample-app sample-package sample-view --watchAll=false',
+      {
+        all: true,
+        reject: false,
+        env: {
+          CI: 'true',
+        },
       },
-    });
+    );
 
     // TODO: Passing CI=true *should* remove all the coloring stuff,
     // it's weird that it doesn't. To workaround it, I've manually
@@ -288,13 +289,13 @@ describe('modular-scripts', () => {
     const cleanedOutput = output.all?.replace(/|\[\d+./gm, '');
 
     expect(cleanedOutput).toContain(
-      'PASS  ../sample-app/src/__tests__/App.test.tsx',
+      'PASS packages/sample-app/src/__tests__/App.test.tsx',
     );
     expect(cleanedOutput).toContain(
-      'PASS  ../sample-view/src/__tests__/index.test.tsx',
+      'PASS packages/sample-view/src/__tests__/index.test.tsx',
     );
     expect(cleanedOutput).toContain(
-      'PASS  ../sample-package/src/__tests__/index.test.ts',
+      'PASS packages/sample-package/src/__tests__/index.test.ts',
     );
   });
 });

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -40,6 +40,7 @@ function execSync(
     stdin: process.stdin,
     stderr: process.stderr,
     stdout: process.stdout,
+    cleanup: true,
     ...opts,
   });
 }
@@ -228,7 +229,10 @@ function addApp(name: string) {
 function test(args: string[]) {
   const modularRoot = getModularRoot();
 
-  const argv = ['--config', path.join(__dirname, '..', 'jest-config.js')];
+  const argv = mri(process.argv.slice(3))._.concat([
+    '--config',
+    path.join(__dirname, '..', 'jest-config.js'),
+  ]);
 
   // Watch unless on CI or explicitly running all tests
   if (!process.env.CI && args.indexOf('--watchAll=false') === -1) {
@@ -239,6 +243,7 @@ function test(args: string[]) {
   return execSync(jestBin, argv, {
     cwd: modularRoot,
     log: false,
+    cleanup: true,
     // @ts-ignore
     env: {
       BABEL_ENV: 'test',

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -303,7 +303,6 @@ function test(args: string[]) {
   return execSync(jestBin, argv, {
     cwd: modularRoot,
     log: false,
-    cleanup: true,
     // @ts-ignore
     env: {
       BABEL_ENV: 'test',


### PR DESCRIPTION
Fix for #112 where currently we require that an `app` be available in the modular structure to be able to run tests. This is because we leverage `craco` and therefore need there to be a `create-react-app` package available. 

This PR is the first step in migrating directly to `jest` for `modular test`. I've exposed `--watchAll` and `--coverage` for now, but we should look to work out exactly what abstraction we want to create on top of jest. This also will allow us to leverage incremental testing in future. 