### PR TITLE
ensure that workspaces are setup properly before running modular 

### DIFF
--- a/.changeset/sharp-ties-retire.md
+++ b/.changeset/sharp-ties-retire.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Prevent yarn workspace errors when starting modular via the CLI.

--- a/packages/modular-scripts/src/buildPackage.ts
+++ b/packages/modular-scripts/src/buildPackage.ts
@@ -32,14 +32,6 @@ import builtinModules from 'builtin-modules';
 import getModularRoot from './utils/getModularRoot';
 import { getAllWorkspaces } from './utils/workspaces';
 
-const modularRoot = getModularRoot();
-
-if (process.cwd() !== modularRoot) {
-  throw new Error(
-    'This command can only be run from the root of a modular project',
-  );
-}
-
 type Console = {
   log: typeof console.log;
   error: typeof console.error;
@@ -593,6 +585,14 @@ export async function buildPackage(
   packagePath: string,
   preserveModules = false,
 ): Promise<void> {
+  const modularRoot = getModularRoot();
+
+  if (process.cwd() !== modularRoot) {
+    throw new Error(
+      'This command can only be run from the root of a modular project',
+    );
+  }
+
   const console = getConsole(packagePath);
   // ensure the root build folder is ready
   await fse.mkdirp(outputDirectory);

--- a/packages/modular-scripts/src/utils/workspaces.ts
+++ b/packages/modular-scripts/src/utils/workspaces.ts
@@ -1,11 +1,12 @@
 import execa from 'execa';
 import getModularRoot from './getModularRoot';
-const modularRoot = getModularRoot();
 
 let workspaces: { [name: string]: { location: string } };
 
 export function getAllWorkspaces(): typeof workspaces {
   if (!workspaces) {
+    const modularRoot = getModularRoot();
+
     workspaces = JSON.parse(
       execa.sync('yarnpkg', ['workspaces', 'info'], {
         all: true,


### PR DESCRIPTION
It could be the case that yarn workspaces are not setup properly with multiple packages using the same package name across different directories. 

I've seen this before internally and while it's not an error specifically it can cause weird errors after ```yarn``` is run initially.