### PR TITLE
don't pass modules:true to the library build's css phase

### DIFF
--- a/.changeset/slimy-maps-chew.md
+++ b/.changeset/slimy-maps-chew.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Don't convert all css files to css modules

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -272,8 +272,8 @@ async function makeBundle(
         include: [`${packagesRoot}/**/*`],
         exclude: 'node_modules/**',
       }),
-      postcss({ extract: false, modules: true }),
-      // TODO: add sass, css modules, dotenv
+      postcss({ extract: false }),
+      // TODO: add sass, dotenv
       json(),
       {
         // via tsdx


### PR DESCRIPTION
I'd made a mistake where css modules were turned on for all css files by default. This PR removes that. The plugin already enables it by default for .module.css files, so nothing more is needed.