### PR TITLE
Bugfix for overlapping directory names

### DIFF
--- a/.changeset/hip-socks-type.md
+++ b/.changeset/hip-socks-type.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Fix `modular check` to support directories which start with the same names

--- a/packages/modular-scripts/src/check.ts
+++ b/packages/modular-scripts/src/check.ts
@@ -93,18 +93,17 @@ export async function check(): Promise<void> {
     })
   ).map((l) => path.dirname(l));
 
-  workspaces.forEach((l) => {
-    const overlapping = workspaceLocations.filter((workspaceLocation) => {
+  workspaces.forEach((workspaceLocation) => {
+    const overlapping = workspaceLocations.filter((otherWorkspaceLocation) => {
       // obviously workspaces which are the same can't be overlapping
-      if (workspaceLocation === l) {
-        return false;
-      } else {
-        return workspaceLocation.startsWith(l);
-      }
+      const relative = path.relative(workspaceLocation, otherWorkspaceLocation);
+      return (
+        relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+      );
     });
     if (overlapping.length) {
       logger.error(
-        `Found ${l} which is an overlapping workspace with ${overlapping.join(
+        `Found ${workspaceLocation} which is an overlapping workspace with ${overlapping.join(
           ', ',
         )} in your current worktree`,
       );


### PR DESCRIPTION
Found a bug where adding multiple packages in the same directory which start with the same name causes an invalid `modular check` failure. 

e.g. 

```
packages/
├─ theme
└─ theme-new
```