### PR TITLE
modify *ignore files

### DIFF
--- a/.changeset/polite-seals-allow.md
+++ b/.changeset/polite-seals-allow.md
@@ -1,0 +1,5 @@
+---
+'create-modular-react-app': patch
+---
+
+Better \*ignore files in new projects.

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,37 @@
-.gitignore
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# Dependencies
+node_modules
+
+# created by tests in modular-scripts
+packages/sample-app
+packages/sample-view
+packages/sample-package
+
+# created by tests in modular-views.macro
+packages/view-1
+packages/view-2
+
+# Build output
+/packages/**/build/
+
+# Testing
+/coverage
+
+# Misc
+.DS_Store
+.eslintcache
+
+# Editors
+.idea
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+/dist
+
+# Used by typescript for incremental builds 
+.tsbuildinfo
+*.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,6 @@ packages/view-2
 
 # Build output
 /packages/*/build/
-/packages/*/dist-cjs/
-/packages/*/dist-es/
-/packages/*/dist-types/
 
 # Testing
 /coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 /dist
-packages/*/dist
-packages/modular-site/public
+packages/**/dist
+packages/**/build
+packages/**/public

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -61,7 +61,7 @@ describe('create-modular-react-app', () => {
       "test-repo
       ├─ .editorconfig #1p4gvuw
       ├─ .eslintignore #1ot2bpo
-      ├─ .gitignore #21yvq5
+      ├─ .gitignore #175wbq
       ├─ .prettierignore #10uqwgj
       ├─ .vscode
       │  ├─ extensions.json #1i4584r

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -60,9 +60,9 @@ describe('create-modular-react-app', () => {
     expect(tree(destination)).toMatchInlineSnapshot(`
       "test-repo
       ├─ .editorconfig #1p4gvuw
-      ├─ .eslintignore #1x09skm
-      ├─ .gitignore #1tm0llc
-      ├─ .prettierignore #1ivaop6
+      ├─ .eslintignore #1ot2bpo
+      ├─ .gitignore #21yvq5
+      ├─ .prettierignore #10uqwgj
       ├─ .vscode
       │  ├─ extensions.json #1i4584r
       │  ├─ launch.json #15fzacl

--- a/packages/create-modular-react-app/template/.eslintignore
+++ b/packages/create-modular-react-app/template/.eslintignore
@@ -8,12 +8,6 @@ node_modules
 # testing
 /coverage
 
-# production
-/packages/*/build
-/packages/*/dist-cjs/
-/packages/*/dist-es/
-/packages/*/dist-types/
-
 # misc
 .DS_Store
 .env.local
@@ -25,4 +19,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-packages/*/public
+packages/**/public
+/dist

--- a/packages/create-modular-react-app/template/.prettierignore
+++ b/packages/create-modular-react-app/template/.prettierignore
@@ -1,4 +1,2 @@
 /dist
-/packages/*/dist
-/packages/*/build
-/packages/*/public
+/packages/**/public

--- a/packages/create-modular-react-app/template/gitignore
+++ b/packages/create-modular-react-app/template/gitignore
@@ -8,12 +8,6 @@ node_modules
 # testing
 /coverage
 
-# production
-/packages/*/build
-/packages/*/dist-cjs/
-/packages/*/dist-es/
-/packages/*/dist-types/
-
 # misc
 .DS_Store
 .env.local

--- a/packages/create-modular-react-app/template/gitignore
+++ b/packages/create-modular-react-app/template/gitignore
@@ -18,3 +18,5 @@ node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/dist

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,19 +15,19 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #alwhsw
+    │  │  └─ index.test.ts #fd9x93
     │  ├─ cli.ts #16bp7u1
     │  └─ index.ts #un0l9d
     └─ template
        ├─ .editorconfig #1p4gvuw
-       ├─ .eslintignore #1x09skm
-       ├─ .prettierignore #1ivaop6
+       ├─ .eslintignore #1ot2bpo
+       ├─ .prettierignore #10uqwgj
        ├─ .vscode
        │  ├─ extensions.json #1i4584r
        │  ├─ launch.json #15fzacl
        │  └─ settings.json #xncm1d
        ├─ README.md #1nksyzj
-       ├─ gitignore #1tm0llc
+       ├─ gitignore #21yvq5
        ├─ modular
        │  ├─ setupEnvironment.ts #m0s4vb
        │  └─ setupTests.ts #bnjknz

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,7 +15,7 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #fd9x93
+    │  │  └─ index.test.ts #9ej560
     │  ├─ cli.ts #16bp7u1
     │  └─ index.ts #un0l9d
     └─ template
@@ -27,7 +27,7 @@ test('it can serialise a folder', () => {
        │  ├─ launch.json #15fzacl
        │  └─ settings.json #xncm1d
        ├─ README.md #1nksyzj
-       ├─ gitignore #21yvq5
+       ├─ gitignore #175wbq
        ├─ modular
        │  ├─ setupEnvironment.ts #m0s4vb
        │  └─ setupTests.ts #bnjknz


### PR DESCRIPTION
A bit more accurate for new projects, and make our own better too. Of note, `.eslintignore` is not symlinked to `.gitignore` anymore, and doesn't have the same contents.