### PR TITLE
[DO NOT MERGE] don't delete generated artifacts on build

### DIFF
--- a/.changeset/modern-points-smash.md
+++ b/.changeset/modern-points-smash.md
@@ -1,0 +1,6 @@
+---
+'create-modular-react-app': patch
+'modular-scripts': patch
+---
+
+Don't delete generated artifacts on lib builds.

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -60,9 +60,9 @@ describe('create-modular-react-app', () => {
     expect(tree(destination)).toMatchInlineSnapshot(`
       "test-repo
       ├─ .editorconfig #1p4gvuw
-      ├─ .eslintignore #1ot2bpo
-      ├─ .gitignore #175wbq
-      ├─ .prettierignore #10uqwgj
+      ├─ .eslintignore #1uujd75
+      ├─ .gitignore #twbblh
+      ├─ .prettierignore #16xg9no
       ├─ .vscode
       │  ├─ extensions.json #1i4584r
       │  ├─ launch.json #15fzacl

--- a/packages/create-modular-react-app/template/.eslintignore
+++ b/packages/create-modular-react-app/template/.eslintignore
@@ -21,3 +21,6 @@ yarn-error.log*
 
 packages/**/public
 /dist
+/packages/**/dist-cjs
+/packages/**/dist-es
+/packages/**/dist-types

--- a/packages/create-modular-react-app/template/.prettierignore
+++ b/packages/create-modular-react-app/template/.prettierignore
@@ -1,2 +1,5 @@
 /dist
 /packages/**/public
+/packages/**/dist-cjs
+/packages/**/dist-es
+/packages/**/dist-types

--- a/packages/create-modular-react-app/template/gitignore
+++ b/packages/create-modular-react-app/template/gitignore
@@ -20,3 +20,6 @@ yarn-debug.log*
 yarn-error.log*
 
 /dist
+/packages/**/dist-cjs
+/packages/**/dist-es
+/packages/**/dist-types

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -642,16 +642,25 @@ export async function build(
   // (if you're curious why we unpack it here, it's because
   // we observed problems with publishing tgz files directly to npm.)
 
+  // there's a race condition when we run modular build <path> on
+  // several packages at the same time, in different processes.
+  // makeTypings(), despite being synchronouse, can be interleaved across processes
+  // so, it maye have picked up a built package, where the package.json is pointing to
+  // built typings. when we delete the built folders, the generated types don't exist
+  // anymore (but it won't pick up the original source folders)
+  // To fix this for now, we're just going to *not* delete the generated folders.
+  // Leaving this code here to revisit later.
+
   // delete the local dist folders
-  await prom(rimraf)(
-    path.join(packagesRoot, packagePath, `${outputDirectory}-cjs`),
-  );
-  await prom(rimraf)(
-    path.join(packagesRoot, packagePath, `${outputDirectory}-es`),
-  );
-  await prom(rimraf)(
-    path.join(packagesRoot, packagePath, `${outputDirectory}-types`),
-  );
+  // await prom(rimraf)(
+  //   path.join(packagesRoot, packagePath, `${outputDirectory}-cjs`),
+  // );
+  // await prom(rimraf)(
+  //   path.join(packagesRoot, packagePath, `${outputDirectory}-es`),
+  // );
+  // await prom(rimraf)(
+  //   path.join(packagesRoot, packagePath, `${outputDirectory}-types`),
+  // );
 
   // then delete the tgz
 

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -15,19 +15,19 @@ test('it can serialise a folder', () => {
     ├─ package.json
     ├─ src
     │  ├─ __tests__
-    │  │  └─ index.test.ts #1w35b9i
+    │  │  └─ index.test.ts #1ntj7u0
     │  ├─ cli.ts #12qu7t3
     │  └─ index.ts #un0l9d
     └─ template
        ├─ .editorconfig #1p4gvuw
-       ├─ .eslintignore #1ot2bpo
-       ├─ .prettierignore #10uqwgj
+       ├─ .eslintignore #1uujd75
+       ├─ .prettierignore #16xg9no
        ├─ .vscode
        │  ├─ extensions.json #1i4584r
        │  ├─ launch.json #15fzacl
        │  └─ settings.json #xncm1d
        ├─ README.md #1nksyzj
-       ├─ gitignore #175wbq
+       ├─ gitignore #twbblh
        ├─ modular
        │  ├─ setupEnvironment.ts #m0s4vb
        │  └─ setupTests.ts #bnjknz


### PR DESCRIPTION
There's a race condition when we run `modular build <path>` on several packages at the same time, in different processes. `makeTypings()`, despite being synchronous, can be interleaved across processes. So, it may have picked up a built package, where the `package.json` is pointing to built typings. When we delete the built folders, the generated types don't exist anymore (but it won't pick up the original source), making the build fail.

To fix this for now, we're just not going to delete the generated artifacts.

I also updated prettierignore/eslintignore/gitignore in fresh projects to ignore these files so they don't accidentally get committed.

---

Made this PR pre-emptively while we test this change internally. We'll likely also have to make a 'clean' command to wipe out files.