### PR TITLE
Add required peer dependency for `eslint-config-modular-app`

### DIFF
--- a/.changeset/large-lobsters-hide.md
+++ b/.changeset/large-lobsters-hide.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-modular-app': patch
+---
+
+Add required dependency

--- a/packages/eslint-config-modular-app/package.json
+++ b/packages/eslint-config-modular-app/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.28.1",
+    "@typescript-eslint/parser": "^4.28.1",
     "babel-eslint": "^10.1.0",
     "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-flowtype": "^5.2.0",


### PR DESCRIPTION
Resolve yarn installation warning for missing peer dep. 