### PR TITLE
Some basic settings for vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint"]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "wayou.vscode-todo-highlight"
+  ]
 }

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -63,7 +63,7 @@ describe('create-modular-react-app', () => {
       ├─ .eslintignore #1ugsijf
       ├─ .gitignore #1ugsijf
       ├─ .vscode
-      │  ├─ extensions.json #6p4679
+      │  ├─ extensions.json #1i4584r
       │  └─ settings.json #xncm1d
       ├─ README.md #1nksyzj
       ├─ modular

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -59,10 +59,14 @@ describe('create-modular-react-app', () => {
     createModularApp({ _: [destination] });
     expect(tree(destination)).toMatchInlineSnapshot(`
       "test-repo
-      ├─ .eslintignore #1ugsijf
+      ├─ .editorconfig #1p4gvuw
       ├─ .gitignore #1ugsijf
+      ├─ .vscode
+      │  ├─ extensions.json #6p4679
+      │  └─ settings.json #xncm1d
       ├─ README.md #1nksyzj
       ├─ modular
+      │  ├─ setupEnvironment.ts #m0s4vb
       │  └─ setupTests.ts #bnjknz
       ├─ package.json
       ├─ packages

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -60,6 +60,7 @@ describe('create-modular-react-app', () => {
     expect(tree(destination)).toMatchInlineSnapshot(`
       "test-repo
       ├─ .editorconfig #1p4gvuw
+      ├─ .eslintignore #1ugsijf
       ├─ .gitignore #1ugsijf
       ├─ .vscode
       │  ├─ extensions.json #6p4679

--- a/packages/create-modular-react-app/src/cli.ts
+++ b/packages/create-modular-react-app/src/cli.ts
@@ -62,8 +62,6 @@ export default function createModularApp(argv: {
     name[0] === '/' || name.includes(':\\')
       ? /* absolute */ name
       : path.join(process.cwd(), name);
-  const packagesPath = path.join(newModularRoot, 'packages');
-  const modularGlobalConfigsPath = path.join(newModularRoot, 'modular');
   const projectPackageJsonPath = path.join(newModularRoot, 'package.json');
   const templatePath = path.join(__dirname, '..', 'template');
 
@@ -131,34 +129,12 @@ export default function createModularApp(argv: {
     { cwd: newModularRoot },
   );
 
-  fs.mkdirpSync(packagesPath);
-  fs.copySync(
-    path.join(templatePath, 'packages/README.md'),
-    path.join(packagesPath, 'README.md'),
-  );
+  fs.copySync(templatePath, newModularRoot);
 
-  fs.mkdirpSync(modularGlobalConfigsPath);
-  fs.copySync(
-    path.join(templatePath, 'modular/setupTests.ts'),
-    path.join(modularGlobalConfigsPath, 'setupTests.ts'),
-  );
-
-  fs.copySync(
-    path.join(templatePath, 'gitignore'),
+  // rename gitgnore to .gitgnore so it actually works
+  fs.moveSync(
+    path.join(newModularRoot, 'gitignore'),
     path.join(newModularRoot, '.gitignore'),
-  );
-
-  fs.copySync(
-    path.join(templatePath, 'gitignore'),
-    path.join(newModularRoot, '.eslintignore'),
-  );
-  fs.copySync(
-    path.join(templatePath, 'tsconfig.json'),
-    path.join(newModularRoot, 'tsconfig.json'),
-  );
-  fs.copySync(
-    path.join(templatePath, 'README.md'),
-    path.join(newModularRoot, 'README.md'),
   );
 
   execSync(

--- a/packages/create-modular-react-app/src/cli.ts
+++ b/packages/create-modular-react-app/src/cli.ts
@@ -137,6 +137,12 @@ export default function createModularApp(argv: {
     path.join(newModularRoot, '.gitignore'),
   );
 
+  // make an eslintignore file from gitignore
+  fs.copySync(
+    path.join(newModularRoot, '.gitignore'),
+    path.join(newModularRoot, '.eslintignore'),
+  );
+
   execSync(
     'yarnpkg',
     ['modular', 'add', 'app', '--unstable-type=app', ...preferOfflineArg],

--- a/packages/create-modular-react-app/template/.editorconfig
+++ b/packages/create-modular-react-app/template/.editorconfig
@@ -1,0 +1,18 @@
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.{md,mdx}]
+max_line_length = 0
+trim_trailing_whitespace = false
+
+[COMMIT_EDITMSG]
+max_line_length = 0

--- a/packages/create-modular-react-app/template/.vscode/extensions.json
+++ b/packages/create-modular-react-app/template/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint"]
+}

--- a/packages/create-modular-react-app/template/.vscode/extensions.json
+++ b/packages/create-modular-react-app/template/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "wayou.vscode-todo-highlight"
+  ]
 }

--- a/packages/create-modular-react-app/template/.vscode/settings.json
+++ b/packages/create-modular-react-app/template/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -189,6 +189,11 @@ describe('modular-scripts', () => {
   });
 
   it('can start an app', async () => {
+    // this leaves habing processes on local environments
+    // so we're disabling it for now. Still runs on CI though.
+    if (!process.env.CI) {
+      return;
+    }
     let browser: puppeteer.Browser | undefined;
     let devServer: DevServer | undefined;
     try {

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,8 +15,8 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #1aq0qbk
-    │  ├─ cli.ts #17tb5ia
+    │  │  └─ index.test.ts #6koefy
+    │  ├─ cli.ts #gcx3cm
     │  └─ index.ts #un0l9d
     └─ template
        ├─ .editorconfig #1p4gvuw

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,10 +15,14 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #vp1gkc
-    │  ├─ cli.ts #9pkwel
+    │  │  └─ index.test.ts #1aq0qbk
+    │  ├─ cli.ts #17tb5ia
     │  └─ index.ts #un0l9d
     └─ template
+       ├─ .editorconfig #1p4gvuw
+       ├─ .vscode
+       │  ├─ extensions.json #6p4679
+       │  └─ settings.json #xncm1d
        ├─ README.md #1nksyzj
        ├─ gitignore #1ugsijf
        ├─ modular

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,13 +15,13 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #6koefy
+    │  │  └─ index.test.ts #1lu3g5f
     │  ├─ cli.ts #gcx3cm
     │  └─ index.ts #un0l9d
     └─ template
        ├─ .editorconfig #1p4gvuw
        ├─ .vscode
-       │  ├─ extensions.json #6p4679
+       │  ├─ extensions.json #1i4584r
        │  └─ settings.json #xncm1d
        ├─ README.md #1nksyzj
        ├─ gitignore #1ugsijf


### PR DESCRIPTION
This is the start of the work to automate project settings in IDEs. This PR makes it so that every modular project, when opened in vscode, gets a recommendation to install the eslint plugin, some editor settings, and a pointer to typescript so it picks up the right version. We'll expand on this in the future.

Closes https://github.com/jpmorganchase/modular/issues/68, but we'll do more in the future. 

Additionally: while working on this, I discovered and fixed a bug where we weren't copying over all files from the template when creating a new project. 