### PR TITLE
Fix failing tests due to upgrades

### DIFF
--- a/packages/create-modular-react-app/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/packages/create-modular-react-app/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -34,7 +34,7 @@ exports[`Creating a new modular app via the CLI should create the right tree 1`]
 │     │  ├─ index.css #o7sk21
 │     │  ├─ index.tsx #zdn6mw
 │     │  ├─ logo.svg #1okqmlj
-│     │  └─ react-app-env.d.ts #1dm2mq6
+│     │  └─ react-app-env.d.ts #t4ygcy
 │     └─ tsconfig.json #6rw46b
 ├─ tsconfig.json #1h72lkd
 └─ yarn.lock"

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -90,7 +90,7 @@ describe('create-modular-react-app', () => {
       │     │  ├─ index.css #o7sk21
       │     │  ├─ index.tsx #zdn6mw
       │     │  ├─ logo.svg #1okqmlj
-      │     │  └─ react-app-env.d.ts #1dm2mq6
+      │     │  └─ react-app-env.d.ts #t4ygcy
       │     └─ tsconfig.json #6rw46b
       ├─ tsconfig.json #1h72lkd
       └─ yarn.lock"
@@ -211,7 +211,7 @@ describe('create-modular-react-app', () => {
       │     │  ├─ index.css #o7sk21
       │     │  ├─ index.tsx #zdn6mw
       │     │  ├─ logo.svg #1okqmlj
-      │     │  └─ react-app-env.d.ts #1dm2mq6
+      │     │  └─ react-app-env.d.ts #t4ygcy
       │     └─ tsconfig.json #6rw46b
       ├─ tsconfig.json #1h72lkd
       └─ yarn.lock"


### PR DESCRIPTION
Due to the nature of the CRMA tests it installs the `latest` release of `modular-scripts`. This causes a lag between releases and changes to itself on the snapshots. 