### PR TITLE
move the puppeteer dependency to the root

### DIFF
--- a/.changeset/blue-plums-cross.md
+++ b/.changeset/blue-plums-cross.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Don't install puppeteer as a dependency

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint-staged": "^10.2.6",
     "micromatch": "^4.0.2",
     "prettier": "2.0.5",
+    "puppeteer": "^5.4.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "semver": "^7.3.2",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -58,9 +58,6 @@
     "pptr-testing-library": "^0.6.4",
     "typescript": "^4.1.2"
   },
-  "optionalDependencies": {
-    "puppeteer": "^5.4.1"
-  },
   "peerDependencies": {
     "typescript": "^4.1.2"
   },


### PR DESCRIPTION
This PR moves `puppeteer`, which was an optional dependency for `modular-scripts`, into the root `package.json` as a dependency. We'd changed it from a dev dependency to an optional dependency because it's not working on Apple M1 machines at the moment. The problem is, that meant it even installs for consumers, making the install flow slower (and occasionally failing because of the network fetch). By moving it into the root here, it won't get installed for consumers but lets us carry on development. Once the underlying issue is fixed, we'll move it back into deDependencies for `modular-scripts`.

Low risk, will land after CI passes. 