### PR TITLE
enable in-browser linting experience

### DIFF
--- a/.changeset/three-wombats-check.md
+++ b/.changeset/three-wombats-check.md
@@ -1,0 +1,7 @@
+---
+'create-modular-react-app': patch
+'eslint-config-modular-app': patch
+'modular-scripts': patch
+---
+
+Enable in-browser lint experience, fix type requirements.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^17.0.1",
     "semver": "^7.3.2",
     "ts-node": "^9.0.0",
-    "typescript": "~4.1.2"
+    "typescript": "^4.1.2"
   },
   "husky": {
     "hooks": {

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -86,7 +86,7 @@ describe('create-modular-react-app', () => {
       │     │  ├─ logo.svg #1okqmlj
       │     │  └─ react-app-env.d.ts #1dm2mq6
       │     └─ tsconfig.json #6rw46b
-      ├─ tsconfig.json #1y19cv2
+      ├─ tsconfig.json #e5344q
       └─ yarn.lock"
     `);
     expect(

--- a/packages/create-modular-react-app/src/cli.ts
+++ b/packages/create-modular-react-app/src/cli.ts
@@ -123,7 +123,7 @@ export default function createModularApp(argv: {
       'prettier',
       'modular-scripts',
       'eslint-config-modular-app',
-      'typescript@~4.1.2',
+      'typescript@^4.1.2',
       ...preferOfflineArg,
     ],
     { cwd: newModularRoot },

--- a/packages/create-modular-react-app/template/tsconfig.json
+++ b/packages/create-modular-react-app/template/tsconfig.json
@@ -13,7 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": ["packages"]
 }

--- a/packages/eslint-config-modular-app/package.json
+++ b/packages/eslint-config-modular-app/package.json
@@ -17,9 +17,9 @@
     "eslint-plugin-testing-library": "^3.9.2"
   },
   "peerDependencies": {
-    "typescript": "~4.1.2"
+    "typescript": "^4.1.2"
   },
   "devDependencies": {
-    "typescript": "~4.1.2"
+    "typescript": "^4.1.2"
   }
 }

--- a/packages/modular-scripts/craco.config.js
+++ b/packages/modular-scripts/craco.config.js
@@ -15,9 +15,23 @@ const absolutePackagesPath = path.resolve(modularRoot, 'packages');
 const absoluteModularGlobalConfigsPath = path.resolve(modularRoot, 'modular');
 
 module.exports = {
+  // It only appears like we're disabling eslint here, but that's to work around the
+  // error generated when using this with crav4+. Note that the webpack eslint plugin
+  // is enabled manually in overrideWebpackConfig.
+  // ref: https://github.com/gsoft-inc/craco/issues/205
+  eslint: {
+    enable: false,
+  },
   plugins: [
     {
       plugin: {
+        overrideCracoConfig: ({ cracoConfig }) => {
+          if (typeof cracoConfig.eslint.enable !== 'undefined') {
+            cracoConfig.disableEslint = !cracoConfig.eslint.enable;
+          }
+          delete cracoConfig.eslint;
+          return cracoConfig;
+        },
         overrideWebpackConfig: ({ webpackConfig }) => {
           const plugin = webpackConfig.plugins.find(
             (plugin) => plugin.constructor.name === 'ESLintWebpackPlugin',

--- a/packages/modular-scripts/craco.config.js
+++ b/packages/modular-scripts/craco.config.js
@@ -15,36 +15,19 @@ const absolutePackagesPath = path.resolve(modularRoot, 'packages');
 const absoluteModularGlobalConfigsPath = path.resolve(modularRoot, 'modular');
 
 module.exports = {
-  // disabling eslint until https://github.com/gsoft-inc/craco/issues/205 is resolved
-  eslint: {
-    enable: false,
-  },
   plugins: [
     {
       plugin: {
-        overrideCracoConfig: ({ cracoConfig }) => {
-          if (typeof cracoConfig.eslint.enable !== 'undefined') {
-            cracoConfig.disableEslint = !cracoConfig.eslint.enable;
-          }
-          delete cracoConfig.eslint;
-          return cracoConfig;
-        },
-        overrideWebpackConfig: ({ webpackConfig, cracoConfig }) => {
-          if (
-            typeof cracoConfig.disableEslint !== 'undefined' &&
-            cracoConfig.disableEslint === true
-          ) {
-            webpackConfig.plugins = webpackConfig.plugins.filter(
-              (instance) => instance.constructor.name !== 'ESLintWebpackPlugin',
-            );
-          }
+        overrideWebpackConfig: ({ webpackConfig }) => {
+          const plugin = webpackConfig.plugins.find(
+            (plugin) => plugin.constructor.name === 'ESLintWebpackPlugin',
+          );
+          plugin.options.emitWarning = true;
           return webpackConfig;
         },
       },
     },
   ],
-  // end disable eslint config
-
   webpack: {
     configure(webpackConfig) {
       const { isFound, match } = getLoader(

--- a/packages/modular-site/tsconfig.json
+++ b/packages/modular-site/tsconfig.json
@@ -6,7 +6,8 @@
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -14,7 +14,7 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #u6q4fo
+    │  │  └─ index.test.ts #yy6l2u
     │  ├─ cli.ts #11k0y31
     │  └─ index.ts #un0l9d
     └─ template
@@ -24,6 +24,6 @@ test('it can serialise a folder', () => {
        │  └─ setupTests.ts #bnjknz
        ├─ packages
        │  └─ README.md #14bthrh
-       └─ tsconfig.json #1y19cv2"
+       └─ tsconfig.json #e5344q"
   `);
 });

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,7 +15,7 @@ test('it can serialise a folder', () => {
     ├─ src
     │  ├─ __tests__
     │  │  └─ index.test.ts #u6q4fo
-    │  ├─ cli.ts #1pgxu36
+    │  ├─ cli.ts #11k0y31
     │  └─ index.ts #un0l9d
     └─ template
        ├─ README.md #1nksyzj

--- a/yarn.lock
+++ b/yarn.lock
@@ -11925,7 +11925,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~4.1.2:
+typescript@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
   integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==


### PR DESCRIPTION
This PR is a a workaround for the the quirks with craco+create-react-appv4 that had led us to disable the in-browser lint experience. Fixes some type requirements too.

Fixes https://github.com/jpmorganchase/modular/issues/136

I'll land and publish this over the weekend to prevent churn. 