### PR TITLE
Remove unneccessary silent flag in cmra cli

### DIFF
--- a/.changeset/large-geckos-push.md
+++ b/.changeset/large-geckos-push.md
@@ -1,0 +1,5 @@
+---
+'create-modular-react-app': patch
+---
+
+Removed unneccessary silent flag

--- a/packages/create-modular-react-app/src/cli.ts
+++ b/packages/create-modular-react-app/src/cli.ts
@@ -135,7 +135,6 @@ export default function createModularApp(argv: {
       'app',
       '--unstable-name',
       'app',
-      '--silent',
       ...preferOfflineArg,
     ],
     {

--- a/packages/tree-view-for-tests/src/__tests__/tree.test.ts
+++ b/packages/tree-view-for-tests/src/__tests__/tree.test.ts
@@ -16,7 +16,7 @@ test('it can serialise a folder', () => {
     ├─ src
     │  ├─ __tests__
     │  │  └─ index.test.ts #qhhzh
-    │  ├─ cli.ts #8gy08n
+    │  ├─ cli.ts #1sx9my
     │  └─ index.ts #1spcux6
     └─ template
        ├─ .editorconfig #1p4gvuw


### PR DESCRIPTION
I removed the --silent flag from the create-modular-react-app cli.

Create-modular-react-app tests install the latest published version of modular-scripts. The latest published version only allows for 2 flags with the add CLI command (--unstable-name and --unstable-type) and when CMRA uses the --silent flag, it rejects it. 

The --silent flag isn't necessary for CMRA because addPackage already sets the --silent flag when it comes time to yarn install for the new package and modular root. 
