### PR TITLE
ignore local build folders

### DIFF
--- a/.changeset/popular-zebras-visit.md
+++ b/.changeset/popular-zebras-visit.md
@@ -1,0 +1,5 @@
+---
+'create-modular-react-app': patch
+---
+
+Ignore new build folders in local workspaces

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ packages/view-2
 
 # Build output
 /packages/*/build/
-/packages/*/dist/
+/packages/*/dist-cjs/
+/packages/*/dist-es/
+/packages/*/dist-types/
 
 # Testing
 /coverage

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -60,8 +60,8 @@ describe('create-modular-react-app', () => {
     expect(tree(destination)).toMatchInlineSnapshot(`
       "test-repo
       ├─ .editorconfig #1p4gvuw
-      ├─ .eslintignore #1ugsijf
-      ├─ .gitignore #1ugsijf
+      ├─ .eslintignore #1tm0llc
+      ├─ .gitignore #1tm0llc
       ├─ .vscode
       │  ├─ extensions.json #1i4584r
       │  └─ settings.json #xncm1d

--- a/packages/create-modular-react-app/template/gitignore
+++ b/packages/create-modular-react-app/template/gitignore
@@ -10,6 +10,9 @@ node_modules
 
 # production
 /packages/*/build
+/packages/*/dist-cjs/
+/packages/*/dist-es/
+/packages/*/dist-types/
 
 # misc
 .DS_Store

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,7 +15,7 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #1lu3g5f
+    │  │  └─ index.test.ts #1jmf81m
     │  ├─ cli.ts #gcx3cm
     │  └─ index.ts #un0l9d
     └─ template
@@ -24,7 +24,7 @@ test('it can serialise a folder', () => {
        │  ├─ extensions.json #1i4584r
        │  └─ settings.json #xncm1d
        ├─ README.md #1nksyzj
-       ├─ gitignore #1ugsijf
+       ├─ gitignore #1tm0llc
        ├─ modular
        │  ├─ setupEnvironment.ts #m0s4vb
        │  └─ setupTests.ts #bnjknz


### PR DESCRIPTION
In #207, I changed the build folder destinations, but forgot to change gitignore directives for the same. This PR adds them for us, and for newly generated projects.

This isn't critical since they get cleaned on build anyway, but good to have.