### PR TITLE
update rollup to 2.38.3

### DIFF
--- a/.changeset/lazy-parrots-pump.md
+++ b/.changeset/lazy-parrots-pump.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Update rollup to 2.38.3

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "*.{js,json,ts,tsx,css,md,mdx}": "prettier --write"
   },
   "resolutions": {
-    "rollup": "^2.33.3",
+    "rollup": "^2.38.3",
     "**/update-notifier/boxen": "^5.0.0"
   }
 }

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -40,7 +40,7 @@
     "resolve": "^1.19.0",
     "resolve-as-bin": "^2.1.0",
     "rimraf": "^3.0.2",
-    "rollup": "^2.33.3",
+    "rollup": "^2.38.3",
     "rollup-plugin-postcss": "^3.1.8",
     "update-notifier": "^5.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6928,6 +6928,11 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+fsevents@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
+  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -12010,12 +12015,12 @@ rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.31.1, rollup@^2.33.3:
-  version "2.33.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.33.3.tgz#ae72ce31f992b09a580072951bfea76e9df17342"
-  integrity sha512-RpayhPTe4Gu/uFGCmk7Gp5Z9Qic2VsqZ040G+KZZvsZYdcuWaJg678JeDJJvJeEQXminu24a2au+y92CUWVd+w==
+rollup@^1.31.1, rollup@^2.38.3:
+  version "2.38.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.38.3.tgz#2a0b6cc6eab1da4431aab875a31a401fa2988c10"
+  integrity sha512-FVx/XzR2DtCozKNDBjHJCHIgkC12rNg/ruAeoYWjLeeKfSKgwhh+lDLDhuCkuRG/fsup8py8dKBTlHdvUFX32A==
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.1"
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
This PR updates rollup, which includes the updated version of fsevents and chokidar (which were deprecated and also didn't work corrertly on M1 machines).

Low risk, will land after CI passes. Also not critical, can wait to bur published whenever. 