### PR TITLE
update craco

### DIFF
--- a/.changeset/sweet-kings-shop.md
+++ b/.changeset/sweet-kings-shop.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Update craco to v6

--- a/packages/modular-scripts/DO_NOT_IMPORT_THIS_OR_YOU_WILL_BE_FIRED_craco.config.js
+++ b/packages/modular-scripts/DO_NOT_IMPORT_THIS_OR_YOU_WILL_BE_FIRED_craco.config.js
@@ -18,33 +18,6 @@ const absolutePackagesPath = path.resolve(modularRoot, 'packages');
 const absoluteModularGlobalConfigsPath = path.resolve(modularRoot, 'modular');
 
 module.exports = {
-  // It only appears like we're disabling eslint here, but that's to work around the
-  // error generated when using this with crav4+. Note that the webpack eslint plugin
-  // is enabled manually in overrideWebpackConfig.
-  // ref: https://github.com/gsoft-inc/craco/issues/205
-  eslint: {
-    enable: false,
-  },
-  plugins: [
-    {
-      plugin: {
-        overrideCracoConfig: ({ cracoConfig }) => {
-          if (typeof cracoConfig.eslint.enable !== 'undefined') {
-            cracoConfig.disableEslint = !cracoConfig.eslint.enable;
-          }
-          delete cracoConfig.eslint;
-          return cracoConfig;
-        },
-        overrideWebpackConfig: ({ webpackConfig }) => {
-          const plugin = webpackConfig.plugins.find(
-            (plugin) => plugin.constructor.name === 'ESLintWebpackPlugin',
-          );
-          plugin.options.emitWarning = true;
-          return webpackConfig;
-        },
-      },
-    },
-  ],
   webpack: {
     configure(webpackConfig) {
       const { isFound, match } = getLoader(

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/preset-env": "^7.12.10",
-    "@craco/craco": "^5.8.0",
+    "@craco/craco": "^6.0.0",
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-commonjs": "^16.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,13 +1361,14 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@craco/craco@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-5.8.0.tgz#2a0f551290a5eab353b615de4d7093dd83785777"
-  integrity sha512-4rhusETLD7rJ195GxOK9VmVdv/VD4jawFxc9hcQ9TrZ3/9ny+qwc0uW+08qu9GYwEF9Eb9meSeSvpWjaqdDr1Q==
+"@craco/craco@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-6.0.0.tgz#f4e66e82f5bc77671dc0a5e839c3269e2414fe0f"
+  integrity sha512-NSgcGqTlQ+XTBJ/AhE0ngdfab5xIyx/06yrRPkvDH02V90ejrL6bSM54k3+h3OjGE/SO7nmF1MqfFwemPo8kVw==
   dependencies:
     cross-spawn "^7.0.0"
     lodash "^4.17.15"
+    semver "^7.3.2"
     webpack-merge "^4.2.2"
 
 "@csstools/convert-colors@^1.4.0":


### PR DESCRIPTION
craco fixed their issues with their eslint usage (https://github.com/gsoft-inc/craco/releases/tag/v6.0.0). This PR updates to v6 that includes those fixes, and removes our workarounds. None of their other changes break our workflow or features, heance the patch changeset.