### PR TITLE
Proposal: Enable multi-team-workspaces

### DIFF
--- a/.changeset/fresh-birds-burn.md
+++ b/.changeset/fresh-birds-burn.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+Add ability for teams to collaborate using scoped packages

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 import mri from 'mri';
 import execa from 'execa';
 import * as fs from 'fs-extra';
@@ -16,6 +15,7 @@ import resolveAsBin from 'resolve-as-bin';
 
 import getModularRoot from './getModularRoot';
 import preflightCheck from './preflightCheck';
+import isModularType from './isModularType';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
@@ -49,23 +49,6 @@ function execSync(
     cleanup: true,
     ...opts,
   });
-}
-
-type PackageType = 'app' | 'view' | 'root'; // | 'package', the default
-
-type ModularPackageJson = PackageJson & {
-  modular?: {
-    type: PackageType;
-  };
-};
-
-function isModularType(dir: string, type: PackageType) {
-  const packageJsonPath = path.join(dir, 'package.json');
-  if (fs.existsSync(packageJsonPath)) {
-    const packageJson = fs.readJsonSync(packageJsonPath) as ModularPackageJson;
-    return packageJson.modular?.type === type;
-  }
-  return false;
 }
 
 // recursively get all files in a folder

--- a/packages/modular-scripts/src/isModularType.ts
+++ b/packages/modular-scripts/src/isModularType.ts
@@ -1,0 +1,22 @@
+import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
+import * as fs from 'fs-extra';
+import path from 'path';
+
+export type PackageType = 'app' | 'view' | 'root'; // | 'package', the default
+
+export type ModularPackageJson = PackageJson & {
+  modular?: {
+    type: PackageType;
+  };
+};
+
+export default function isModularType(dir: string, type: PackageType): boolean {
+  const packageJsonPath = path.join(dir, 'package.json');
+
+  if (fs.existsSync(packageJsonPath)) {
+    const packageJson = fs.readJsonSync(packageJsonPath) as ModularPackageJson;
+    return packageJson.modular?.type === type;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Through testing internally I think it's become apparent that we need to be able to support different "verticals" within the same repository - this might be separate teams who don't share the same scope within their packages. 

We discussed this previously and said that we would have to be strict about the implementation - I've done a bit of a PoC for what this could look like. The rules work as follows: 
1. `workspaces` in the modular `root` `package.json` must either have `[ "packages/*"] ]` or `[ "packages/*/*" ]`.
2. In the single `*` namespace end. 
3. In the multi scope case...
    *  validate that each package name in the "scope" directory name matches.
    * validate that each package name matches the directory name which contains it.

This will enable the repo to scale across multiple teams and other `modular` based teams to merge repositories without changing their scope. It also means that `CODEOWNERS` can work more easily, since you can assign `packages/team/*` to a particular group. 