### PR TITLE
Restrict tsconfig files so that TypeScript files live in `src` for packages

### DIFF
--- a/.changeset/wet-nails-care.md
+++ b/.changeset/wet-nails-care.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+---
+
+Fix an issue where generated files from libraries would interfere with
+typescript definition generation

--- a/packages/create-modular-react-app/template/tsconfig.json
+++ b/packages/create-modular-react-app/template/tsconfig.json
@@ -15,5 +15,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["packages"]
+  "include": ["modular", "packages/*/src"]
 }

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -509,7 +509,10 @@ function makeTypings(directoryName: string) {
   };
 
   // then add our custom stuff
-  tsconfig.include = [`${packagesRoot}/${directoryName}`];
+
+  // Only include src files from the package to prevent already built
+  // files from interferring with the compile
+  tsconfig.include = [`${packagesRoot}/${directoryName}/src`];
   tsconfig.compilerOptions = {
     ...tsconfig.compilerOptions,
     declarationDir: `${packagesRoot}/${directoryName}/${outputDirectory}/types`,

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -30,6 +30,6 @@ test('it can serialise a folder', () => {
        │  └─ setupTests.ts #bnjknz
        ├─ packages
        │  └─ README.md #14bthrh
-       └─ tsconfig.json #e5344q"
+       └─ tsconfig.json #sm7bga"
   `);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,6 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
     "sourceMap": true,
     "incremental": true
-  }
+  },
+  "include": ["modular", "packages/*/src"]
 }


### PR DESCRIPTION
This PR restricts the location of TypeScript files into the `src` directory for each package to prevent erroneous files being picked up by type checking and build scripts. This is the beginning of imposing sensible defaults for the modular environment.

After replacing the JPM build script that we had pre `modular build` I came across this bug when trying to generate typescript files. Since the include is set so broadly it will start picking up generated `dist` files and fail. I edited the file locally to test and it works fine.