### PR TITLE
put a scary warning on the craco config file name

### DIFF
--- a/.changeset/tame-spiders-grin.md
+++ b/.changeset/tame-spiders-grin.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Put a scary warning in the craco config file name

--- a/packages/modular-scripts/DO_NOT_IMPORT_THIS_OR_YOU_WILL_BE_FIRED_craco.config.js
+++ b/packages/modular-scripts/DO_NOT_IMPORT_THIS_OR_YOU_WILL_BE_FIRED_craco.config.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// If you need to modify this, talk to us! Maybe your change
+// is good enough for everybody, or we have alternate workarounds.
+
 const path = require('path');
 const { getLoader, loaderByName } = require('@craco/craco');
 const glob = require('glob');

--- a/packages/modular-scripts/jest-config.js
+++ b/packages/modular-scripts/jest-config.js
@@ -4,6 +4,6 @@
 // coverage reports correctly across workspaces, etc.
 
 const { createJestConfig } = require('@craco/craco');
-const cracoConfig = require('./craco.config.js');
+const cracoConfig = require('./DO_NOT_IMPORT_THIS_OR_YOU_WILL_BE_FIRED_craco.config.js');
 const jestConfig = createJestConfig(cracoConfig);
 module.exports = jestConfig;

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -25,7 +25,11 @@ process.on('unhandledRejection', (err) => {
 
 const cracoBin = resolveAsBin('craco');
 const jestBin = resolveAsBin('jest');
-const cracoConfig = path.join(__dirname, '..', 'craco.config.js');
+const cracoConfig = path.join(
+  __dirname,
+  '..',
+  'DO_NOT_IMPORT_THIS_OR_YOU_WILL_BE_FIRED_craco.config.js',
+);
 
 function execSync(
   file: string,


### PR DESCRIPTION
I noticed that folks reach directly to the config and use craco to run their apps. That sucks, and will make our upgrade path harder. Instead, we should work with them and either fix our config, or propose workarounds. This PR puts a scary disclaimer in the file name. In the future we'll remove craco altogether. 