### PR TITLE
fix broken build for modular-scripts

### DIFF
--- a/.changeset/hungry-moles-brake.md
+++ b/.changeset/hungry-moles-brake.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Fix broken build from #207

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -62,5 +62,9 @@
   "peerDependencies": {
     "typescript": "^4.1.2"
   },
-  "files": ["*.js"]
+  "files": [
+    "build",
+    "types",
+    "*.js"
+  ]
 }


### PR DESCRIPTION
I screwed up the build by missing which files to include when building-modular-scripts. This PR fixes it. Sorry!