### PR TITLE
When building libs, don't throw an error on submodule import for non-js files

### DIFF
--- a/.changeset/little-maps-swim.md
+++ b/.changeset/little-maps-swim.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+When building libs, don't throw an error on submodule import for non-js files

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -362,10 +362,19 @@ async function makeBundle(
             : // non-scoped
               importedPath[0];
 
-        if (importedPackage !== imported) {
+        if (
+          importedPackage !== imported &&
+          packageNames.includes(importedPackage) &&
+          // it's fine if it's anything but a js file
+          extensions.includes(path.extname(imported))
+        ) {
           // TODO: revisit this if and when we have support for multiple entrypoints
           // TODO: add a line number and file name here
-          throw new Error(`cannot import a submodule from ${importedPackage}`);
+          console.error(
+            `cannot import a submodule ${imported} from ${importedPackage}`,
+          );
+          // TODO: This could probably be an error, but
+          // let's revisit it when we have a better story.
         }
 
         if (packageJsons[importedPackage]) {


### PR DESCRIPTION
Doing a submodule import is fine for static assets like css and images _for now_, so we should allow them when building. We should only do this for imports from local workspaces, not for third party deps. 