### PR TITLE
Add support for running tests with an attached debugger.

### DIFF
--- a/.changeset/lazy-vans-fry.md
+++ b/.changeset/lazy-vans-fry.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Bring back support for --inspect-brk, for testing with a debugger.

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -261,7 +261,21 @@ function test(args: string[]) {
 
   // ends the section copied from CRA
 
-  return execSync(jestBin, argv, {
+  let testBin = jestBin,
+    testArgs = argv;
+
+  if (argv.includes('--inspect-brk')) {
+    // If we're trying to attach to a debugger, we need to run node
+    // instead. This moves around the command line arguments for so.
+    testBin = 'node';
+    testArgs = [
+      '--inspect-brk',
+      jestBin,
+      ...testArgs.filter((x) => x !== '--inspect-brk'),
+    ];
+  }
+
+  return execSync(testBin, testArgs, {
     cwd: modularRoot,
     log: false,
     // @ts-ignore


### PR DESCRIPTION
When we migrated to controlling the tests by ourselves, we broke integration with using a debugger. This PR brings back support for it, teh same way react-scripts would.

To attach a debugger to tests, run `modular test --inspect-brk --runInBand <other params>`. Then open a new tab in chrome, open chrome://inspect, and follow instructions.