### PR TITLE
Adds a "debug tests" vscode launch config

### DIFF
--- a/.changeset/pink-nails-wave.md
+++ b/.changeset/pink-nails-wave.md
@@ -1,0 +1,5 @@
+---
+'create-modular-react-app': minor
+---
+
+Adds a debug test launch config for vscode

--- a/.changeset/pink-nails-wave.md
+++ b/.changeset/pink-nails-wave.md
@@ -1,5 +1,5 @@
 ---
-'create-modular-react-app': minor
+'create-modular-react-app': patch
 ---
 
 Adds a debug test launch config for vscode

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -64,6 +64,7 @@ describe('create-modular-react-app', () => {
       ├─ .gitignore #1tm0llc
       ├─ .vscode
       │  ├─ extensions.json #1i4584r
+      │  ├─ launch.json #15fzacl
       │  └─ settings.json #xncm1d
       ├─ README.md #1nksyzj
       ├─ modular

--- a/packages/create-modular-react-app/template/.vscode/launch.json
+++ b/packages/create-modular-react-app/template/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/modular",
+      "args": ["test", "--runInBand", "--no-cache", "--env=jsdom", "{file}"],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,13 +15,14 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #1v8shn0
+    │  │  └─ index.test.ts #1g6aupe
     │  ├─ cli.ts #gcx3cm
     │  └─ index.ts #un0l9d
     └─ template
        ├─ .editorconfig #1p4gvuw
        ├─ .vscode
        │  ├─ extensions.json #1i4584r
+       │  ├─ launch.json #15fzacl
        │  └─ settings.json #xncm1d
        ├─ README.md #1nksyzj
        ├─ gitignore #1tm0llc


### PR DESCRIPTION
This adds a vscode launch config to newly created projects, making it easier to debug tests and code inside vscode directly. Tested this internally and it works well.