### PR TITLE
Write workspace info to stdout

### DIFF
--- a/.changeset/funny-parents-drive.md
+++ b/.changeset/funny-parents-drive.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Write result of modular workspace to stdout

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -167,7 +167,7 @@ program
         './utils/getWorkspaceInfo'
       );
       const workspace = await getWorkspaceInfo();
-      logger.log(JSON.stringify(workspace, null, 2));
+      process.stdout.write(JSON.stringify(workspace, null, 2));
     }),
   );
 


### PR DESCRIPTION
Instead of logging workspace info, it should write it to stdout so that it can be captured