### PR TITLE
move verify packages and rename setupFiles

### DIFF
--- a/.changeset/fair-mangos-mate.md
+++ b/.changeset/fair-mangos-mate.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+---
+
+Fix issue where verifyPackages would be called on all jest workers and exit
+without logging

--- a/packages/modular-scripts/craco.config.js
+++ b/packages/modular-scripts/craco.config.js
@@ -83,7 +83,7 @@ module.exports = {
         coverageDirectory: path.resolve(modularRoot, 'coverage'),
         collectCoverageFrom: ['<rootDir>/*/src/**/*.{js,ts,tsx}', '!**/*.d.ts'],
         setupFiles: jestConfig.setupFiles
-          .concat([path.join(__dirname, './jest-setupFiles.js')])
+          .concat([path.join(__dirname, './jest-setupEnvironment.js')])
           .concat(
             glob.sync(
               `${absoluteModularGlobalConfigsPath}/setupEnvironment.{js,ts,tsx}`,

--- a/packages/modular-scripts/jest-setupEnvironment.js
+++ b/packages/modular-scripts/jest-setupEnvironment.js
@@ -6,3 +6,5 @@
 // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/scripts/test.js
 
 require('react-scripts/config/env');
+
+// Unlike CRA, let's NOT verify typescript config when running tests.

--- a/packages/modular-scripts/jest-setupEnvironment.js
+++ b/packages/modular-scripts/jest-setupEnvironment.js
@@ -6,10 +6,3 @@
 // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/scripts/test.js
 
 require('react-scripts/config/env');
-
-const verifyPackageTree = require('react-scripts/scripts/utils/verifyPackageTree');
-if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
-  verifyPackageTree();
-}
-
-// Unlike CRA, let's NOT verify typescript config when running tests.

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -92,6 +92,7 @@ function getAllFiles(dirPath: string, arrayOfFiles: string[] = []) {
 function run() {
   const help = `
   Usage:
+    $ modular check
     $ modular add <package-name>
     $ modular start
     $ modular build
@@ -118,6 +119,8 @@ function run() {
         return start(argv._[1]);
       case 'build':
         return build(argv._[1]);
+      case 'check':
+        return check();
       default:
         console.log(help);
         process.exit(1);
@@ -304,7 +307,20 @@ function build(appPath: string) {
   });
 }
 
+type VerifyPackageTree = () => void;
+
+function check() {
+  const verifyPackageTree = require('react-scripts/scripts/utils/verifyPackageTree') as VerifyPackageTree; // eslint-disable-line @typescript-eslint/no-var-requires
+  verifyPackageTree();
+  // Unlike CRA, let's NOT verify typescript config when running tests.
+  console.log(chalk.greenBright(`All Good!`));
+}
+
 try {
+  if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
+    check();
+  }
+
   void run();
 } catch (err) {
   console.error(err);

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -92,7 +92,7 @@ function getAllFiles(dirPath: string, arrayOfFiles: string[] = []) {
 function run() {
   const help = `
   Usage:
-    $ modular check
+
     $ modular add <package-name>
     $ modular start
     $ modular build
@@ -119,8 +119,6 @@ function run() {
         return start(argv._[1]);
       case 'build':
         return build(argv._[1]);
-      case 'check':
-        return check();
       default:
         console.log(help);
         process.exit(1);
@@ -188,7 +186,14 @@ async function addPackage(name: string, typeArg: string | void) {
   execSync('yarnpkg', [], { cwd: newPackagePath });
 }
 
+type VerifyPackageTree = () => void;
+
 function test(args: string[]) {
+  if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
+    const verifyPackageTree = require('react-scripts/scripts/utils/verifyPackageTree') as VerifyPackageTree; // eslint-disable-line @typescript-eslint/no-var-requires
+    verifyPackageTree();
+  }
+
   const modularRoot = getModularRoot();
 
   let argv = process.argv
@@ -307,20 +312,7 @@ function build(appPath: string) {
   });
 }
 
-type VerifyPackageTree = () => void;
-
-function check() {
-  const verifyPackageTree = require('react-scripts/scripts/utils/verifyPackageTree') as VerifyPackageTree; // eslint-disable-line @typescript-eslint/no-var-requires
-  verifyPackageTree();
-  // Unlike CRA, let's NOT verify typescript config when running tests.
-  console.log(chalk.greenBright(`All Good!`));
-}
-
 try {
-  if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
-    check();
-  }
-
   void run();
 } catch (err) {
   console.error(err);


### PR DESCRIPTION
Fix issue where jest workers would exit without logs if there was an issue in the package tree. 