### PR TITLE
use yarn --silent 

### DIFF
--- a/.changeset/silver-cats-mate.md
+++ b/.changeset/silver-cats-mate.md
@@ -1,0 +1,6 @@
+---
+'create-modular-react-app': patch
+'modular-scripts': patch
+---
+
+Use yarn --silent where possible

--- a/packages/create-modular-react-app/src/cli.ts
+++ b/packages/create-modular-react-app/src/cli.ts
@@ -111,6 +111,7 @@ export default function createModularApp(argv: {
     [
       'add',
       '-W',
+      '--silent',
       '@testing-library/dom',
       '@testing-library/jest-dom',
       '@testing-library/react',
@@ -147,7 +148,14 @@ export default function createModularApp(argv: {
 
   execSync(
     'yarnpkg',
-    ['modular', 'add', 'app', '--unstable-type=app', ...preferOfflineArg],
+    [
+      'modular',
+      'add',
+      'app',
+      '--unstable-type=app',
+      '--silent',
+      ...preferOfflineArg,
+    ],
     {
       cwd: newModularRoot,
     },

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -617,6 +617,7 @@ export async function build(
       // TODO: verify this works on windows
       [
         'pack',
+        '--silent',
         '--filename',
         path.join(`../../${outputDirectory}`, directoryName + '.tgz'),
       ],

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -16,7 +16,7 @@ test('it can serialise a folder', () => {
     ├─ src
     │  ├─ __tests__
     │  │  └─ index.test.ts #4g4vlr
-    │  ├─ cli.ts #z6yvql
+    │  ├─ cli.ts #1i6cy4n
     │  └─ index.ts #un0l9d
     └─ template
        ├─ .editorconfig #1p4gvuw


### PR DESCRIPTION
This adds the `--silent` flag when adding dependencies in a new project. It reduces a whole bund of console spam, but stills shows progress bars, and importantly, also stderr.

To compare, on my laptop, running all tests now is about 400 lines of console spam, compared to about 2400 lines before this PR. (Your numbers may change depending on terminal width, etc)