### PR TITLE
Reordered Babel plugins

### DIFF
--- a/.changeset/nasty-days-drop.md
+++ b/.changeset/nasty-days-drop.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Corrected issue with Babel plugins that was making @babel/preset-typescript not to apply correctly

--- a/.changeset/nasty-days-drop.md
+++ b/.changeset/nasty-days-drop.md
@@ -2,4 +2,5 @@
 'modular-scripts': patch
 ---
 
-Corrected issue with Babel plugins that was making @babel/preset-typescript not to apply correctly
+Corrected issue with Babel plugins that was making @babel/preset-typescript not
+to apply correctly

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -260,12 +260,13 @@ async function makeBundle(
       babel({
         babelHelpers: 'bundled',
         presets: [
-          ['@babel/preset-typescript', { isTSX: true, allExtensions: true }],
-          '@babel/preset-react',
+          // Preset orders matters, please see: https://github.com/babel/babel/issues/8752#issuecomment-486541662
           [
             '@babel/preset-env',
             // TODO: why doesn't this read `targets` from package.json?
           ],
+          ['@babel/preset-typescript', { isTSX: true, allExtensions: true }],
+          '@babel/preset-react',
         ],
         plugins: ['@babel/plugin-proposal-class-properties'],
         extensions,


### PR DESCRIPTION
### Babel is not generating JS output correctly

For some reason, order does matter when defining babel plugins. In order for ``@babel/preset-typescript`` to work properly, it needs to be referenced after ``@babel/preset-env``.

See this issue for reference: https://github.com/babel/babel/issues/8752#issuecomment-486541662