### PR TITLE
fix the macro's type generation, and some dependency fixes

### DIFF
--- a/.changeset/proud-fireants-confess.md
+++ b/.changeset/proud-fireants-confess.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+'modular-views.macro': patch
+---
+
+Fix the macro's type generation, and avoid some console spam when installing.

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "@babel/cli": "^7.10.1",
-    "@babel/core": "^7.9.6",
-    "@babel/preset-env": "^7.9.6",
+    "@babel/core": "7.12.3",
+    "@babel/preset-env": "^7.12.10",
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@changesets/cli": "^2.10.2",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -15,6 +15,7 @@
     "build": "babel --root-mode upward src --out-dir build --extensions .ts --ignore 'src/**/*.test.ts'"
   },
   "dependencies": {
+    "@babel/core": "7.12.3",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/preset-env": "^7.12.10",
     "@craco/craco": "^6.0.0",
@@ -55,7 +56,8 @@
     "@types/puppeteer": "^5.4.0",
     "@types/rimraf": "^3.0.0",
     "@types/tar": "^4.0.4",
-    "pptr-testing-library": "^0.6.4"
+    "pptr-testing-library": "^0.6.4",
+    "typescript": "^4.1.2"
   },
   "optionalDependencies": {
     "puppeteer": "^5.4.1"

--- a/packages/modular-views.macro/package.json
+++ b/packages/modular-views.macro/package.json
@@ -2,7 +2,7 @@
   "name": "modular-views.macro",
   "version": "1.2.0",
   "main": "build/index.macro.js",
-  "typings": "types/index.macro.d.ts",
+  "typings": "build/index.macro.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
     "@types/babel-plugin-macros": "^2.8.4",
@@ -15,6 +15,6 @@
     "prebuild": "yarn clean",
     "build": "yarn build:lib && yarn build:types",
     "build:lib": "babel --root-mode upward src --out-dir build --extensions .ts --ignore 'src/**/*.test.ts'",
-    "build:types": "tsc --emitDeclarationOnly --outDir dist-types"
+    "build:types": "tsc --emitDeclarationOnly --declarationDir build"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,7 +36,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.7.tgz#9329b4782a7d6bbd7eef57e11addf91ee3ef1e41"
   integrity sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==
 
-"@babel/core@7.12.3", "@babel/core@^7.1.0", "@babel/core@^7.7.5", "@babel/core@^7.8.4", "@babel/core@^7.9.0", "@babel/core@^7.9.6":
+"@babel/core@7.12.3", "@babel/core@^7.1.0", "@babel/core@^7.7.5", "@babel/core@^7.8.4", "@babel/core@^7.9.0":
   version "7.12.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
   integrity sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==
@@ -912,7 +912,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/preset-env@7.12.1", "@babel/preset-env@^7.8.4", "@babel/preset-env@^7.9.5", "@babel/preset-env@^7.9.6":
+"@babel/preset-env@7.12.1", "@babel/preset-env@^7.8.4", "@babel/preset-env@^7.9.5":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.1.tgz#9c7e5ca82a19efc865384bb4989148d2ee5d7ac2"
   integrity sha512-H8kxXmtPaAGT7TyBvSSkoSTUK6RHh61So05SyEbpmr0MCZrsNYn7mGMzzeYoOUCdHzww61k8XBft2TaES+xPLg==


### PR DESCRIPTION
- `modular-views.macro` was generating to a different folder than what its package.json was pointing to, fixed that.
- added `@babel/core` as a dependency to `modular-scripts`, to avoid a whole bunch of missing peer dependency warnings whenever someone makes a new project.
- `@manypkg/cli check` also suggested a couple of changes for the root package.json that seemed reasonable, added those too.