### PR TITLE
enhancements/fixes to `modular build <package>`

### DIFF
--- a/.changeset/seven-rats-share.md
+++ b/.changeset/seven-rats-share.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+minor enhancements/fixes to `modular build <package>`

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ packages/view-2
 
 # Build output
 /packages/*/build/
+/packages/*/dist/
 
 # Testing
 /coverage

--- a/packages/modular-scripts/jest-setupEnvironment.js
+++ b/packages/modular-scripts/jest-setupEnvironment.js
@@ -6,5 +6,3 @@
 // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/scripts/test.js
 
 require('react-scripts/config/env');
-
-// Unlike CRA, let's NOT verify typescript config when running tests.

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -23,6 +23,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@types/is-ci": "^2.0.0",
     "@types/update-notifier": "^5.0.0",
+    "@rollup/plugin-node-resolve": "^11.0.1",
     "builtin-modules": "^3.1.0",
     "chalk": "^4.1.0",
     "change-case": "^4.1.1",
@@ -35,6 +36,7 @@
     "mri": "^1.1.6",
     "prompts": "^2.4.0",
     "react-scripts": "^4.0.1",
+    "resolve": "^1.19.0",
     "resolve-as-bin": "^2.1.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.33.3",
@@ -56,5 +58,11 @@
   },
   "optionalDependencies": {
     "puppeteer": "^5.4.1"
-  }
+  },
+  "peerDependencies": {
+    "typescript": "^4.1.2"
+  },
+  "files": [
+    "*.js"
+  ]
 }

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -318,33 +318,80 @@ describe('modular-scripts', () => {
       stdio: 'inherit',
     });
 
+    expect(
+      await fs.readJson(
+        path.join(modularRoot, 'dist', 'sample-package', 'package.json'),
+      ),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "dependencies": Object {},
+        "files": Array [
+          "/dist-cjs",
+          "/dist-es",
+          "/dist-types",
+          "README.md",
+        ],
+        "license": "UNLICENSED",
+        "main": "dist-cjs/index.js",
+        "module": "dist-es/index.js",
+        "name": "sample-package",
+        "typings": "dist-types/src/index.d.ts",
+        "version": "1.0.0",
+      }
+    `);
+
+    expect(
+      await fs.readJson(
+        path.join(modularRoot, 'dist', 'sample-view', 'package.json'),
+      ),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "dependencies": Object {
+          "react": "^17.0.1",
+        },
+        "files": Array [
+          "/dist-cjs",
+          "/dist-es",
+          "/dist-types",
+          "README.md",
+        ],
+        "license": "UNLICENSED",
+        "main": "dist-cjs/sample-view.cjs.js",
+        "modular": Object {
+          "type": "view",
+        },
+        "module": "dist-es/sample-view.es.js",
+        "name": "sample-view",
+        "typings": "dist-types/src/index.d.ts",
+        "version": "1.0.0",
+      }
+    `);
+
     expect(tree(path.join(modularRoot, 'dist'))).toMatchInlineSnapshot(`
       "dist
       ├─ sample-package
       │  ├─ README.md #1jv3l2q
-      │  ├─ dist
-      │  │  ├─ cjs
-      │  │  │  └─ src
-      │  │  │     ├─ index.js #rq9uxe
-      │  │  │     └─ index.js.map #95g4ej
-      │  │  ├─ es
-      │  │  │  └─ src
-      │  │  │     ├─ index.js #1gjntzw
-      │  │  │     └─ index.js.map #1861m7m
-      │  │  └─ types
-      │  │     └─ src
-      │  │        └─ index.d.ts #f68aj
+      │  ├─ dist-cjs
+      │  │  ├─ index.js #rq9uxe
+      │  │  └─ index.js.map #ys8x0i
+      │  ├─ dist-es
+      │  │  ├─ index.js #1gjntzw
+      │  │  └─ index.js.map #b17359
+      │  ├─ dist-types
+      │  │  └─ src
+      │  │     └─ index.d.ts #f68aj
       │  └─ package.json
       └─ sample-view
          ├─ README.md #11adaka
-         ├─ dist
+         ├─ dist-cjs
          │  ├─ sample-view.cjs.js #fmbogr
-         │  ├─ sample-view.cjs.js.map #4xu206
+         │  └─ sample-view.cjs.js.map #4xu206
+         ├─ dist-es
          │  ├─ sample-view.es.js #10hnw4k
-         │  ├─ sample-view.es.js.map #jqhhy5
-         │  └─ types
-         │     └─ src
-         │        └─ index.d.ts #1vloh7q
+         │  └─ sample-view.es.js.map #jqhhy5
+         ├─ dist-types
+         │  └─ src
+         │     └─ index.d.ts #1vloh7q
          └─ package.json"
     `);
   });

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -2,6 +2,9 @@
 // could be happening simultaneously across packages, so
 // try be 'thread-safe'. No state outside of functions
 
+// shorthand for building every workspace, if you're ever debugging this flow
+// rm -rf dist && yarn modular build `ls -m1 packages | sed -e 'H;${x;s/\n/,/g;s/^,//;p;};d'`
+
 import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 import { JSONSchemaForTheTypeScriptCompilerSConfigurationFile as TSConfig } from '@schemastore/tsconfig';
 
@@ -160,6 +163,9 @@ const typescriptConfig: TSConfig = {};
       '**/*.spec.tsx',
       '**/*.test.tsx',
       '__tests__',
+      '**/dist-cjs',
+      '**/dist-es',
+      '**/dist-types',
       // TS defaults below
       'node_modules',
       'bower_components',
@@ -250,6 +256,7 @@ async function makeBundle(
     input: path.join(packagesRoot, directoryName, packageJson.main),
     external: (id) => {
       // via tsdx
+      // TODO: this should probably be included into deps instead
       if (id === 'babel-plugin-transform-async-to-promises/helpers') {
         // we want to inline these helpers
         return false;
@@ -275,10 +282,7 @@ async function makeBundle(
           '@babel/preset-react',
           [
             '@babel/preset-env',
-            {
-              // targets: { esmodules: true }, // Use the targets that you was already using
-              // bugfixes: true, // will be default in Babel 8
-            },
+            // TODO: why doesn't this read `targets` from package.json?
           ],
         ],
         plugins: ['@babel/plugin-proposal-class-properties'],
@@ -327,11 +331,16 @@ async function makeBundle(
   // "local" workspaces/packages that were imported, i.e - packages/*
   const localImports: { [name: string]: string } = {};
 
+  // this is used to collect local filenames being referenced
+  // to prevent errors where facades are imported as dependencies
+  // and are collected in missingDependencies
+  const localFileNames = new Set<string>();
+
   // imports that aren't defined in package.json or root package.json
   // Now, this will also mark dependencies that were transient/nested,
   // but I think that's the right choice; a dependency might remove it,
   // even in a patch, and it'll break your code and you wouldn't know why.
-  const missingDependencies: string[] = [];
+  const missingDependencies: Set<string> = new Set();
 
   for (const chunkOrAsset of output) {
     if (chunkOrAsset.type === 'asset') {
@@ -386,7 +395,10 @@ async function makeBundle(
               // TODO: if it's in root's dev dependencies, should throw a
               // different kind of error
               if (!builtinModules.includes(importedPackage)) {
-                missingDependencies.push(importedPackage);
+                // save filename to remove from missingDeps later
+                // if they exist there
+                localFileNames.add(chunkOrAsset.fileName);
+                missingDependencies.add(importedPackage);
               }
             }
           }
@@ -400,9 +412,16 @@ async function makeBundle(
     console.log(localImports);
   }
 
-  if (missingDependencies.length > 0) {
+  // remove local filenames from missingDependencies
+  const missingDependenciesWithoutLocalFileNames = [
+    ...missingDependencies,
+  ].filter((dep) => !localFileNames.has(dep));
+
+  if (missingDependenciesWithoutLocalFileNames.length > 0) {
     throw new Error(
-      `Missing dependencies: ${missingDependencies.join(', ')};`, // TODO: lineNo, filename
+      `Missing dependencies: ${missingDependenciesWithoutLocalFileNames.join(
+        ', ',
+      )};`, // TODO: lineNo, filename
     );
   }
 
@@ -414,19 +433,13 @@ async function makeBundle(
     ...(preserveModules
       ? {
           preserveModules: true,
-          dir: path.join(
-            packagesRoot,
-            directoryName,
-            outputDirectory,
-            'cjs',
-            path.dirname(packageJson.main),
-          ),
+          dir: path.join(packagesRoot, directoryName, `${outputDirectory}-cjs`),
         }
       : {
           file: path.join(
             packagesRoot,
             directoryName,
-            outputDirectory,
+            `${outputDirectory}-cjs`,
             directoryName + '.cjs.js',
           ),
         }),
@@ -439,19 +452,13 @@ async function makeBundle(
     ...(preserveModules
       ? {
           preserveModules: true,
-          dir: path.join(
-            packagesRoot,
-            directoryName,
-            outputDirectory,
-            'es',
-            path.dirname(packageJson.main),
-          ),
+          dir: path.join(packagesRoot, directoryName, `${outputDirectory}-es`),
         }
       : {
           file: path.join(
             packagesRoot,
             directoryName,
-            outputDirectory,
+            `${outputDirectory}-es`,
             directoryName + '.es.js',
           ),
         }),
@@ -465,28 +472,35 @@ async function makeBundle(
     // TODO: what of 'bin' fields?
     main: preserveModules
       ? path.join(
-          outputDirectory,
-          'cjs',
-          packageJson.main.replace(/\.tsx?$/, '.js'),
+          `${outputDirectory}-cjs`,
+          packageJson.main
+            .replace(/\.tsx?$/, '.js')
+            .replace(path.dirname(packageJson.main) + '/', ''),
         )
-      : `${outputDirectory}/${directoryName + '.cjs.js'}`,
+      : `${outputDirectory}-cjs/${directoryName + '.cjs.js'}`,
     module: preserveModules
       ? path.join(
-          outputDirectory,
-          'es',
-          packageJson.main.replace(/\.tsx?$/, '.js'),
+          `${outputDirectory}-es`,
+          packageJson.main
+            .replace(/\.tsx?$/, '.js')
+            .replace(path.dirname(packageJson.main) + '/', ''),
         )
-      : `${outputDirectory}/${directoryName + '.es.js'}`,
+      : `${outputDirectory}-es/${directoryName + '.es.js'}`,
     typings: path.join(
-      outputDirectory,
-      'types',
+      `${outputDirectory}-types`,
       packageJson.main.replace(/\.tsx?$/, '.d.ts'),
     ),
     dependencies: {
       ...packageJson.dependencies,
       ...localImports,
     },
-    files: distinct([...(packageJson.files || []), '/dist']),
+    files: distinct([
+      ...(packageJson.files || []),
+      '/dist-cjs',
+      '/dist-es',
+      '/dist-types',
+      'README.md',
+    ]),
   };
 
   console.log(`built ${directoryName}`);
@@ -510,7 +524,7 @@ function makeTypings(directoryName: string) {
   tsconfig.include = [`${packagesRoot}/${directoryName}`];
   tsconfig.compilerOptions = {
     ...tsconfig.compilerOptions,
-    declarationDir: `${packagesRoot}/${directoryName}/${outputDirectory}/types`,
+    declarationDir: `${packagesRoot}/${directoryName}/${outputDirectory}-types`,
     rootDir: `${packagesRoot}/${directoryName}`,
   };
 
@@ -559,8 +573,16 @@ export async function build(
   // ensure the root build folder is ready
   await fse.mkdirp(outputDirectory);
 
-  // delete any existing build folder, if at all
-  await prom(rimraf)(path.join(packagesRoot, directoryName, outputDirectory));
+  // delete any existing local build folders
+  await prom(rimraf)(
+    path.join(packagesRoot, directoryName, `${outputDirectory}-cjs`),
+  );
+  await prom(rimraf)(
+    path.join(packagesRoot, directoryName, `${outputDirectory}-es`),
+  );
+  await prom(rimraf)(
+    path.join(packagesRoot, directoryName, `${outputDirectory}-types`),
+  );
 
   // generate the js files
   const didBundle = await makeBundle(directoryName, preserveModules);
@@ -608,6 +630,7 @@ export async function build(
 
   // cool. now unpack the tgz's contents in the root dist
   await fse.mkdirp(path.join(outputDirectory, directoryName));
+
   await extract({
     file: path.join(outputDirectory, directoryName + '.tgz'),
     strip: 1,
@@ -617,11 +640,38 @@ export async function build(
   // (if you're curious why we unpack it here, it's because
   // we observed problems with publishing tgz files directly to npm.)
 
-  // delete the local dist folder
-  await prom(rimraf)(path.join(packagesRoot, directoryName, outputDirectory));
+  // delete the local dist folders
+  await prom(rimraf)(
+    path.join(packagesRoot, directoryName, `${outputDirectory}-cjs`),
+  );
+  await prom(rimraf)(
+    path.join(packagesRoot, directoryName, `${outputDirectory}-es`),
+  );
+  await prom(rimraf)(
+    path.join(packagesRoot, directoryName, `${outputDirectory}-types`),
+  );
 
   // then delete the tgz
   await fse.remove(path.join(outputDirectory, directoryName + '.tgz'));
   /// and... that's it
   console.log('finished');
 }
+
+/* TODO:
+
+- build command
+  - rm -rf dist && yarn modular build create-modular-react-app,modular-scripts --preserve-modules && yarn workspace modular-views.macro build
+- cleanup local dist folders on errors 
+- read preset-env targets from package.json
+  - also, if something _does_ need regenerator, how do we add it as a dep?
+- package.json should be able to specify build arguments. Specifically:
+  - preserveModules: boolean
+  - preserveEntrySignatures:  "strict" | "allow-extension" | "exports-only" | false
+- should we disallow using __dirname/__filename in libraries?
+- how do we deal with bin fields? maybe inside a standalone bin file, 
+  we can read package.json's main field?? That could be clever. 
+- rewrite modular-views.macro with typescript 
+- how does this work with changesets?
+- some kind of build info would be helpful? eg: https://unpkg.com/browse/react@17.0.1/build-info.json
+- can we run tests on our built versions? to verify we haven't broken anything.
+*/

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -296,11 +296,16 @@ async function buildParallel(
   directoryNames: string[],
   preserveModules?: boolean,
 ) {
+  console.log('building packages:', directoryNames.join(', '));
   const result = await Promise.allSettled(
     directoryNames.map((name) => build(name, preserveModules)),
   );
   const error = result.find((result) => result.status === 'rejected');
-  if (error) throw error;
+
+  if (error?.status === 'rejected') {
+    console.error(`building ${directoryNames[result.indexOf(error)]} failed`);
+    throw error.reason;
+  }
 }
 
 async function build(directoryName: string, preserveModules?: boolean) {

--- a/packages/modular-scripts/src/getModularRoot.ts
+++ b/packages/modular-scripts/src/getModularRoot.ts
@@ -1,4 +1,3 @@
-// keep this in sync with modular-views.macro/src/getModularRoot
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import findUp from 'find-up';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "allowJs": true,
+    "resolveJsonModule": true,
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Basic Options */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,6 +1727,18 @@
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
 
+"@rollup/plugin-node-resolve@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.1.tgz#d3765eec4bccf960801439a999382aed2dca959b"
+  integrity sha512-ltlsj/4Bhwwhb+Nb5xCz/6vieuEj2/BAkkqVIKmZwC7pIdl8srmgmglE4S0jFlZa32K4qvdQ6NHdmpRKD/LwoQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
@@ -2193,6 +2205,13 @@
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
 
@@ -11140,7 +11159,7 @@ resolve@1.18.1:
     is-core-module "^2.0.0"
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.16.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.16.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==


### PR DESCRIPTION
I've been working on using `modular build <package>` to build modular's packages. There's more to do, but these changes should probably land regardless. The changes I had to make during this PR

- include README.md in published packages by default
- fix dependencies in modular-scripts (the build script correctly caught the missing ones!)
- exclude /dist when generating type definitions
- exclude local imports from missingDependencies generated when rollup makes facades.
- fix our own tsconfig
- make the output a little flatter (re: directory structure). This helps in avoiding issues when using __dirname/__filename in node packages. (The problem still exists  if preserveModules: false, but that can't be avoided much. But even in that case, it's still better when the source files are flat in src)

There are more TODOs that arose from this, included in a comment at the bottom of build.ts, and I'll keep working on them.