### PR TITLE
Fix modular workspace public prop

### DIFF
--- a/.changeset/dirty-buses-perform.md
+++ b/.changeset/dirty-buses-perform.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Fix modular workspace public prop

--- a/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
@@ -5,21 +5,21 @@ Object {
   "create-modular-react-app": Object {
     "location": "packages/create-modular-react-app",
     "mismatchedWorkspaceDependencies": Array [],
-    "public": false,
+    "public": true,
     "type": "package",
     "workspaceDependencies": Array [],
   },
   "eslint-config-modular-app": Object {
     "location": "packages/eslint-config-modular-app",
     "mismatchedWorkspaceDependencies": Array [],
-    "public": false,
+    "public": true,
     "type": "package",
     "workspaceDependencies": Array [],
   },
   "modular-scripts": Object {
     "location": "packages/modular-scripts",
     "mismatchedWorkspaceDependencies": Array [],
-    "public": false,
+    "public": true,
     "type": "package",
     "workspaceDependencies": Array [],
   },
@@ -33,7 +33,7 @@ Object {
   "modular-views.macro": Object {
     "location": "packages/modular-views.macro",
     "mismatchedWorkspaceDependencies": Array [],
-    "public": false,
+    "public": true,
     "type": "package",
     "workspaceDependencies": Array [],
   },

--- a/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
+++ b/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
@@ -28,10 +28,11 @@ export async function getWorkspaceInfo(): Promise<WorkspaceInfo> {
 
     const type = packageJson.modular?.type || ('package' as ModularType);
 
-    const modularPackageInfo = Object.assign(packageInfo, {
+    const modularPackageInfo = {
+      ...packageInfo,
       type,
-      public: !!packageJson.public,
-    });
+      public: !packageJson.private,
+    };
 
     res[packageName] = modularPackageInfo;
   }


### PR DESCRIPTION
`getWorkspaceInfo` returns a `public` prop for each workspace. It's currently set to always return false because it tries to use the packageJson's `public` prop, which isn't a real prop so it's always undefined. 

What it should do is read from the packageJson's `private` prop and set the inverse of that value as the `public` prop of the workspace. 