### PR TITLE
move puppeteer to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,14 @@
     "lint-staged": "^10.2.6",
     "micromatch": "^4.0.2",
     "prettier": "2.0.5",
-    "puppeteer": "^5.4.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "semver": "^7.3.2",
     "ts-node": "^9.0.0",
     "typescript": "^4.1.2"
+  },
+  "optionalDependencies": {
+    "puppeteer": "^5.4.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Sigh. I moved puppeteer to the root in #252, but that should have been in optional dependencies too. (This is only breaking for me, sorry for the churn). This PR marks it as optional.

Landing this once CI passes. Doesn't need a changeset. 