### PR TITLE
Add validation for worktree structure

### DIFF
--- a/.changeset/silent-coats-try.md
+++ b/.changeset/silent-coats-try.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': major
+---
+
+Add validation of worktree stucture to prevent nested workspaces.

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -52,7 +52,7 @@
     "file-loader": "6.2.0",
     "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",
-    "glob": "^7.1.7",
+    "globby": "^11.0.4",
     "html-webpack-plugin": "4.5.2",
     "identity-obj-proxy": "3.0.0",
     "is-ci": "^2.0.0",

--- a/packages/modular-scripts/src/__tests__/init.test.tsx
+++ b/packages/modular-scripts/src/__tests__/init.test.tsx
@@ -45,8 +45,8 @@ describe('Creating a new modular folder', () => {
     expect(String(lockfile)).toMatchSnapshot();
   });
 
-  it('should not have any workspace info', () => {
-    const workspace = getYarnWorkspaceInfo(folder);
+  it('should not have any workspace info', async () => {
+    const workspace = await getYarnWorkspaceInfo(folder);
     expect(workspace).toEqual({});
   });
 });

--- a/packages/modular-scripts/src/buildPackage/getPackageEntryPoints.ts
+++ b/packages/modular-scripts/src/buildPackage/getPackageEntryPoints.ts
@@ -1,10 +1,11 @@
 import getPackageMetadata from './getPackageMetadata';
 
-export function getPackageEntryPoints(packagePath: string): {
+export async function getPackageEntryPoints(packagePath: string): Promise<{
   main: string;
   compilingBin: boolean;
-} {
-  const { packageJsonsByPackagePath } = getPackageMetadata();
+}> {
+  const { packageJsonsByPackagePath } = await getPackageMetadata();
+
   const packageJson = packageJsonsByPackagePath[packagePath];
 
   let compilingBin = false;

--- a/packages/modular-scripts/src/buildPackage/getPackageMetadata.ts
+++ b/packages/modular-scripts/src/buildPackage/getPackageMetadata.ts
@@ -16,7 +16,7 @@ function distinct<T>(arr: T[]): T[] {
   return [...new Set(arr)];
 }
 
-function getPackageMetadata() {
+async function getPackageMetadata() {
   const modularRoot = getModularRoot();
 
   // dependencies defined at the root
@@ -36,7 +36,8 @@ function getPackageMetadata() {
   const packageNames: string[] = [];
 
   // let's populate the above three
-  for (const [name, { location }] of Object.entries(getAllWorkspaces())) {
+  const workspace = await getAllWorkspaces();
+  for (const [name, { location }] of Object.entries(workspace)) {
     const pathToPackageJson = path.join(modularRoot, location, 'package.json');
     const packageJson = fse.readJsonSync(pathToPackageJson) as PackageJson;
 

--- a/packages/modular-scripts/src/buildPackage/index.ts
+++ b/packages/modular-scripts/src/buildPackage/index.ts
@@ -32,7 +32,7 @@ export async function buildPackage(
 ): Promise<void> {
   const modularRoot = getModularRoot();
   const packagePath = await getRelativeLocation(target);
-  const { publicPackageJsons } = getPackageMetadata();
+  const { publicPackageJsons } = await getPackageMetadata();
 
   if (process.cwd() !== modularRoot) {
     throw new Error(
@@ -50,9 +50,9 @@ export async function buildPackage(
   await rimraf(path.join(modularRoot, packagePath, `${outputDirectory}-types`));
 
   // Generate the typings for a package first so that we can do type checking and don't waste time bundling otherwise
-  const { compilingBin } = getPackageEntryPoints(packagePath);
+  const { compilingBin } = await getPackageEntryPoints(packagePath);
   if (!compilingBin) {
-    makeTypings(packagePath);
+    await makeTypings(packagePath);
   }
 
   // generate the js files now that we know we have a valid package

--- a/packages/modular-scripts/src/buildPackage/makeBundle.ts
+++ b/packages/modular-scripts/src/buildPackage/makeBundle.ts
@@ -30,7 +30,7 @@ export async function makeBundle(
   preserveModules: boolean,
 ): Promise<boolean> {
   const modularRoot = getModularRoot();
-  const metadata = getPackageMetadata();
+  const metadata = await getPackageMetadata();
   const {
     rootPackageJsonDependencies,
     packageJsons,
@@ -42,7 +42,7 @@ export async function makeBundle(
 
   const packageJson = packageJsonsByPackagePath[packagePath];
 
-  const { main, compilingBin } = getPackageEntryPoints(packagePath);
+  const { main, compilingBin } = await getPackageEntryPoints(packagePath);
 
   if (!packageJson) {
     throw new Error(`no package.json in ${packagePath}, bailing...`);

--- a/packages/modular-scripts/src/buildPackage/makeTypings.ts
+++ b/packages/modular-scripts/src/buildPackage/makeTypings.ts
@@ -9,9 +9,9 @@ import getPackageMetadata from './getPackageMetadata';
 const outputDirectory = 'dist';
 const typescriptConfigFilename = 'tsconfig.json';
 
-export function makeTypings(packagePath: string): void {
+export async function makeTypings(packagePath: string): Promise<void> {
   const logger = getLogger(packagePath);
-  const { typescriptConfig } = getPackageMetadata();
+  const { typescriptConfig } = await getPackageMetadata();
 
   logger.log('generating .d.ts files');
 

--- a/packages/modular-scripts/src/check.ts
+++ b/packages/modular-scripts/src/check.ts
@@ -1,29 +1,43 @@
+import globby from 'globby';
+import * as fs from 'fs-extra';
 import * as path from 'path';
-import getWorkspaceInfo, { WorkSpaceRecord } from './utils/getWorkspaceInfo';
+import getWorkspaceInfo from './utils/getWorkspaceInfo';
 import {
   getModularType,
   isValidModularType,
-  isValidModularRootPackageJson,
+  ModularPackageJson,
 } from './utils/isModularType';
 import * as logger from './utils/logger';
 import getModularRoot from './utils/getModularRoot';
 
 export async function check(): Promise<void> {
-  // ensure that workspaces are setup correctly with yarn§
+  const modularRoot = getModularRoot();
+
+  const rootPackageJsonPath = path.join(modularRoot, 'package.json');
+  const rootPackageJson = (await fs.readJSON(
+    rootPackageJsonPath,
+  )) as ModularPackageJson;
+  if (!rootPackageJson.private) {
+    throw new Error(`Modular workspace roots must be marked as private`);
+  }
+
+  if (!rootPackageJson?.workspaces?.includes('packages/**')) {
+    throw new Error(
+      `Modular workspaces must include "packages/**" to pick up any modular packages in the worktree`,
+    );
+  }
+
+  // ensure that workspaces are setup correctly with yarn
   // init is a special case where we don't already need to be in a modular repository
   // in this case there's no use checking the workspaces yet because we're setting
   // up a new folder
   const workspace = await getWorkspaceInfo();
-  const modularRoot = getModularRoot();
 
-  if (!isValidModularRootPackageJson(modularRoot)) {
-    throw new Error(
-      'Your root package.json file has a missing modular type, workspaces, or is not marked private',
-    );
-  }
-  for (const [packageName, _packageInfo] of Object.entries(workspace)) {
-    const packageInfo = _packageInfo as WorkSpaceRecord;
-
+  /**
+   * Validate the structure of the workspace to ensure there's no mismatched dependencies and that
+   * all the workspaces are valid modular package types.
+   */
+  for (const [packageName, packageInfo] of Object.entries(workspace)) {
     if (packageInfo.mismatchedWorkspaceDependencies.length) {
       throw new Error(
         `${packageName} has mismatchedWorkspaceDependencies ${packageInfo.mismatchedWorkspaceDependencies.join(
@@ -59,8 +73,40 @@ export async function check(): Promise<void> {
     logger.debug(`${packageName} is valid.`);
   }
 
-  if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
-    const { verifyPackageTree } = await import('./utils/verifyPackageTree');
-    await verifyPackageTree();
-  }
+  /**
+   * Validate the the worktrree is valid against the globby of pacakge.json files which are found in the
+   * current working directory. They should be the same but you never know...
+   */
+  const workspaces = Object.values(workspace).map((w) => w.location);
+
+  const workspaceLocations: string[] = (
+    await globby(['packages/**/package.json', '!**/node_modules/**'], {
+      onlyFiles: true,
+      cwd: modularRoot,
+    })
+  ).map((l) => path.dirname(l));
+
+  workspaces.forEach((l) => {
+    const overlapping = workspaceLocations.filter((workspaceLocation) => {
+      // obviously workspaces which are the same can't be overlapping
+      if (workspaceLocation === l) {
+        return false;
+      } else {
+        return workspaceLocation.startsWith(l);
+      }
+    });
+    if (overlapping.length) {
+      throw new Error(
+        `Found ${l} which is an overlapping workspace with ${overlapping.join(
+          ', ',
+        )} in your current worktree`,
+      );
+    }
+  });
+
+  /**
+   * Taken from react-scripts - this assets that we share common versions of utils which we depend on.
+   */
+  const { verifyPackageTree } = await import('./utils/verifyPackageTree');
+  await verifyPackageTree();
 }

--- a/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
+++ b/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
@@ -14,10 +14,10 @@ export interface WorkSpaceRecord {
   public: boolean;
 }
 
-type WorkspaceInfo = Record<string, WorkSpaceRecord | undefined>;
+type WorkspaceInfo = Record<string, WorkSpaceRecord>;
 
 export async function getWorkspaceInfo(): Promise<WorkspaceInfo> {
-  const workspace = getAllWorkspaces();
+  const workspace = await getAllWorkspaces();
   const workspaceRoot = getModularRoot();
 
   const res: WorkspaceInfo = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6966,7 +6966,7 @@ glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -7025,7 +7025,7 @@ globby@11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.0, globby@^11.0.3:
+globby@^11.0.0, globby@^11.0.3, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==


### PR DESCRIPTION
Additional validation of worktree structure to enforce packages are not nested within the `yarn` worktree to prevent confusion when building and packing libraries. 