### PR TITLE
Add init API

### DIFF
--- a/.changeset/strong-spiders-listen.md
+++ b/.changeset/strong-spiders-listen.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+add `init` API which is a replacement of `npm init` for creating a new modular folder in the current working directory.

--- a/.changeset/strong-spiders-listen.md
+++ b/.changeset/strong-spiders-listen.md
@@ -1,5 +1,0 @@
----
-'modular-scripts': minor
----
-
-add `init` API which is a replacement of `npm init` for creating a new modular folder in the current working directory.

--- a/.changeset/weak-spiders-listen.md
+++ b/.changeset/weak-spiders-listen.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+add `init` API which is a replacement of `npm init` for creating a new modular folder in the current working directory.

--- a/.changeset/weak-spiders-listen.md
+++ b/.changeset/weak-spiders-listen.md
@@ -2,4 +2,5 @@
 'modular-scripts': minor
 ---
 
-add `init` API which is a replacement of `npm init` for creating a new modular folder in the current working directory.
+add `init` API which is a replacement of `npm init` for creating a new modular
+folder in the current working directory.

--- a/packages/modular-scripts/src/__tests__/__snapshots__/init.test.tsx.snap
+++ b/packages/modular-scripts/src/__tests__/__snapshots__/init.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Creating a new modular folder should make a new repo with the right name and properties 1`] = `
+Object {
+  "author": "",
+  "description": "",
+  "keywords": Array [],
+  "license": "MIT",
+  "main": "index.js",
+  "modular": Object {
+    "type": "root",
+  },
+  "name": "test-modular-app",
+  "scripts": Object {
+    "test": "echo \\"Error: no test specified\\" && exit 1",
+  },
+  "version": "1.0.0",
+  "workspaces": Array [
+    "packages/**",
+  ],
+}
+`;

--- a/packages/modular-scripts/src/__tests__/init.test.tsx
+++ b/packages/modular-scripts/src/__tests__/init.test.tsx
@@ -1,0 +1,31 @@
+import { initModularFolder } from '../init';
+import * as path from 'path';
+import * as tmp from 'tmp';
+import * as fs from 'fs-extra';
+import { promisify } from 'util';
+import { ModularPackageJson } from '../utils/isModularType';
+
+const mktempd = promisify(tmp.dir);
+
+describe('Creating a new modular folder', () => {
+  let folder: string;
+  beforeEach(async () => {
+    folder = await mktempd();
+  });
+
+  afterEach(async () => {
+    await fs.remove(folder);
+  });
+
+  it('should make a new repo with the right name and properties', async () => {
+    await initModularFolder(folder, true);
+
+    const packageJson = (await fs.readJSON(
+      path.join(folder, 'package.json'),
+    )) as ModularPackageJson;
+
+    packageJson.name = 'test-modular-app';
+
+    expect(packageJson).toMatchSnapshot();
+  });
+});

--- a/packages/modular-scripts/src/__tests__/init.test.tsx
+++ b/packages/modular-scripts/src/__tests__/init.test.tsx
@@ -11,6 +11,7 @@ describe('Creating a new modular folder', () => {
   let folder: string;
   beforeEach(async () => {
     folder = await mktempd();
+    await initModularFolder(folder, true);
   });
 
   afterEach(async () => {
@@ -18,8 +19,6 @@ describe('Creating a new modular folder', () => {
   });
 
   it('should make a new repo with the right name and properties', async () => {
-    await initModularFolder(folder, true);
-
     const packageJson = (await fs.readJSON(
       path.join(folder, 'package.json'),
     )) as ModularPackageJson;
@@ -27,5 +26,15 @@ describe('Creating a new modular folder', () => {
     packageJson.name = 'test-modular-app';
 
     expect(packageJson).toMatchSnapshot();
+  });
+
+  it('should create a modular folder', async () => {
+    expect(fs.existsSync(path.join(folder, 'modular'))).toEqual(true);
+    expect(await fs.readdir(path.join(folder, 'modular'))).toEqual([]);
+  });
+
+  it('should create a packages folder', async () => {
+    expect(fs.existsSync(path.join(folder, 'packages'))).toEqual(true);
+    expect(await fs.readdir(path.join(folder, 'packages'))).toEqual([]);
   });
 });

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+
+import * as fs from 'fs-extra';
 import commander from 'commander';
 import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 
@@ -19,8 +21,11 @@ process.on('unhandledRejection', (err) => {
 
 const program = new commander.Command('modular');
 program.version(
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  (require('../package.json') as PackageJson).version as string,
+  (
+    fs.readJsonSync(
+      require.resolve('modular-scripts/package.json'),
+    ) as PackageJson
+  ).version as string,
 );
 
 program

--- a/packages/modular-scripts/src/init.ts
+++ b/packages/modular-scripts/src/init.ts
@@ -1,0 +1,49 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import execSync from './utils/execSync';
+import { ModularPackageJson } from './utils/isModularType';
+
+export async function initModularFolder(
+  folder: string,
+  initOverride: boolean,
+): Promise<void> {
+  const packageJsonPath = path.join(folder, 'package.json');
+
+  if (!fs.existsSync(packageJsonPath)) {
+    const args = ['init'];
+    if (initOverride) {
+      args.push('-y');
+    }
+    execSync('npm', args, {
+      cwd: folder,
+    });
+  }
+
+  const packageJson = (await fs.readJSON(
+    packageJsonPath,
+  )) as ModularPackageJson;
+
+  let changed = false;
+  if (!packageJson.modular) {
+    packageJson.modular = {
+      type: 'root',
+    };
+    changed = true;
+  }
+
+  if (!packageJson.workspaces) {
+    packageJson.workspaces = ['packages/**'];
+  }
+
+  if (changed) {
+    await fs.writeJSON(packageJsonPath, packageJson, {
+      spaces: 2,
+    });
+  }
+
+  console.log('Modular repository initialized!');
+}
+
+export default function init(initOverride = false): Promise<void> {
+  return initModularFolder(process.cwd(), initOverride);
+}

--- a/packages/modular-scripts/src/init.ts
+++ b/packages/modular-scripts/src/init.ts
@@ -41,6 +41,9 @@ export async function initModularFolder(
     });
   }
 
+  await fs.mkdirp(path.join(folder, 'modular'));
+  await fs.mkdirp(path.join(folder, 'packages'));
+
   console.log('Modular repository initialized!');
 }
 

--- a/packages/modular-scripts/src/utils/preflightCheck.ts
+++ b/packages/modular-scripts/src/utils/preflightCheck.ts
@@ -54,16 +54,21 @@ async function preflightCheck(): Promise<void> {
       );
     }
 
-    // ensure that workspaces are setup correctly with yarn
-    const workspace = await getWorkspaceInfo();
+    if (process.argv.slice(2)[0] !== 'init') {
+      // ensure that workspaces are setup correctly with yarn
+      // init is a special case where we don't already need to be in a modular repository
+      // in this case there's no use checking the workspaces yet because we're setting
+      // up a new folder
+      const workspace = await getWorkspaceInfo();
 
-    for (const [packageName, packageInfo] of Object.entries(workspace)) {
-      if (packageInfo.mismatchedWorkspaceDependencies.length) {
-        throw new Error(
-          `${packageName} has mismatchedWorkspaceDependencies ${packageInfo.mismatchedWorkspaceDependencies.join(
-            ', ',
-          )}`,
-        );
+      for (const [packageName, packageInfo] of Object.entries(workspace)) {
+        if (packageInfo.mismatchedWorkspaceDependencies.length) {
+          throw new Error(
+            `${packageName} has mismatchedWorkspaceDependencies ${packageInfo.mismatchedWorkspaceDependencies.join(
+              ', ',
+            )}`,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
`modular init` is a replacement for `npm init` or `yarn init` which creates a new modular root package in the current directory. This is useful if you wanted to create a new empty repository in a directory rather than scaffold an entire app as part of setup. 