### PR TITLE
[DO NOT MERGE] use babel-preset-react-app for lib builds

### DIFF
--- a/.changeset/gold-monkeys-leave.md
+++ b/.changeset/gold-monkeys-leave.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+use babel-preset-react-app for lib builds

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -347,14 +347,19 @@ describe('modular-scripts', () => {
     rimraf.sync(path.join(modularRoot, 'dist'));
 
     // build a view
-    await modular('build sample-view', { stdio: 'inherit' });
+    await modular('build sample-view', {
+      stdio: 'inherit',
+      env: { NODE_ENV: 'production' },
+    });
     // build a package too, but preserve modules
     await modular('build sample-package --preserve-modules', {
       stdio: 'inherit',
+      env: { NODE_ENV: 'production' },
     });
     // build the nested package
     await modular('build nested/sample-nested-package', {
       stdio: 'inherit',
+      env: { NODE_ENV: 'production' },
     });
 
     expect(
@@ -363,7 +368,9 @@ describe('modular-scripts', () => {
       ),
     ).toMatchInlineSnapshot(`
       Object {
-        "dependencies": Object {},
+        "dependencies": Object {
+          "@babel/runtime": "^7.12.5",
+        },
         "files": Array [
           "/dist-cjs",
           "/dist-es",
@@ -386,6 +393,7 @@ describe('modular-scripts', () => {
     ).toMatchInlineSnapshot(`
       Object {
         "dependencies": Object {
+          "@babel/runtime": "^7.12.5",
           "react": "^17.0.2",
         },
         "files": Array [
@@ -417,7 +425,9 @@ describe('modular-scripts', () => {
       ),
     ).toMatchInlineSnapshot(`
       Object {
-        "dependencies": Object {},
+        "dependencies": Object {
+          "@babel/runtime": "^7.12.5",
+        },
         "files": Array [
           "/dist-cjs",
           "/dist-es",
@@ -463,11 +473,11 @@ describe('modular-scripts', () => {
       └─ sample-view
          ├─ README.md #11adaka
          ├─ dist-cjs
-         │  ├─ sample-view.cjs.js #8jw6cg
-         │  └─ sample-view.cjs.js.map #130r3z8
+         │  ├─ sample-view.cjs.js #pz1p9l
+         │  └─ sample-view.cjs.js.map #1o7p2t4
          ├─ dist-es
-         │  ├─ sample-view.es.js #1ctbbz8
-         │  └─ sample-view.es.js.map #12deywy
+         │  ├─ sample-view.es.js #1pcl5b9
+         │  └─ sample-view.es.js.map #2jby31
          ├─ dist-types
          │  └─ src
          │     └─ index.d.ts #1vloh7q

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -4,7 +4,7 @@ import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/pa
 
 import preflightCheck from './utils/preflightCheck';
 
-import buildPackages from './build';
+import build from './build';
 import addPackage from './addPackage';
 import start from './start';
 import test, { TestOptions } from './test';
@@ -60,11 +60,18 @@ program
         preserveModules?: boolean;
       },
     ) => {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error(
+          'Builds should be done with production settings. Try calling NODE_ENV=production modular build <name>',
+        );
+        process.exit(1);
+      }
+
       console.log('building packages at:', packagePaths.join(', '));
 
       for (let i = 0; i < packagePaths.length; i++) {
         try {
-          await buildPackages(packagePaths[i], options['preserveModules']);
+          await build(packagePaths[i], options['preserveModules']);
         } catch (err) {
           console.error(`building ${packagePaths[i]} failed`);
           throw err;


### PR DESCRIPTION
Keeps output consistent across apps and libs, across upgrades and changes.
(For the babel part, we still need to fix some missing features.)
This PR should also make lib bundles smaller, by avoiding bundling @babel/runtime helpers. 

I need to test this internally before merging it in, so don't merge this just yet. 