### PR TITLE
Add tsconfig for publishing + changeset

### DIFF
--- a/.changeset/grumpy-dragons-burn.md
+++ b/.changeset/grumpy-dragons-burn.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Add tsconfig for publishing

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -65,6 +65,7 @@
   "files": [
     "build",
     "types",
+    "tsconfig.json",
     "*.js"
   ]
 }


### PR DESCRIPTION
Adding `tsconfig.json` to list of files for publishing in `modular-scripts` so it can be consumed downstream.