### PR TITLE
Switch jsx transform to maintain esbuild compatibility

### DIFF
--- a/.changeset/dry-bottles-return.md
+++ b/.changeset/dry-bottles-return.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+---
+
+Switch to "jsx": "react" in tsconfig to maintain compatibility with
+esbuild-loader and React.

--- a/packages/modular-scripts/tsconfig.json
+++ b/packages/modular-scripts/tsconfig.json
@@ -15,7 +15,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "sourceMap": true
   }
 }


### PR DESCRIPTION
`esbuild` currently does not support the new `jsx` transform for React 17. This means that

1. `modular` itself is incompatible with apps which are not using React 17. 
2. `esbuild` and `modular-scripts` TypeScript setup will conflict on the transform. 

This PR corrects the differences to maintain compatibility between the two. 