### PR TITLE
Fix snapshots

### DIFF
--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -156,12 +156,7 @@ describe('create-modular-react-app', () => {
             "not op_mini all",
           ],
         },
-        "dependencies": Object {
-          "@types/react": "?",
-          "@types/react-dom": "?",
-          "react": "?",
-          "react-dom": "?",
-        },
+        "dependencies": Object {},
         "modular": Object {
           "type": "app",
         },

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -14,7 +14,7 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #1bzm54i
+    │  │  └─ index.test.ts #1r66pzs
     │  ├─ cli.ts #11y9qvx
     │  └─ index.ts #un0l9d
     └─ template


### PR DESCRIPTION
Because of how we run tests, it's possible for snapshots to _occasionally_ be out of date after we do a release (not always). This PR updates the broken snapshots. Will think of a longer term fix later.

This doesn't require a changeset, and I'll land it as soon as CI passes. 