### PR TITLE
Allow multiple references to the views macro

### DIFF
--- a/.changeset/quiet-needles-add.md
+++ b/.changeset/quiet-needles-add.md
@@ -1,0 +1,5 @@
+---
+'modular-views.macro': patch
+---
+
+Allow multiple references in one file

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "modular": "ts-node packages/modular-scripts/src/cli.ts",
     "test": "yarn modular test",
     "build": "yarn workspace create-modular-react-app build && yarn workspace modular-scripts build && yarn workspace modular-views.macro build",
-    "release": "yarn build && changeset publish"
+    "release": "yarn build && changeset publish",
+    "start": "yarn modular start modular-site"
   },
   "dependencies": {
     "@babel/cli": "^7.10.1",

--- a/packages/modular-views.macro/src/__tests__/index.test.js
+++ b/packages/modular-views.macro/src/__tests__/index.test.js
@@ -37,7 +37,8 @@ afterAll(async () => {
 it('outputs a plain object when no views are available', async () => {
   const output = await transform();
   expect(output.all).toMatchInlineSnapshot(`
-    "console.log({});
+    "const __views__map__ = {};
+    console.log(__views__map__);
     "
   `);
 });
@@ -49,10 +50,11 @@ it('outputs a mapping of names to lazy components when views are available', asy
   const output = await transform();
   expect(output.all).toMatchInlineSnapshot(`
     "import { lazy as __lazy__ } from 'react';
-    console.log({
+    const __views__map__ = {
       'view-1': __lazy__(() => import('view-1')),
       'view-2': __lazy__(() => import('view-2'))
-    });
+    };
+    console.log(__views__map__);
     "
   `);
 });

--- a/packages/modular-views.macro/src/index.macro.js
+++ b/packages/modular-views.macro/src/index.macro.js
@@ -56,11 +56,15 @@ const viewsMap = `({
 })`;
 
 function views({ references, babel }) {
+  if (!references.default || references.default.length === 0) {
+    return;
+  }
+
   references.default[0].hub.file.path.node.body.unshift(
     babel.template.ast(`const __views__map__ = ${viewsMap};`),
   );
 
-  if (references.default.length > 0 && packageNames.length > 0) {
+  if (packageNames.length > 0) {
     references.default[0].hub.file.path.node.body.unshift(
       babel.template.ast("import {lazy as __lazy__} from 'react';"),
     );

--- a/packages/modular-views.macro/src/index.macro.js
+++ b/packages/modular-views.macro/src/index.macro.js
@@ -56,20 +56,19 @@ const viewsMap = `({
 })`;
 
 function views({ references, babel }) {
-  if (references.default.length > 1) {
-    throw new Error(
-      'Do not use modular-views.macro more than once in a module, it will bloat your bundle size.',
-    );
-    // TODO: would be nice if we could restrict it to only one usage per _program_.
-  }
-
-  references.default.forEach((ref) => ref.replaceWithSourceString(viewsMap));
+  references.default[0].hub.file.path.node.body.unshift(
+    babel.template.ast(`const __views__map__ = ${viewsMap};`),
+  );
 
   if (references.default.length > 0 && packageNames.length > 0) {
     references.default[0].hub.file.path.node.body.unshift(
       babel.template.ast("import {lazy as __lazy__} from 'react';"),
     );
   }
+
+  references.default.forEach((ref) =>
+    ref.replaceWithSourceString(`__views__map__`),
+  );
 }
 
 module.exports = createMacro(views);


### PR DESCRIPTION
This PR modifies the macro so you can have multiple references to the macro in one file and it won't output the map multiple times (also avoiding the annoying error).