### PR TITLE
update engine requirements

### DIFF
--- a/.changeset/neat-mails-repair.md
+++ b/.changeset/neat-mails-repair.md
@@ -1,0 +1,6 @@
+---
+'create-modular-react-app': patch
+'modular-scripts': patch
+---
+
+Update node engine requirements to >=12

--- a/packages/create-modular-react-app/package.json
+++ b/packages/create-modular-react-app/package.json
@@ -6,7 +6,7 @@
     "create-modular-react-app": "build/index.js"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "clean": "rimraf build",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -6,7 +6,7 @@
     "modular": "build/cli.js"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "clean": "rimraf build",


### PR DESCRIPTION
We already require node>=12 for developing modular, we should also freeze the version requirements of our packages to node>=12. 