### PR TITLE
Add engine validation check into modular cli startup

### DIFF
--- a/.changeset/poor-knives-tie.md
+++ b/.changeset/poor-knives-tie.md
@@ -1,0 +1,7 @@
+---
+'create-modular-react-app': major
+'modular-scripts': major
+---
+
+Add engine startup check to CLIs to ensure that the version of node running is
+supported

--- a/packages/create-modular-react-app/package.json
+++ b/packages/create-modular-react-app/package.json
@@ -18,9 +18,11 @@
     "chalk": "^4.1.1",
     "commander": "^8.0.0",
     "execa": "^5.1.1",
-    "fs-extra": "^10.0.0"
+    "fs-extra": "^10.0.0",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
+    "@types/semver": "^7.3.6",
     "@schemastore/package": "^0.0.6",
     "@types/fs-extra": "^9.0.11",
     "@types/node": "*",

--- a/packages/create-modular-react-app/src/index.ts
+++ b/packages/create-modular-react-app/src/index.ts
@@ -1,7 +1,9 @@
+import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 import execa from 'execa';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import chalk from 'chalk';
+import * as semver from 'semver';
 
 function execSync(
   file: string,
@@ -34,6 +36,17 @@ export default function createModularApp(argv: {
   repo?: boolean;
   preferOffline?: boolean;
 }): Promise<void> {
+  const { engines } = fs.readJSONSync(
+    require.resolve('create-modular-react-app/package.json'),
+  ) as PackageJson;
+
+  const nodeEngines = engines?.node as string;
+  if (!semver.satisfies(process.version, nodeEngines)) {
+    throw new Error(
+      `${process.version} does not satisfy modular engine constraint ${nodeEngines}`,
+    );
+  }
+
   const preferOfflineArg = argv.preferOffline ? ['--prefer-offline'] : [];
   if (isYarnInstalled() === false) {
     console.error(


### PR DESCRIPTION
Since we have updated the dependencies of `modular-scripts` there have been reports of `yarn` installation issues for some modular commands in the dependency tree. This adds a startup check to make sure that the version of node running is supported up front. 