### PR TITLE
move all action APIs to become asyncronous in the cli for faster startup

### DIFF
--- a/.changeset/cuddly-beans-hug.md
+++ b/.changeset/cuddly-beans-hug.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Make action imports asyncronous in cli startup

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -5,10 +5,7 @@ import chalk from 'chalk';
 import commander from 'commander';
 import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 
-import buildPackages from './build';
-import addPackage from './addPackage';
-import start from './start';
-import test, { TestOptions } from './test';
+import type { TestOptions } from './test';
 
 import startupCheck from './utils/startupCheck';
 import actionPreflightCheck from './utils/actionPreflightCheck';
@@ -45,7 +42,7 @@ program
     true,
   )
   .action(
-    (
+    async (
       packageName: string,
       addOptions: {
         unstableType?: string;
@@ -53,6 +50,7 @@ program
         preferOffline?: boolean;
       },
     ) => {
+      const { default: addPackage } = await import('./addPackage');
       return addPackage(
         packageName,
         addOptions.unstableType,
@@ -75,6 +73,7 @@ program
         preserveModules?: boolean;
       },
     ) => {
+      const { default: buildPackages } = await import('./build');
       logger.log('building packages at:', packagePaths.join(', '));
 
       for (let i = 0; i < packagePaths.length; i++) {
@@ -139,9 +138,11 @@ program
   .option('--no-cache', testOptions.cache.description)
   .allowUnknownOption()
   .description('Run tests over the codebase')
-  .action((regexes: string[], options: CLITestOptions) => {
+  .action(async (regexes: string[], options: CLITestOptions) => {
+    const { default: test } = await import('./test');
+
+    // proxy simplified options to testOptions
     const { U, ...testOptions } = options;
-    // proxy simplified options to testOptions;
     testOptions.updateSnapshot = !!(options.updateSnapshot || U);
 
     return test(testOptions, regexes);
@@ -152,7 +153,8 @@ program
   .description(
     `Start a dev-server for an app. Only available for modular 'app' types.`,
   )
-  .action((packageName: string) => {
+  .action(async (packageName: string) => {
+    const { default: start } = await import('./start');
     return start(packageName);
   });
 

--- a/packages/modular-scripts/src/utils/actionPreflightCheck.ts
+++ b/packages/modular-scripts/src/utils/actionPreflightCheck.ts
@@ -5,9 +5,8 @@ type ModularAction = (...args: any[]) => Promise<void>;
 
 function actionPreflightCheck(fn: ModularAction): ModularAction {
   const wrappedFn: ModularAction = async (...args) => {
-    const { check } = await import('../check');
-
     if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
+      const { check } = await import('../check');
       await check();
     } else {
       logger.warn(


### PR DESCRIPTION
I've moved all the action APIs into the action handlers in the CLI - this reduces startup time by minimising the imports which are required for the CLI itself. This will become more important if we start scaling out the `start` and `build` commands to run things themselves. 