### PR TITLE
Resolve bin relative to modular-scripts 

### DIFF
--- a/.changeset/rotten-dancers-retire.md
+++ b/.changeset/rotten-dancers-retire.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+---
+
+Fix issues where modular bin dependencies could not be found when running from
+global CLI

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -47,7 +47,6 @@
     "react-native-web": "^0.16.5",
     "react-scripts": "^4.0.3",
     "resolve": "^1.20.0",
-    "resolve-as-bin": "^2.1.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.52.0",
     "rollup-plugin-postcss": "^4.0.0",

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import resolveAsBin from 'resolve-as-bin';
 
 import { outputDirectory, packagesRoot, cracoConfig } from './config';
 import getModularRoot from './utils/getModularRoot';
 import isModularType from './utils/isModularType';
 import execSync from './utils/execSync';
+import { resolveAsBin } from './utils/resolve-as-bin';
 
 export default async function build(
   packagePath: string,
@@ -14,7 +14,7 @@ export default async function build(
   const modularRoot = getModularRoot();
 
   if (isModularType(path.join(modularRoot, packagesRoot, packagePath), 'app')) {
-    const cracoBin = resolveAsBin('craco');
+    const cracoBin = await resolveAsBin('@craco/craco');
 
     // create-react-app doesn't support plain module outputs yet,
     // so --preserve-modules has no effect here

--- a/packages/modular-scripts/src/start.ts
+++ b/packages/modular-scripts/src/start.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import resolveAsBin from 'resolve-as-bin';
+import { resolveAsBin } from './utils/resolve-as-bin';
 import getModularRoot from './utils/getModularRoot';
 import isModularType from './utils/isModularType';
 import execSync from './utils/execSync';
@@ -12,7 +12,8 @@ export default async function start(appPath: string): Promise<void> {
   if (!isModularType(path.join(modularRoot, packagesRoot, appPath), 'app')) {
     throw new Error(`The package at ${appPath} is not a valid modular app.`);
   }
-  const cracoBin = resolveAsBin('craco');
+
+  const cracoBin = await resolveAsBin('@craco/craco');
 
   execSync(cracoBin, ['start', '--config', cracoConfig], {
     cwd: path.join(modularRoot, packagesRoot, appPath),

--- a/packages/modular-scripts/src/test.ts
+++ b/packages/modular-scripts/src/test.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 import resolve from 'resolve';
-import resolveBin from 'resolve-as-bin';
 import execSync from './utils/execSync';
 import getModularRoot from './utils/getModularRoot';
+import { resolveAsBin } from './utils/resolve-as-bin';
 export interface TestOptions {
   bail: boolean;
   debug: boolean;
@@ -121,7 +121,7 @@ export default async function test(
   // finally add the script regexes to run
   cleanArgv.push(...cleanRegexes);
 
-  const jestBin = resolveBin('jest');
+  const jestBin = await resolveAsBin('jest-cli');
   let testBin = jestBin,
     testArgs = cleanArgv;
 

--- a/packages/modular-scripts/src/utils/resolve-as-bin.ts
+++ b/packages/modular-scripts/src/utils/resolve-as-bin.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { ModularPackageJson } from './isModularType';
+
+async function getBin(packageDir: string) {
+  const packageJson = (await fs.readJson(
+    path.join(packageDir, 'package.json'),
+  )) as ModularPackageJson;
+  if (!packageJson.bin) {
+    throw Error(`No bins found.`);
+  } else {
+    if (typeof packageJson.bin === 'string') {
+      return packageJson.bin;
+    } else {
+      const bins = Object.values(packageJson.bin);
+      return bins[0] as string;
+    }
+  }
+}
+
+export async function resolveAsBin(packageName: string): Promise<string> {
+  const packageDir = path.dirname(
+    require.resolve(`${packageName}/package.json`),
+  );
+  const bin = await getBin(packageDir);
+  return path.join(packageDir, bin);
+}


### PR DESCRIPTION
This prevents a edge case in resolve-as-bin which accounts for the fact that modular can be used a global bin - this prevents users from having a `yarn global add modular-scripts` and running modular commands.