### PR TITLE
`modular build <library>`

### DIFF
--- a/.changeset/tender-rice-whisper.md
+++ b/.changeset/tender-rice-whisper.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+modular build `<library>`

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ packages/view-2
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/dist
+
+# Used by typescript for incremental builds 
+.tsbuildinfo
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --cache --fix --ext .js,.ts,.tsx --max-warnings 0",
     "*.{js,json,ts,tsx,css,md,mdx}": "prettier --write"
+  },
+  "resolutions": {
+    "rollup": "^2.33.3"
   }
 }

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -14,7 +14,13 @@
     "build": "babel --root-mode upward src --out-dir build --extensions .ts --ignore 'src/**/*.test.ts'"
   },
   "dependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.12.1",
+    "@babel/preset-env": "^7.12.10",
     "@craco/craco": "^5.8.0",
+    "@rollup/plugin-babel": "^5.2.1",
+    "@rollup/plugin-commonjs": "^16.0.0",
+    "@rollup/plugin-json": "^4.1.0",
+    "builtin-modules": "^3.1.0",
     "chalk": "^4.1.0",
     "change-case": "^4.1.1",
     "codegen.macro": "^4.0.0",
@@ -26,10 +32,14 @@
     "prompts": "^2.4.0",
     "react-scripts": "^4.0.1",
     "resolve-as-bin": "^2.1.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "rollup": "^2.33.3",
+    "rollup-plugin-postcss": "^3.1.8",
+    "tar": "^6.0.5"
   },
   "devDependencies": {
     "@schemastore/package": "^0.0.6",
+    "@schemastore/tsconfig": "^0.0.9",
     "@types/find-up": "^4.0.0",
     "@types/fs-extra": "^5.0.2",
     "@types/mri": "^1.1.0",
@@ -37,6 +47,7 @@
     "@types/prompts": "^2.0.9",
     "@types/puppeteer": "^5.4.0",
     "@types/rimraf": "^3.0.0",
+    "@types/tar": "^4.0.4",
     "pptr-testing-library": "^0.6.4",
     "puppeteer": "^5.4.1"
   }

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -48,7 +48,9 @@
     "@types/puppeteer": "^5.4.0",
     "@types/rimraf": "^3.0.0",
     "@types/tar": "^4.0.4",
-    "pptr-testing-library": "^0.6.4",
+    "pptr-testing-library": "^0.6.4"
+  },
+  "optionalDependencies": {
     "puppeteer": "^5.4.1"
   }
 }

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -1,6 +1,5 @@
 import execa from 'execa';
 import rimraf from 'rimraf';
-import puppeteer from 'puppeteer';
 import tree from 'tree-view-for-tests';
 import path from 'path';
 import fs from 'fs-extra';
@@ -27,17 +26,6 @@ const { getNodeText } = queries;
 jest.setTimeout(10 * 60 * 1000);
 
 const packagesPath = path.join(getModularRoot(), 'packages');
-
-function getBrowser() {
-  return puppeteer.launch(
-    process.env.CI
-      ? {
-          headless: true,
-          args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        }
-      : {},
-  );
-}
 
 function modular(str: string, opts: Record<string, unknown> = {}) {
   return execa('yarnpkg', ['modular', ...str.split(' ')], {
@@ -190,6 +178,28 @@ describe('modular-scripts', () => {
   });
 
   it('can start an app', async () => {
+    // Ok, so. Sunil's decided to get the new M1 MacBook Air. Some software doesn't run on it
+    // well yet. Particularly the puppeteer npm package failes to install and run
+    // (see https://github.com/puppeteer/puppeteer/issues/, issues #6634 and #6641,
+    // possible fix in pull #6495)
+
+    // Because of this, he's marked puppeteer in optionalDependencies, so it's failure to install
+    // doesn't block everything else. Further, because this particular test is already flaky,
+    // it's disabled when running locally. However, because it fails to install, it causes
+    // typescript and eslint failures. Hence the need to disable those errors for now.
+
+    // It's Sunil's responsibility to fix this when better, so shout at him if he doesn't.
+
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+
+    // This seems to be leaving hanging processes locally,
+    // so marking this test as a no-op for now. Sigh.
+    if (!process.env.CI) {
+      return;
+    }
+
+    const puppeteer = require('puppeteer');
+    // @ts-expect-error FIXME
     let browser: puppeteer.Browser | undefined;
     let devServer: DevServer | undefined;
     try {
@@ -198,7 +208,14 @@ describe('modular-scripts', () => {
         path.join(packagesPath, 'sample-app', 'src', 'App.tsx'),
       );
 
-      browser = await getBrowser();
+      browser = await puppeteer.launch(
+        process.env.CI
+          ? {
+              headless: true,
+              args: ['--no-sandbox', '--disable-setuid-sandbox'],
+            }
+          : {},
+      );
       devServer = await startApp('sample-app');
 
       const page = await browser.newPage();
@@ -225,6 +242,8 @@ describe('modular-scripts', () => {
         devServer.kill();
       }
     }
+
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
   });
 
   it('can add a view', async () => {

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -199,7 +199,7 @@ describe('modular-scripts', () => {
     }
 
     const puppeteer = require('puppeteer');
-    
+
     // @ts-expect-error FIXME
     let browser: puppeteer.Browser | undefined;
     let devServer: DevServer | undefined;

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -24,6 +24,15 @@ import * as ts from 'typescript';
 import * as fse from 'fs-extra';
 
 import builtinModules from 'builtin-modules';
+import getModularRoot from './getModularRoot';
+
+const modularRoot = getModularRoot();
+
+if (process.cwd() !== modularRoot) {
+  throw new Error(
+    'This command can only be run from the root of a modular project',
+  );
+}
 
 type Console = {
   log: typeof console.log;

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -542,7 +542,7 @@ function makeTypings(directoryName: string) {
   }
 }
 
-export default async function buildPackage(
+export async function build(
   directoryName: string,
   preserveModules = false,
 ): Promise<void> {

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -1,0 +1,500 @@
+// While working on this file, be aware that builds
+// could be happening simultaneously across packages, so
+// try be 'thread-safe'. No state outside of functions
+
+import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
+import { JSONSchemaForTheTypeScriptCompilerSConfigurationFile as TSConfig } from '@schemastore/tsconfig';
+
+import { promisify as prom } from 'util';
+
+import * as rollup from 'rollup';
+import rimraf from 'rimraf';
+import * as path from 'path';
+import { extract } from 'tar';
+
+import execa from 'execa';
+
+import postcss from 'rollup-plugin-postcss';
+import json from '@rollup/plugin-json';
+import resolve from '@rollup/plugin-node-resolve';
+import babel from '@rollup/plugin-babel';
+import commonjs from '@rollup/plugin-commonjs';
+
+import * as ts from 'typescript';
+import * as fse from 'fs-extra';
+
+import builtinModules from 'builtin-modules';
+
+// from https://github.com/Microsoft/TypeScript/issues/6387
+// a helper to output a readable message from a ts diagnostics object
+function reportTSDiagnostics(diagnostics: ts.Diagnostic[]): void {
+  diagnostics.forEach((diagnostic) => {
+    let message = 'Error';
+    if (diagnostic.file) {
+      const where = diagnostic.file.getLineAndCharacterOfPosition(
+        diagnostic.start as number,
+      );
+      message += ` ${diagnostic.file.fileName} ${where.line}, ${
+        where.character + 1
+      }`;
+    }
+    message +=
+      ': ' + ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+    console.log(message);
+  });
+}
+
+const extensions = ['.js', '.jsx', '.ts', '.tsx'];
+const outputDirectory = 'dist';
+const typescriptConfigFilename = 'tsconfig.json';
+const packagesRoot = 'packages';
+
+// list of all directories under packages
+const packageDirectoryNames = fse
+  .readdirSync(packagesRoot, { withFileTypes: true })
+  .filter((directoryEntry) => directoryEntry.isDirectory())
+  .map((directory) => directory.name);
+
+// dependencies defined at the root
+const rootPackageJsonDependencies =
+  (fse.readJSONSync('package.json') as PackageJson).dependencies || {};
+
+// a map of all package.json contents, indexed by package name
+const packageJsons: { [key: string]: PackageJson } = {};
+// a map of all package.json contents, indexed by directory name
+const packageJsonsByDirectoryName: {
+  [key: string]: PackageJson;
+} = {};
+
+// let's populate the above two
+for (let i = 0; i < packageDirectoryNames.length; i++) {
+  const pathToPackageJson = path.join(
+    packagesRoot,
+    packageDirectoryNames[i],
+    'package.json',
+  );
+  if (fse.existsSync(pathToPackageJson)) {
+    const packageJson = fse.readJsonSync(pathToPackageJson) as PackageJson;
+    // TODO: throw if there isn't a name?
+    packageJsons[packageJson.name as string] = packageJson;
+    packageJsonsByDirectoryName[packageDirectoryNames[i]] = packageJson;
+  }
+}
+
+const publicPackageJsons: {
+  [name: string]: PackageJson;
+} = {};
+
+const typescriptConfig: TSConfig = {};
+// validate tsconfig
+{
+  // Extract configuration from config file and parse JSON,
+  // after removing comments. Just a fancier JSON.parse
+  const result = ts.parseConfigFileTextToJson(
+    typescriptConfigFilename,
+    fse.readFileSync(typescriptConfigFilename, 'utf8').toString(),
+  );
+
+  const configObject = result.config as TSConfig;
+
+  if (!configObject) {
+    reportTSDiagnostics([result.error as ts.Diagnostic]);
+    throw new Error('Failed to load Typescript configuration');
+  }
+
+  Object.assign(typescriptConfig, configObject);
+
+  Object.assign(typescriptConfig.compilerOptions, {
+    declarationDir: outputDirectory,
+    noEmit: false,
+    declaration: true,
+    emitDeclarationOnly: true,
+    incremental: false,
+  });
+
+  Object.assign(typescriptConfig, {
+    exclude: [
+      // all TS test files, regardless whether co-located or in test/ etc
+      '**/*.stories.ts',
+      '**/*.stories.tsx',
+      '**/*.spec.ts',
+      '**/*.test.ts',
+      '**/*.e2e.ts',
+      '**/*.spec.tsx',
+      '**/*.test.tsx',
+      '__tests__',
+      // TS defaults below
+      'node_modules',
+      'bower_components',
+      'jspm_packages',
+      'tmp',
+    ],
+  });
+}
+
+async function makeBundle(directoryName: string): Promise<boolean> {
+  // TODO: - run whatever's in its scripts.build field too?
+  // TODO: verify that directoryName is in packageDirectoryNames
+
+  const packageJson = packageJsonsByDirectoryName[directoryName];
+
+  if (!packageJson) {
+    console.log(`no package.json in packages/${directoryName}, bailing...`);
+    return false;
+  }
+  if (packageJson.private === true) {
+    console.log(`packages/${directoryName} is marked private, bailing...`);
+    return false;
+  }
+
+  console.log(
+    `building ${packageJson.name as string} at packages/${directoryName}...`,
+  );
+
+  const bundle = await rollup.rollup({
+    // TODO: verify that .main exists
+    input: path.join(packagesRoot, directoryName, packageJson.main as string),
+    external: (id) => {
+      // via tsdx
+      if (id === 'babel-plugin-transform-async-to-promises/helpers') {
+        // we want to inline these helpers
+        return false;
+      }
+      // exclude any dependency that's not a realtive import
+      return !id.startsWith('.') && !path.isAbsolute(id);
+    },
+    treeshake: {
+      // via tsdx: Don't use getters and setters on plain objects.
+      propertyReadSideEffects: false,
+    },
+    plugins: [
+      resolve({
+        extensions,
+        browser: true,
+        mainFields: ['module', 'main', 'browser'],
+      }),
+      commonjs({ include: /\/node_modules\// }),
+      babel({
+        babelHelpers: 'bundled',
+        presets: [
+          ['@babel/preset-typescript', { isTSX: true, allExtensions: true }],
+          '@babel/preset-react',
+          [
+            '@babel/preset-env',
+            {
+              // targets: { esmodules: true }, // Use the targets that you was already using
+              // bugfixes: true, // will be default in Babel 8
+            },
+          ],
+        ],
+        plugins: ['@babel/plugin-proposal-class-properties'],
+        extensions,
+        include: [`${packagesRoot}/**/*`],
+        exclude: 'node_modules/**',
+      }),
+      postcss({ extract: false, modules: true }),
+      // TODO: add sass, css modules, dotenv
+      json(),
+      {
+        // via tsdx
+        // Custom plugin that removes shebang from code because newer
+        // versions of bublé bundle their own private version of `acorn`
+        // and I don't know a way to patch in the option `allowHashBang`
+        // to acorn. Taken from microbundle.
+        // See: https://github.com/Rich-Harris/buble/pull/165
+        name: 'strip-shebang',
+        transform(code) {
+          code = code.replace(/^#!(.*)/, '');
+
+          return {
+            code,
+            map: null,
+          };
+        },
+      },
+    ],
+    // TODO: support for css modules, sass, dotenv,
+    // and anything else create-react-app supports
+    // (alternatively, disable support for those in apps)
+  });
+
+  const outputOptions = {
+    freeze: false,
+    sourcemap: true, // TODO: read this off env
+    globals: { react: 'React', 'react-native': 'ReactNative' }, // why?
+  };
+
+  // we're going to use bundle.write() to actually generate the
+  // output files, but first we're going to do a scan
+  // to validate dependencies and collect some metadata for later
+  const { output } = await bundle.generate(outputOptions);
+  // TODO: we should use this loop to generate the files itself
+  // to avoid the second scan, but it's ok for now I guess.
+
+  // "local" workspaces/packages that were imported, i.e - packages/*
+  const localImports: { [name: string]: string } = {};
+
+  // imports that aren't defined in package.json or root package.json
+  // Now, this will also mark dependencies that were transient/nested,
+  // but I think that's the right choice; a dependency might remove it,
+  // even in a patch, and it'll break your code and you wouldn't know why.
+  const missingDependencies: string[] = [];
+
+  for (const chunkOrAsset of output) {
+    if (chunkOrAsset.type === 'asset') {
+      // TODO: what should happen here?
+    } else {
+      // it's a 'chunk' of source code, let's analyse it
+      for (const imported of [
+        ...chunkOrAsset.imports,
+        ...chunkOrAsset.dynamicImports,
+      ]) {
+        // get the dependency (without references any inner modules)
+        // TODO: we should probably throw an error if you try to reference
+        // an inner module from a separate workspace, until we land support
+        // for multiple entry points
+        const importedPath = imported.split('/');
+        const importedPackage =
+          // scoped package?
+          importedPath[0][0] === '@'
+            ? `${importedPath[0]}/${importedPath[1]}`
+            : // non-scoped
+              importedPath[0];
+
+        if (packageJsons[importedPackage]) {
+          // This means we're importing from a local workspace
+          // Let's collect the name and add it in the package.json
+          // we publish to the registry
+          // TODO: make sure local workspaces are NOT explicitly included in package.json
+          if (packageJsons[importedPackage].private !== true) {
+            localImports[importedPackage] = packageJsons[importedPackage]
+              .version as string;
+          } else {
+            throw new Error(
+              `referencing a private package: ${importedPackage}`,
+            ); // TODO - lineNo, filename
+          }
+        } else {
+          // remote
+          if (
+            // not mentioned in the local package.json
+            !packageJson.dependencies?.[importedPackage] &&
+            !packageJson.peerDependencies?.[importedPackage]
+          ) {
+            if (rootPackageJsonDependencies[importedPackage]) {
+              localImports[importedPackage] =
+                rootPackageJsonDependencies[importedPackage];
+            } else {
+              // not mentioned in the root package.json either, so
+              // let's collect its name and throw an error later
+              // TODO: if it's in root's dev dependencies, should throw a
+              // different kind of error
+              if (!builtinModules.includes(importedPackage)) {
+                missingDependencies.push(importedPackage);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (Object.keys(localImports).length > 0) {
+    console.log('Adding these dependencies to the generated packages.json:');
+    console.log(localImports);
+  }
+
+  if (missingDependencies.length > 0) {
+    throw new Error(
+      `Missing dependencies: ${missingDependencies.join(', ')};`, // TODO: lineNo, filename
+    );
+  }
+
+  // now actually write the bundles to disk
+  // TODO: write to disk in the above check itself to prevent this 2nd pass
+
+  await bundle.write({
+    ...outputOptions,
+    preserveModules: true,
+    dir: path.join(
+      packagesRoot,
+      directoryName,
+      outputDirectory,
+      'cjs',
+      path.dirname(packageJson.main as string),
+    ),
+    format: 'cjs',
+  });
+
+  await bundle.write({
+    ...outputOptions,
+    preserveModules: true,
+    dir: path.join(
+      packagesRoot,
+      directoryName,
+      outputDirectory,
+      'es',
+      path.dirname(packageJson.main as string),
+    ),
+    format: 'es',
+  });
+
+  // store the public facing package.json that we'll write to disk later
+  // TODO: We should probably warn that module/typings will be overwritten
+  // if they're already specified
+  publicPackageJsons[directoryName] = {
+    ...packageJson,
+    main: path.join(
+      outputDirectory,
+      'cjs',
+      (packageJson.main as string).replace(/\.tsx?$/, '.js'),
+    ),
+    module: path.join(
+      outputDirectory,
+      'es',
+      (packageJson.main as string).replace(/\.tsx?$/, '.js'),
+    ),
+    typings: path.join(
+      outputDirectory,
+      'types',
+      (packageJson.main as string).replace(/\.tsx?$/, '.d.ts'),
+    ),
+    dependencies: {
+      ...packageJson.dependencies,
+      ...localImports,
+    },
+    files: [...new Set([...(packageJson.files || []), '/dist'])],
+  };
+
+  console.log(`built ${directoryName}`);
+  return true;
+}
+
+function makeTypings(packageDirectory: string) {
+  console.log('generating .d.ts files for', packageDirectory);
+
+  // make a shallow copy of the configuration
+  const tsconfig: TSConfig = {
+    ...typescriptConfig,
+  };
+
+  tsconfig.compilerOptions = {
+    ...typescriptConfig.compilerOptions,
+  };
+
+  // then add our custom stuff
+  tsconfig.include = [`${packagesRoot}/${packageDirectory}`];
+  tsconfig.compilerOptions = {
+    ...tsconfig.compilerOptions,
+    declarationDir: `${packagesRoot}/${packageDirectory}/${outputDirectory}/types`,
+    rootDir: `${packagesRoot}/${packageDirectory}`,
+  };
+
+  // Extract config information
+  const configParseResult = ts.parseJsonConfigFileContent(
+    tsconfig,
+    ts.sys,
+    path.dirname(typescriptConfigFilename),
+  );
+
+  if (configParseResult.errors.length > 0) {
+    reportTSDiagnostics(configParseResult.errors);
+    throw new Error('Could not parse Typescript configuration');
+  }
+
+  const host = ts.createCompilerHost(configParseResult.options);
+  host.writeFile = (fileName, contents) => {
+    fse.mkdirpSync(path.dirname(fileName));
+    fse.writeFileSync(fileName, contents);
+  };
+
+  // Compile
+  const program = ts.createProgram(
+    configParseResult.fileNames,
+    configParseResult.options,
+    host,
+  );
+
+  const emitResult = program.emit();
+
+  // Report errors
+  // TODO: this should fail the build
+  reportTSDiagnostics(
+    ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics),
+  );
+}
+
+async function cleanPackage(directoryName: string) {
+  // delete packageName/dist
+  await prom(rimraf)(path.join(packagesRoot, directoryName, outputDirectory));
+}
+
+export default async function buildPackage(
+  directoryName: string,
+): Promise<void> {
+  // ensure the root build folder is ready
+  await fse.mkdirp(outputDirectory);
+
+  // delete any existing build folder, if at all
+  await cleanPackage(directoryName);
+
+  // generate the js files
+  const didBundle = await makeBundle(directoryName);
+  if (!didBundle) {
+    return;
+  }
+  // then the .d.ts files
+  makeTypings(directoryName);
+
+  const originalPkgJsonContent = (await fse.readJson(
+    path.join(packagesRoot, directoryName, 'package.json'),
+  )) as PackageJson;
+
+  // switch in the special package.json
+  await fse.writeJson(
+    path.join(packagesRoot, directoryName, 'package.json'),
+    publicPackageJsons[directoryName],
+    { spaces: 2 },
+  );
+
+  // TODO: this should fail if the tgz already exists?
+  await execa(
+    'yarnpkg',
+    // TODO: verify this works on windows
+    [
+      'pack',
+      '--filename',
+      path.join(`../../${outputDirectory}`, directoryName + '.tgz'),
+    ],
+    {
+      cwd: packagesRoot + '/' + directoryName,
+      stdin: process.stdin,
+      stderr: process.stderr,
+      stdout: process.stdout,
+    },
+  );
+
+  // now revert package.json
+  await fse.writeJson(
+    path.join(packagesRoot, directoryName, 'package.json'),
+    originalPkgJsonContent,
+    { spaces: 2 },
+  );
+
+  // cool. now unpack the tgz's contents in the root dist
+  await fse.mkdirp(path.join(outputDirectory, directoryName));
+  await extract({
+    file: path.join(outputDirectory, directoryName + '.tgz'),
+    strip: 1,
+    C: path.join(outputDirectory, directoryName),
+  });
+
+  // delete the local dist folder
+  await prom(rimraf)(path.join(packagesRoot, directoryName, outputDirectory));
+
+  // if you're curious why we unpack it here, it's because
+  // we observed problems with publishing tgz files directly to npm.
+
+  // then delete the tgz
+  await fse.remove(path.join(outputDirectory, directoryName + '.tgz'));
+  /// and... that's it
+}

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -68,7 +68,7 @@ function reportTSDiagnostics(
   });
 }
 
-const extensions = ['.js', '.jsx', '.ts', '.tsx'];
+const extensions = ['.ts', '.tsx', '.js', '.jsx'];
 const outputDirectory = 'dist';
 const typescriptConfigFilename = 'tsconfig.json';
 const packagesRoot = 'packages';

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -306,7 +306,6 @@ async function makeBundle(
   const outputOptions = {
     freeze: false,
     sourcemap: true, // TODO: read this off env
-    globals: { react: 'React', 'react-native': 'ReactNative' }, // why?
   };
 
   // we're going to use bundle.write() to actually generate the

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -12,7 +12,6 @@ import {
 } from 'change-case';
 import prompts from 'prompts';
 import resolveAsBin from 'resolve-as-bin';
-import buildPackage from './build';
 import getModularRoot from './getModularRoot';
 
 // Makes the script crash on unhandled rejections instead of silently
@@ -337,7 +336,10 @@ async function build(directoryName: string, preserveModules?: boolean) {
     await fs.move(`packages/${directoryName}/build`, `dist/${directoryName}`);
   } else {
     // it's a view/package, run a library build
-    await buildPackage(directoryName, preserveModules);
+    const { build } = await import('./build');
+    // ^ we do a dynamic import here to defer the module's initial side effects
+    // till when it's actually needed (i.e. now)
+    await build(directoryName, preserveModules);
   }
 }
 

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -121,8 +121,8 @@ async function run() {
       case 'start':
         return start(argv._[1]);
       case 'build':
-        return build(
-          argv._[1],
+        return buildParallel(
+          argv._[1].split(','),
           argv['preserve-modules'] as boolean | undefined,
         );
       default:
@@ -301,12 +301,26 @@ function start(appPath: string) {
   });
 }
 
+// run builds in parallel
+async function buildParallel(
+  directoryNames: string[],
+  preserveModules?: boolean,
+) {
+  const result = await Promise.allSettled(
+    directoryNames.map((name) => build(name, preserveModules)),
+  );
+  const error = result.find((result) => result.status === 'rejected');
+  if (error) throw error;
+}
+
 async function build(directoryName: string, preserveModules?: boolean) {
   const modularRoot = getModularRoot();
 
   if (isModularType(path.join(modularRoot, 'packages', directoryName), 'app')) {
     // create-react-app doesn't support plain module outputs yet,
     // so --preserve-modules has no effect here
+    await fs.remove(`dist/${directoryName}`);
+    // TODO: this shouldn't be sync
     execSync(cracoBin, ['build', '--config', cracoConfig], {
       cwd: path.join(modularRoot, 'packages', directoryName),
       log: false,
@@ -315,18 +329,16 @@ async function build(directoryName: string, preserveModules?: boolean) {
         MODULAR_ROOT: modularRoot,
       },
     });
+
+    await fs.move(`packages/${directoryName}/build`, `dist/${directoryName}`);
   } else {
     // it's a view/package, run a library build
     await buildPackage(directoryName, preserveModules);
   }
 }
 
-void run()
-  .catch((err) => {
-    // todo - cleanup on errors
-    console.error(err);
-    process.exit(1);
-  })
-  .then(() => {
-    // console.log('success! all built.');
-  });
+void run().catch((err) => {
+  // todo - cleanup on errors
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -112,13 +112,19 @@ async function run() {
   try {
     switch (command) {
       case 'add':
-        return addPackage(argv._[1], argv['unstable-type'] as string | void);
+        return addPackage(
+          argv._[1],
+          argv['unstable-type'] as string | undefined,
+        );
       case 'test':
         return test(process.argv.slice(3));
       case 'start':
         return start(argv._[1]);
       case 'build':
-        return build(argv._[1]);
+        return build(
+          argv._[1],
+          argv['preserve-modules'] as boolean | undefined,
+        );
       default:
         console.log(help);
         process.exit(1);
@@ -295,10 +301,12 @@ function start(appPath: string) {
   });
 }
 
-async function build(directoryName: string) {
+async function build(directoryName: string, preserveModules?: boolean) {
   const modularRoot = getModularRoot();
 
   if (isModularType(path.join(modularRoot, 'packages', directoryName), 'app')) {
+    // create-react-app doesn't support plain module outputs yet,
+    // so --preserve-modules has no effect here
     execSync(cracoBin, ['build', '--config', cracoConfig], {
       cwd: path.join(modularRoot, 'packages', directoryName),
       log: false,
@@ -308,8 +316,8 @@ async function build(directoryName: string) {
       },
     });
   } else {
-    // it's a view/package, run
-    await buildPackage(directoryName);
+    // it's a view/package, run a library build
+    await buildPackage(directoryName, preserveModules);
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "jsx": "react-jsx" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     "noEmit": true /* Do not emit outputs. */,
     "isolatedModules": true /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */,
-
+    "downlevelIteration": true,
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
 
@@ -20,6 +20,7 @@
 
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-    "sourceMap": true
+    "sourceMap": true,
+    "incremental": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,6 +31,11 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.5.tgz#f56db0c4bb1bbbf221b4e81345aab4141e7cb0e9"
   integrity sha512-DTsS7cxrsH3by8nqQSpFSyjSfSYl57D6Cf4q8dW3LK83tBKBDCkfcay1nYkXq1nIHXnpX8WMMb/O25HOy3h1zg==
 
+"@babel/compat-data@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.7.tgz#9329b4782a7d6bbd7eef57e11addf91ee3ef1e41"
+  integrity sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==
+
 "@babel/core@7.12.3", "@babel/core@^7.1.0", "@babel/core@^7.7.5", "@babel/core@^7.8.4", "@babel/core@^7.9.0", "@babel/core@^7.9.6":
   version "7.12.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
@@ -94,7 +99,7 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-compilation-targets@^7.12.1":
+"@babel/helper-compilation-targets@^7.12.1", "@babel/helper-compilation-targets@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz#cb470c76198db6a24e9dbc8987275631e5d29831"
   integrity sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
@@ -170,7 +175,7 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.1":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
   integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
@@ -376,6 +381,14 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
+"@babel/plugin-proposal-numeric-separator@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz#8bf253de8139099fea193b297d23a9d406ef056b"
+  integrity sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+
 "@babel/plugin-proposal-object-rest-spread@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz#def9bd03cea0f9b72283dac0ec22d289c7691069"
@@ -397,6 +410,15 @@
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz#cce122203fc8a32794296fc377c6dedaf4363797"
   integrity sha512-c2uRpY6WzaVDzynVY9liyykS+kVU+WRZPMPYpkelXH8KBt1oXoI89kPbZKKG/jDT5UK92FTW2fZkZaJhdiBabw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+
+"@babel/plugin-proposal-optional-chaining@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz#e02f0ea1b5dc59d401ec16fb824679f683d3303c"
+  integrity sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
@@ -838,6 +860,13 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-regex" "^7.10.4"
 
+"@babel/plugin-transform-sticky-regex@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz#560224613ab23987453948ed21d0b0b193fa7fad"
+  integrity sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
 "@babel/plugin-transform-template-literals@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz#b43ece6ed9a79c0c71119f576d299ef09d942843"
@@ -849,6 +878,13 @@
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz#9ca6be343d42512fbc2e68236a82ae64bc7af78a"
   integrity sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-typeof-symbol@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz#de01c4c8f96580bd00f183072b0d0ecdcf0dec4b"
+  integrity sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -948,6 +984,78 @@
     core-js-compat "^3.6.2"
     semver "^5.5.0"
 
+"@babel/preset-env@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.10.tgz#ca981b95f641f2610531bd71948656306905e6ab"
+  integrity sha512-Gz9hnBT/tGeTE2DBNDkD7BiWRELZt+8lSysHuDwmYXUIvtwZl0zI+D6mZgXZX0u8YBlLS4tmai9ONNY9tjRgRA==
+  dependencies:
+    "@babel/compat-data" "^7.12.7"
+    "@babel/helper-compilation-targets" "^7.12.5"
+    "@babel/helper-module-imports" "^7.12.5"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-validator-option" "^7.12.1"
+    "@babel/plugin-proposal-async-generator-functions" "^7.12.1"
+    "@babel/plugin-proposal-class-properties" "^7.12.1"
+    "@babel/plugin-proposal-dynamic-import" "^7.12.1"
+    "@babel/plugin-proposal-export-namespace-from" "^7.12.1"
+    "@babel/plugin-proposal-json-strings" "^7.12.1"
+    "@babel/plugin-proposal-logical-assignment-operators" "^7.12.1"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
+    "@babel/plugin-proposal-numeric-separator" "^7.12.7"
+    "@babel/plugin-proposal-object-rest-spread" "^7.12.1"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.12.1"
+    "@babel/plugin-proposal-optional-chaining" "^7.12.7"
+    "@babel/plugin-proposal-private-methods" "^7.12.1"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.12.1"
+    "@babel/plugin-syntax-async-generators" "^7.8.0"
+    "@babel/plugin-syntax-class-properties" "^7.12.1"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+    "@babel/plugin-syntax-json-strings" "^7.8.0"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+    "@babel/plugin-syntax-top-level-await" "^7.12.1"
+    "@babel/plugin-transform-arrow-functions" "^7.12.1"
+    "@babel/plugin-transform-async-to-generator" "^7.12.1"
+    "@babel/plugin-transform-block-scoped-functions" "^7.12.1"
+    "@babel/plugin-transform-block-scoping" "^7.12.1"
+    "@babel/plugin-transform-classes" "^7.12.1"
+    "@babel/plugin-transform-computed-properties" "^7.12.1"
+    "@babel/plugin-transform-destructuring" "^7.12.1"
+    "@babel/plugin-transform-dotall-regex" "^7.12.1"
+    "@babel/plugin-transform-duplicate-keys" "^7.12.1"
+    "@babel/plugin-transform-exponentiation-operator" "^7.12.1"
+    "@babel/plugin-transform-for-of" "^7.12.1"
+    "@babel/plugin-transform-function-name" "^7.12.1"
+    "@babel/plugin-transform-literals" "^7.12.1"
+    "@babel/plugin-transform-member-expression-literals" "^7.12.1"
+    "@babel/plugin-transform-modules-amd" "^7.12.1"
+    "@babel/plugin-transform-modules-commonjs" "^7.12.1"
+    "@babel/plugin-transform-modules-systemjs" "^7.12.1"
+    "@babel/plugin-transform-modules-umd" "^7.12.1"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.12.1"
+    "@babel/plugin-transform-new-target" "^7.12.1"
+    "@babel/plugin-transform-object-super" "^7.12.1"
+    "@babel/plugin-transform-parameters" "^7.12.1"
+    "@babel/plugin-transform-property-literals" "^7.12.1"
+    "@babel/plugin-transform-regenerator" "^7.12.1"
+    "@babel/plugin-transform-reserved-words" "^7.12.1"
+    "@babel/plugin-transform-shorthand-properties" "^7.12.1"
+    "@babel/plugin-transform-spread" "^7.12.1"
+    "@babel/plugin-transform-sticky-regex" "^7.12.7"
+    "@babel/plugin-transform-template-literals" "^7.12.1"
+    "@babel/plugin-transform-typeof-symbol" "^7.12.10"
+    "@babel/plugin-transform-unicode-escapes" "^7.12.1"
+    "@babel/plugin-transform-unicode-regex" "^7.12.1"
+    "@babel/preset-modules" "^0.1.3"
+    "@babel/types" "^7.12.10"
+    core-js-compat "^3.8.0"
+    semver "^5.5.0"
+
 "@babel/preset-modules@^0.1.3":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.4.tgz#362f2b68c662842970fdb5e254ffc8fc1c2e415e"
@@ -1043,6 +1151,15 @@
   version "7.12.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
   integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.10.tgz#7965e4a7260b26f09c56bcfcb0498af1f6d9b260"
+  integrity sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -1581,6 +1698,34 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@rollup/plugin-babel@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.2.1.tgz#20fc8f8864dc0eaa1c5578408459606808f72924"
+  integrity sha512-Jd7oqFR2dzZJ3NWANDyBjwTtX/lYbZpVcmkHrfQcpvawHs9E4c0nYk5U2mfZ6I/DZcIvy506KZJi54XK/jxH7A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@rollup/pluginutils" "^3.1.0"
+
+"@rollup/plugin-commonjs@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-16.0.0.tgz#169004d56cd0f0a1d0f35915d31a036b0efe281f"
+  integrity sha512-LuNyypCP3msCGVQJ7ki8PqYdpjfEkE/xtFa5DqlF+7IBD0JsfMZ87C58heSwIMint58sAUZbt3ITqOmdQv/dXw==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
+
+"@rollup/plugin-json@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
@@ -1613,6 +1758,11 @@
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@schemastore/package/-/package-0.0.6.tgz#9a76713da1c7551293b7e72e4f387f802bfd5d81"
   integrity sha512-uNloNHoyHttSSdeuEkkSC+mdxJXMKlcUPOMb//qhQbIQijXg8x54VmAw3jm6GJZQ5DBtIqGBd66zEQCDCChQVA==
+
+"@schemastore/tsconfig@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@schemastore/tsconfig/-/tsconfig-0.0.9.tgz#77a1a1fb55eb879391aa78db3154dbcc4d93948b"
+  integrity sha512-0T6K8M9Lt+s9IfMotEb6rLifYlwLHyazkwLO9B9km+RNSqDrx2NI5cB/7wAiZfvIVKK/UFlG0abaCNf01ydx8Q==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
@@ -1933,6 +2083,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
+"@types/minipass@*":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/minipass/-/minipass-2.2.0.tgz#51ad404e8eb1fa961f75ec61205796807b6f9651"
+  integrity sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mri@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/mri/-/mri-1.1.0.tgz#66555e4d797713789ea0fefdae0898d8170bf5af"
@@ -2036,6 +2193,14 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+
+"@types/tar@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.4.tgz#d680de60855e7778a51c672b755869a3b8d2889f"
+  integrity sha512-0Xv+xcmkTsOZdIF4yCnd7RkOOyfyqPaqJ7RZFKnwdxfDbkN3eAAE9sHl8zJFqBz4VhxolW9EErbjR1oyH7jK2A==
+  dependencies:
+    "@types/minipass" "*"
+    "@types/node" "*"
 
 "@types/testing-library__jest-dom@^5.9.1":
   version "5.9.5"
@@ -2464,7 +2629,7 @@ acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0:
+acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -2568,6 +2733,11 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -3286,6 +3456,17 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4
     escalade "^3.1.1"
     node-releases "^1.1.66"
 
+browserslist@^4.15.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.0.tgz#410277627500be3cb28a1bfe037586fbedf9488b"
+  integrity sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==
+  dependencies:
+    caniuse-lite "^1.0.30001165"
+    colorette "^1.2.1"
+    electron-to-chromium "^1.3.621"
+    escalade "^3.1.1"
+    node-releases "^1.1.67"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -3488,6 +3669,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz#2d11aaeb239b340bc1aa730eca18a37fdb07a9ab"
   integrity sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==
 
+caniuse-lite@^1.0.30001165:
+  version "1.0.30001165"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz#32955490d2f60290bb186bb754f2981917fa744f"
+  integrity sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==
+
 capital-case@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.3.tgz#339bd77e8fab6cf75111d4fca509b3edf7c117c8"
@@ -3522,6 +3708,17 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
 
 chalk@^3.0.0:
   version "3.0.0"
@@ -3889,6 +4086,13 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concat-with-sourcemaps@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz#d4ea93f05ae25790951b99e7b3b09e3908a4082e"
+  integrity sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==
+  dependencies:
+    source-map "^0.6.1"
+
 confusing-browser-globals@^1.0.10, confusing-browser-globals@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
@@ -3980,6 +4184,14 @@ core-js-compat@^3.6.2:
   integrity sha512-V8yBI3+ZLDVomoWICO6kq/CD28Y4r1M7CWeO4AGpMdMfseu8bkSubBmUPySMGKRTS+su4XQ07zUkAsiu9FCWTg==
   dependencies:
     browserslist "^4.14.6"
+    semver "7.0.0"
+
+core-js-compat@^3.8.0:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.1.tgz#8d1ddd341d660ba6194cbe0ce60f4c794c87a36e"
+  integrity sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==
+  dependencies:
+    browserslist "^4.15.0"
     semver "7.0.0"
 
 core-js-pure@^3.0.0:
@@ -4162,6 +4374,18 @@ css-loader@4.3.0:
     schema-utils "^2.7.1"
     semver "^7.3.2"
 
+css-modules-loader-core@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz#5908668294a1becd261ae0a4ce21b0b551f21d16"
+  integrity sha1-WQhmgpShvs0mGuCkziGwtVHyHRY=
+  dependencies:
+    icss-replace-symbols "1.1.0"
+    postcss "6.0.1"
+    postcss-modules-extract-imports "1.1.0"
+    postcss-modules-local-by-default "1.2.0"
+    postcss-modules-scope "1.1.0"
+    postcss-modules-values "1.3.0"
+
 css-prefers-color-scheme@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz#6f830a2714199d4f0d0d0bb8a27916ed65cff1f4"
@@ -4193,6 +4417,14 @@ css-select@^2.0.0:
     css-what "^3.2.1"
     domutils "^1.7.0"
     nth-check "^1.0.2"
+
+css-selector-tokenizer@^0.7.0:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz#735f26186e67c749aaf275783405cf0661fae8f1"
+  integrity sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==
+  dependencies:
+    cssesc "^3.0.0"
+    fastparse "^1.1.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -4790,6 +5022,11 @@ electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.591:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.592.tgz#4621521b223bf6e5469373528321e185d3c24670"
   integrity sha512-kGNowksvqQiPb1pUSQKpd8JFoGPLxYOwduNRCqCxGh/2Q1qE2JdmwouCW41lUzDxOb/2RIV4lR0tVIfboWlO9A==
 
+electron-to-chromium@^1.3.621:
+  version "1.3.622"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.622.tgz#9726bd2e67a5462154750ce9701ca6af07d07877"
+  integrity sha512-AJT0Fm1W0uZlMVVkkJrcCVvczDuF8tPm3bwzQf5WO8AaASB2hwTRP7B8pU5rqjireH+ib6am8+hH5/QkXzzYKw==
+
 elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
@@ -4977,7 +5214,7 @@ escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -5245,6 +5482,11 @@ estree-walker@^1.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
+estree-walker@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.1.tgz#f8e030fb21cefa183b44b7ad516b747434e7a3e0"
+  integrity sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5255,7 +5497,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-eventemitter3@^4.0.0:
+eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -5494,6 +5736,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastparse@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
+  integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
 fastq@^1.6.0:
   version "1.9.0"
@@ -5854,6 +6101,13 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+generic-names@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-2.0.1.tgz#f8a378ead2ccaa7a34f0317b05554832ae41b872"
+  integrity sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==
+  dependencies:
+    loader-utils "^1.1.0"
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -6047,6 +6301,18 @@ harmony-reflect@^1.4.6:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
   integrity sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==
+
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -6353,6 +6619,11 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+icss-replace-symbols@1.1.0, icss-replace-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
+  integrity sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=
+
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.1.tgz#21170b53789ee27447c2f47dd683081403f9a467"
@@ -6399,6 +6670,13 @@ import-cwd@^2.0.0:
   dependencies:
     import-from "^2.1.0"
 
+import-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"
+  integrity sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==
+  dependencies:
+    import-from "^3.0.0"
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -6421,6 +6699,13 @@ import-from@^2.1.0:
   integrity sha1-M1238qev/VOqpHHUuAId7ja387E=
   dependencies:
     resolve-from "^3.0.0"
+
+import-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-3.0.0.tgz#055cfec38cd5a27d8057ca51376d7d3bf0891966"
+  integrity sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==
+  dependencies:
+    resolve-from "^5.0.0"
 
 import-local@^2.0.0:
   version "2.0.0"
@@ -6767,6 +7052,13 @@ is-potential-custom-element-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
+
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
 
 is-regex@^1.0.4, is-regex@^1.1.1:
   version "1.1.1"
@@ -7736,6 +8028,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -8367,6 +8664,11 @@ node-releases@^1.1.61, node-releases@^1.1.66:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.66.tgz#609bd0dc069381015cd982300bae51ab4f1b1814"
   integrity sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg==
 
+node-releases@^1.1.67:
+  version "1.1.67"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
+  integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -8721,12 +9023,27 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-queue@^6.3.0:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
 p-retry@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-3.0.1.tgz#316b4c8893e2c8dc1cfa891f406c4b422bebf328"
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -8931,6 +9248,11 @@ pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-5.0.0.tgz#1f5eca3f5e87ebec28cc6d54a0e4aaf00acc127f"
+  integrity sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -9227,7 +9549,7 @@ postcss-lab-function@^2.0.1:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
-postcss-load-config@^2.0.0:
+postcss-load-config@^2.0.0, postcss-load-config@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-2.1.2.tgz#c5ea504f2c4aef33c7359a34de3573772ad7502a"
   integrity sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==
@@ -9321,12 +9643,27 @@ postcss-minify-selectors@^4.0.2:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
+postcss-modules-extract-imports@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz#b614c9720be6816eaee35fb3a5faa1dba6a05ddb"
+  integrity sha1-thTJcgvmgW6u41+zpfqh26agXds=
+  dependencies:
+    postcss "^6.0.1"
+
 postcss-modules-extract-imports@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz#818719a1ae1da325f9832446b01136eeb493cd7e"
   integrity sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==
   dependencies:
     postcss "^7.0.5"
+
+postcss-modules-local-by-default@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz#f7d80c398c5a393fa7964466bd19500a7d61c069"
+  integrity sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=
+  dependencies:
+    css-selector-tokenizer "^0.7.0"
+    postcss "^6.0.1"
 
 postcss-modules-local-by-default@^3.0.3:
   version "3.0.3"
@@ -9338,6 +9675,14 @@ postcss-modules-local-by-default@^3.0.3:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
+postcss-modules-scope@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz#d6ea64994c79f97b62a72b426fbe6056a194bb90"
+  integrity sha1-1upkmUx5+XtipytCb75gVqGUu5A=
+  dependencies:
+    css-selector-tokenizer "^0.7.0"
+    postcss "^6.0.1"
+
 postcss-modules-scope@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz#385cae013cc7743f5a7d7602d1073a89eaae62ee"
@@ -9346,6 +9691,14 @@ postcss-modules-scope@^2.2.0:
     postcss "^7.0.6"
     postcss-selector-parser "^6.0.0"
 
+postcss-modules-values@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz#ecffa9d7e192518389f42ad0e83f72aec456ea20"
+  integrity sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=
+  dependencies:
+    icss-replace-symbols "^1.1.0"
+    postcss "^6.0.1"
+
 postcss-modules-values@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz#5b5000d6ebae29b4255301b4a3a54574423e7f10"
@@ -9353,6 +9706,17 @@ postcss-modules-values@^3.0.0:
   dependencies:
     icss-utils "^4.0.0"
     postcss "^7.0.6"
+
+postcss-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules/-/postcss-modules-2.0.0.tgz#473d0d7326651d8408585c2a154115d5cb36cce0"
+  integrity sha512-eqp+Bva+U2cwQO7dECJ8/V+X+uH1HduNeITB0CPPFAu6d/8LKQ32/j+p9rQ2YL1QytVcrNU0X+fBqgGmQIA1Rw==
+  dependencies:
+    css-modules-loader-core "^1.1.0"
+    generic-names "^2.0.1"
+    lodash.camelcase "^4.3.0"
+    postcss "^7.0.1"
+    string-hash "^1.1.1"
 
 postcss-nesting@^7.0.0:
   version "7.0.1"
@@ -9651,6 +10015,15 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
+postcss@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.1.tgz#000dbd1f8eef217aa368b9a212c5fc40b2a8f3f2"
+  integrity sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=
+  dependencies:
+    chalk "^1.1.3"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
 postcss@7.0.21:
   version "7.0.21"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.21.tgz#06bb07824c19c2021c5d056d5b10c35b989f7e17"
@@ -9659,6 +10032,15 @@ postcss@7.0.21:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^6.0.1:
+  version "6.0.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
+  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
 
 postcss@^7, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.35"
@@ -9774,6 +10156,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise.series@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/promise.series/-/promise.series-0.2.0.tgz#2cc7ebe959fc3a6619c04ab4dbdc9e452d864bbd"
+  integrity sha1-LMfr6Vn8OmYZwEq029yeRS2GS70=
 
 promise@^8.1.0:
   version "8.1.0"
@@ -10463,7 +10850,7 @@ resolve@1.18.1:
     is-core-module "^2.0.0"
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.16.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
@@ -10554,6 +10941,26 @@ rollup-plugin-babel@^4.3.3:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
 
+rollup-plugin-postcss@^3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-postcss/-/rollup-plugin-postcss-3.1.8.tgz#d1bcaf8eb0fcb0936e3684c22dd8628d13a82fd1"
+  integrity sha512-JHnGfW8quNc6ePxEkZ05HEZ1YiRxDgY9RKEetMfsrwxR2kh/d90OVScTc6b1c2Q17Cs/5TRYL+1uddG21lQe3w==
+  dependencies:
+    chalk "^4.0.0"
+    concat-with-sourcemaps "^1.1.0"
+    cssnano "^4.1.10"
+    import-cwd "^3.0.0"
+    p-queue "^6.3.0"
+    pify "^5.0.0"
+    postcss "^7.0.27"
+    postcss-load-config "^2.1.0"
+    postcss-modules "^2.0.0"
+    promise.series "^0.2.0"
+    resolve "^1.16.1"
+    rollup-pluginutils "^2.8.2"
+    safe-identifier "^0.4.1"
+    style-inject "^0.3.0"
+
 rollup-plugin-terser@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz#8c650062c22a8426c64268548957463bf981b413"
@@ -10572,14 +10979,12 @@ rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.31.1:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
+rollup@^1.31.1, rollup@^2.33.3:
+  version "2.33.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.33.3.tgz#ae72ce31f992b09a580072951bfea76e9df17342"
+  integrity sha512-RpayhPTe4Gu/uFGCmk7Gp5Z9Qic2VsqZ040G+KZZvsZYdcuWaJg678JeDJJvJeEQXminu24a2au+y92CUWVd+w==
+  optionalDependencies:
+    fsevents "~2.1.2"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -10614,6 +11019,11 @@ safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1,
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-identifier@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/safe-identifier/-/safe-identifier-0.4.2.tgz#cf6bfca31c2897c588092d1750d30ef501d59fcb"
+  integrity sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -11279,6 +11689,11 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
+string-hash@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
+  integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
+
 string-length@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.1.tgz#4a973bf31ef77c4edbceadd6af2611996985f8a1"
@@ -11437,6 +11852,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+style-inject@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/style-inject/-/style-inject-0.3.0.tgz#d21c477affec91811cc82355832a700d22bf8dd3"
+  integrity sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==
+
 style-loader@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.3.0.tgz#828b4a3b3b7e7aa5847ce7bae9e874512114249e"
@@ -11454,7 +11874,19 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-supports-color@^5.3.0:
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
+  dependencies:
+    has-flag "^1.0.0"
+
+supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -11548,7 +11980,7 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^6.0.2:
+tar@^6.0.2, tar@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
   integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==


### PR DESCRIPTION
This PR adds a feature to let modular build workspaces as libraries (as opposed to only apps). It uses rollup to generate commonjs and esm builds of the workspace it's pointing to (based on the `main` field in the workspace's `package.json`), and then generates typescript typings for the same. It then generates a publishable folder under `dist/<workspace name>`, with a modified `package.json` that points to these built versions of the files. The folder will also contain any other files specified by the `files` field, and/or `.npmignore` in the workspace. Passing `--preserve-modules` decides whether or not to make a bundle. 

You can also do parallel builds by passing a comma-separated list of packages: `modular build app1,app2,package1,view1,etc`

Finally, I made it so app builds go to `/dist/<app-name>`, for consistency. 

This is a port of the script we used internally at JPM for the same, and makes it a first class feature for modular. It's fast and works fairly well.

Three things missing from this:

- We should use it for our own builds 
- No tests for parallel/multiple builds
- Docs

I'll do these in the next PR. 