### PR TITLE
Use eslint-config-modular-app for our own project

### DIFF
--- a/.changeset/five-comics-retire.md
+++ b/.changeset/five-comics-retire.md
@@ -1,0 +1,9 @@
+---
+'create-modular-react-app': minor
+'eslint-config-modular-app': minor
+'modular-scripts': minor
+'modular-views.macro': patch
+---
+
+Enhance eslint-config-modular-app, add .prettierignore and .eslintignore files
+in templates

--- a/.changeset/five-comics-retire.md
+++ b/.changeset/five-comics-retire.md
@@ -1,7 +1,7 @@
 ---
-'create-modular-react-app': minor
+'create-modular-react-app': patch
 'eslint-config-modular-app': minor
-'modular-scripts': minor
+'modular-scripts': patch
 'modular-views.macro': patch
 ---
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,108 +1,33 @@
-// The ESLint browser environment defines all browser globals as valid,
-// even though most people don't know some of them exist (e.g. `name` or `status`).
-// This is dangerous as it hides accidentally undefined variables.
-// We blacklist the globals that we deem potentially confusing.
-// To use them, explicitly reference them, e.g. `window.name` or `window.status`.
-// See https://github.com/facebook/create-react-app/blob/3c2f2d4/packages/eslint-config-react-app/index.js#L19-L24
-const restrictedGlobals = require('confusing-browser-globals');
+'use strict';
 
+// Short hand codes for the values eslint expects
+// Might feel like overkill, but is also effectively visually
+// when scanning through the config and looking for values.
+
+// eslint-disable-next-line  no-unused-vars
 const ERROR = 'error';
 const WARN = 'warn';
 const OFF = 'off';
 
 module.exports = {
-  root: true,
-  env: {
-    browser: true,
-    es6: true,
-    node: true,
-  },
-  extends: [
-    'eslint:recommended',
-    'plugin:import/recommended',
-    'plugin:react/recommended',
-    'plugin:react-hooks/recommended',
-    'prettier',
-    'prettier/react',
-  ],
-  globals: {
-    Atomics: 'readonly',
-    SharedArrayBuffer: 'readonly',
-  },
-  parser: 'babel-eslint',
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
-    },
-    ecmaVersion: 2020,
-    sourceType: 'module',
-  },
-  plugins: ['import', 'react', 'react-hooks'],
-  reportUnusedDisableDirectives: true,
-
-  // NOTE: When adding rules here, you need to make sure they are compatible with
-  // `typescript-eslint`, as some rules such as `no-array-constructor` aren't compatible.
+  extends: ['modular-app'],
   rules: {
-    // http://eslint.org/docs/rules/
-    'no-restricted-globals': [ERROR, ...restrictedGlobals],
-
-    // https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules
-    'import/first': ERROR,
-    'import/no-amd': ERROR,
-    'import/no-anonymous-default-export': WARN,
-    // disabling this because it doesn't consider local yarn workspaces
-    // or root dependencies as legitimate, and we use it extensively.
-    // 'import/no-extraneous-dependencies': ERROR,
-    'import/no-webpack-loader-syntax': ERROR,
-  },
-  settings: {
-    react: {
-      version: 'detect',
-    },
+    strict: [WARN, 'global'],
   },
   overrides: [
     {
-      files: ['*.{ts,tsx}'],
-      extends: [
-        'plugin:@typescript-eslint/recommended',
-        'plugin:@typescript-eslint/recommended-requiring-type-checking',
-        'plugin:import/typescript',
-        'prettier/@typescript-eslint',
-      ],
+      files: 'packages/modular-scripts/types/**/*',
+      rules: {
+        'react/jsx-pascal-case': OFF,
+      },
+    },
+    {
+      // if we want to use js in this repo, then they have
+      // to be explitly marked as modules
+      files: '**/*.js',
       parserOptions: {
-        // See: https://github.com/typescript-eslint/typescript-eslint/issues/1928#issuecomment-617969784
-        project: ['./tsconfig.json'],
-        // `.eslintrc.js` needs to be a JavaScript file to access `__dirname` since we want linting to
-        // work if we run it from a different current working directory.
-        // See: https://github.com/typescript-eslint/typescript-eslint/issues/101#issuecomment-499303058
-        // TODO: https://github.com/jpmorganchase/modular/issues/9
-        tsconfigRootDir: __dirname,
+        sourceType: 'script',
       },
-      plugins: ['@typescript-eslint'],
-      rules: {
-        // TypeScript compilation already ensures that default imports exist in the referenced module
-        'import/default': OFF,
-        '@typescript-eslint/ban-ts-comment': OFF,
-      },
-    },
-    {
-      // Disable rules within templates that are fired erroneously.
-      files: ['packages/create-modular-react-app/template/**/*.{ts,tsx}'],
-      rules: {
-        '@typescript-eslint/no-unsafe-assignment': OFF,
-        '@typescript-eslint/no-unsafe-call': OFF,
-        'import/no-extraneous-dependencies': OFF,
-      },
-    },
-    {
-      files: ['**/__tests__/**/*.{ts,tsx,js}', '**/*.test.{ts,tsx,js}'],
-      extends: [
-        'plugin:jest/recommended',
-        'plugin:jest/style',
-        'plugin:jest-dom/recommended',
-        'plugin:testing-library/react',
-      ],
-      plugins: ['jest', 'jest-dom', 'testing-library'],
     },
   ],
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+/dist
+packages/*/dist
+packages/modular-site/public

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,8 @@
+// We're only using this file for builds right now.
+// It'll go away once we self host builds as well.
+
+'use strict';
+
 const semver = require('semver');
 const pkgJson = require('./package.json');
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "scripts": {
     "prettier": "prettier --write .",
     "lint": "node ./scripts/lint.js --cache --ext .js,.ts,.tsx --max-warnings 0",
-    "linc": "node ./scripts/linc.js --cache --fix --ext .js,.ts,.tsx --max-warnings 0",
+    "linc": "node ./scripts/linc.js --cache --ext .js,.ts,.tsx --max-warnings 0",
+    "lint:fix": "yarn lint --fix",
+    "linc:fix": "yarn linc --fix",
     "modular": "ts-node packages/modular-scripts/src/cli.ts",
     "test": "yarn modular test --watchAll=false --runInBand",
     "build": "yarn workspace create-modular-react-app build && yarn workspace modular-scripts build && yarn workspace modular-views.macro build",
@@ -31,18 +33,7 @@
     "@types/jest": "^25.2.3",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "@typescript-eslint/eslint-plugin": "^4.0.0",
-    "@typescript-eslint/parser": "^4.0.0",
-    "babel-eslint": "^10.1.0",
-    "confusing-browser-globals": "^1.0.9",
     "eslint": "^7.1.0",
-    "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-jest": "^24.0.0",
-    "eslint-plugin-jest-dom": "^2.1.0",
-    "eslint-plugin-react": "^7.20.3",
-    "eslint-plugin-react-hooks": "^4.0.8",
-    "eslint-plugin-testing-library": "^3.9.2",
     "execa": "^4.0.3",
     "husky": "^4.2.5",
     "is-ci": "^2.0.0",
@@ -57,14 +48,14 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-push": "lint-staged"
     }
   },
   "modular": {
     "type": "root"
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": "eslint --cache --fix --ext .js,.ts,.tsx --max-warnings 0",
+    "*.{js,ts,tsx}": "eslint --cache --ext .js,.ts,.tsx --max-warnings 0",
     "*.{js,json,ts,tsx,css,md,mdx}": "prettier --write"
   },
   "resolutions": {

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -62,6 +62,7 @@ describe('create-modular-react-app', () => {
       ├─ .editorconfig #1p4gvuw
       ├─ .eslintignore #1tm0llc
       ├─ .gitignore #1tm0llc
+      ├─ .prettierignore #1ivaop6
       ├─ .vscode
       │  ├─ extensions.json #1i4584r
       │  ├─ launch.json #15fzacl

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -60,7 +60,7 @@ describe('create-modular-react-app', () => {
     expect(tree(destination)).toMatchInlineSnapshot(`
       "test-repo
       ├─ .editorconfig #1p4gvuw
-      ├─ .eslintignore #1tm0llc
+      ├─ .eslintignore #1x09skm
       ├─ .gitignore #1tm0llc
       ├─ .prettierignore #1ivaop6
       ├─ .vscode

--- a/packages/create-modular-react-app/src/cli.ts
+++ b/packages/create-modular-react-app/src/cli.ts
@@ -140,12 +140,6 @@ export default function createModularApp(argv: {
     path.join(newModularRoot, '.gitignore'),
   );
 
-  // make an eslintignore file from gitignore
-  fs.copySync(
-    path.join(newModularRoot, '.gitignore'),
-    path.join(newModularRoot, '.eslintignore'),
-  );
-
   execSync(
     'yarnpkg',
     [

--- a/packages/create-modular-react-app/template/.eslintignore
+++ b/packages/create-modular-react-app/template/.eslintignore
@@ -1,0 +1,28 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/packages/*/build
+/packages/*/dist-cjs/
+/packages/*/dist-es/
+/packages/*/dist-types/
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+packages/*/public

--- a/packages/create-modular-react-app/template/.prettierignore
+++ b/packages/create-modular-react-app/template/.prettierignore
@@ -1,0 +1,4 @@
+/dist
+/packages/*/dist
+/packages/*/build
+/packages/*/public

--- a/packages/eslint-config-modular-app/index.js
+++ b/packages/eslint-config-modular-app/index.js
@@ -1,5 +1,46 @@
 'use strict';
 
+// Short hand codes for the values eslint expects
+// Might feel like overkill, but is also effectively visually
+// when scanning through the config and looking for values.
+
+// eslint-disable-next-line  no-unused-vars
+const ERROR = 'error';
+// eslint-disable-next-line  no-unused-vars
+const WARN = 'warn';
+const OFF = 'off';
+
 module.exports = {
   extends: ['react-app'],
+  reportUnusedDisableDirectives: true,
+  overrides: [
+    {
+      files: ['**/__tests__/**/*.{ts,tsx,js}', '**/*.test.{ts,tsx,js}'],
+      extends: [
+        'plugin:jest/recommended',
+        'plugin:jest/style',
+        'plugin:jest-dom/recommended',
+        'plugin:testing-library/react',
+      ],
+      plugins: ['jest', 'jest-dom', 'testing-library'],
+    },
+    {
+      files: ['*.{ts,tsx}'],
+      parserOptions: {
+        project: ['./tsconfig.json'],
+      },
+      extends: [
+        'plugin:@typescript-eslint/recommended',
+        'plugin:@typescript-eslint/recommended-requiring-type-checking',
+        'plugin:import/typescript',
+      ],
+
+      plugins: ['@typescript-eslint'],
+      rules: {
+        // TypeScript compilation already ensures that default imports exist in the referenced module
+        'import/default': OFF,
+        '@typescript-eslint/ban-ts-comment': OFF,
+      },
+    },
+  ],
 };

--- a/packages/eslint-config-modular-app/package.json
+++ b/packages/eslint-config-modular-app/package.json
@@ -11,6 +11,7 @@
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jest": "^24.0.0",
+    "eslint-plugin-jest-dom": "^2.1.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",

--- a/packages/modular-scripts/jest-config.js
+++ b/packages/modular-scripts/jest-config.js
@@ -3,6 +3,8 @@
 // of a monorepo. Owning the runner then gives us the opportunity to generate
 // coverage reports correctly across workspaces, etc.
 
+'use strict';
+
 const { createJestConfig } = require('@craco/craco');
 const cracoConfig = require('./DO_NOT_IMPORT_THIS_OR_YOU_WILL_BE_FIRED_craco.config.js');
 const jestConfig = createJestConfig(cracoConfig);

--- a/packages/modular-scripts/jest-setupEnvironment.js
+++ b/packages/modular-scripts/jest-setupEnvironment.js
@@ -4,5 +4,6 @@
 // coverage reports correctly across workspaces, etc.
 
 // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/scripts/test.js
+'use strict';
 
 require('react-scripts/config/env');

--- a/packages/modular-site/src/App.tsx
+++ b/packages/modular-site/src/App.tsx
@@ -47,7 +47,6 @@ export default function App(): JSX.Element {
 
   // You can also the use the stringified config values as attributes
   return (
-    //eslint-disable-next-line react/react-in-jsx-scope
     <perspective-viewer
       ref={viewer} /*row-pivots='["State"]'*/
     ></perspective-viewer>

--- a/packages/modular-views.macro/src/__tests__/.eslintrc.json
+++ b/packages/modular-views.macro/src/__tests__/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": "fixture.js",
+      "parserOptions": {
+        "sourceType": "module"
+      }
+    }
+  ]
+}

--- a/packages/modular-views.macro/src/__tests__/fixture.js
+++ b/packages/modular-views.macro/src/__tests__/fixture.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import views from '../../build/index.macro';
 
 console.log(views);

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,8 +15,8 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #ob5uub
-    │  ├─ cli.ts #1i6cy4n
+    │  │  └─ index.test.ts #alwhsw
+    │  ├─ cli.ts #16bp7u1
     │  └─ index.ts #un0l9d
     └─ template
        ├─ .editorconfig #1p4gvuw

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,11 +15,13 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #4g4vlr
+    │  │  └─ index.test.ts #ob5uub
     │  ├─ cli.ts #1i6cy4n
     │  └─ index.ts #un0l9d
     └─ template
        ├─ .editorconfig #1p4gvuw
+       ├─ .eslintignore #1x09skm
+       ├─ .prettierignore #1ivaop6
        ├─ .vscode
        │  ├─ extensions.json #1i4584r
        │  ├─ launch.json #15fzacl

--- a/yarn.lock
+++ b/yarn.lock
@@ -4502,7 +4502,7 @@ configstore@^5.0.1:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
-confusing-browser-globals@^1.0.10, confusing-browser-globals@^1.0.9:
+confusing-browser-globals@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
   integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
@@ -6070,13 +6070,6 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^6.11.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
-  integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
-  dependencies:
-    get-stdin "^6.0.0"
-
 eslint-config-react-app@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz#ccff9fc8e36b322902844cbd79197982be355a0e"
@@ -6980,11 +6973,6 @@ get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
-
-get-stdin@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
-  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR uses eslint-config-modular-app for our own app. It also takes some of the custom rules we were using and adds them to the config.

This also adds .prettierignore files, for ourselves, and generated projects.