### PR TITLE
Enable puppeteer tests to CI

### DIFF
--- a/.changeset/tricky-seals-stare.md
+++ b/.changeset/tricky-seals-stare.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Close dev-server when running `start` in CI.

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ packages/nested
 # created by tests in modular-views.macro
 packages/view-1
 packages/view-2
+packages/scoped
 
 
 # Build output

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "@types/jest": "^26.0.24",
     "@types/node": "*",
     "@types/prompts": "^2.0.14",
-    "@types/puppeteer": "^5.4.4",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",
     "@types/rimraf": "^3.0.1",
+    "@types/puppeteer": "^5.4.4",
     "@types/tar": "^4.0.5",
     "@types/update-notifier": "^5.0.1",
     "commander": "^8.0.0",
@@ -53,15 +53,13 @@
     "lint-staged": "^11.0.1",
     "micromatch": "^4.0.4",
     "pptr-testing-library": "^0.6.5",
+    "puppeteer": "^10.1.0",
     "prettier": "^2.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "semver": "^7.3.5",
     "ts-node": "^10.1.0",
     "typescript": "^4.3.5"
-  },
-  "optionalDependencies": {
-    "puppeteer": "^10.1.0"
   },
   "modular": {
     "type": "root"

--- a/packages/modular-scripts/react-scripts/scripts/start.js
+++ b/packages/modular-scripts/react-scripts/scripts/start.js
@@ -149,13 +149,11 @@ checkBrowsers(paths.appPath, isInteractive)
       });
     });
 
-    if (process.env.CI !== 'true') {
-      // Gracefully exit when stdin ends
-      process.stdin.on('end', function () {
-        devServer.close();
-        process.exit();
-      });
-    }
+    // Gracefully exit when stdin ends
+    process.stdin.on('end', function () {
+      devServer.close();
+      process.exit();
+    });
   })
   .catch((err) => {
     if (err && err.message) {

--- a/packages/modular-scripts/src/__tests__/app.test.ts
+++ b/packages/modular-scripts/src/__tests__/app.test.ts
@@ -11,6 +11,7 @@ import {
   queries,
 } from 'pptr-testing-library';
 import getModularRoot from '../utils/getModularRoot';
+import puppeteer from 'puppeteer';
 
 import { startApp, DevServer } from './start-app';
 
@@ -23,8 +24,6 @@ const modularRoot = getModularRoot();
 jest.setTimeout(10 * 60 * 1000);
 
 const packagesPath = path.join(getModularRoot(), 'packages');
-
-const skipIfCI = process.env.CI ? it.skip : it;
 
 function modular(str: string, opts: Record<string, unknown> = {}) {
   return execa('yarnpkg', ['modular', ...str.split(' ')], {
@@ -180,30 +179,7 @@ describe('when working with an app', () => {
     );
   });
 
-  skipIfCI('can start an app', async () => {
-    // Ok, so. Sunil's decided to get the new M1 MacBook Air. Some software doesn't run on it
-    // well yet. Particularly the puppeteer npm package failes to install and run
-    // (see https://github.com/puppeteer/puppeteer/issues/, issues #6634 and #6641,
-    // possible fix in pull #6495)
-
-    // Because of this, he's marked puppeteer in optionalDependencies, so it's failure to install
-    // doesn't block everything else. Further, because this particular test is already flaky,
-    // it's disabled when running locally. However, because it fails to install, it causes
-    // typescript and eslint failures. Hence the need to disable those errors for now.
-
-    // It's Sunil's responsibility to fix this when better, so shout at him if he doesn't.
-
-    /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
-
-    // This seems to be leaving hanging processes locally,
-    // so marking this test as a no-op for now. Sigh.
-    if (!process.env.CI) {
-      return;
-    }
-
-    const puppeteer = require('puppeteer');
-
-    // @ts-expect-error FIXME
+  it('can start an app', async () => {
     let browser: puppeteer.Browser | undefined;
     let devServer: DevServer | undefined;
     let port: string;
@@ -231,10 +207,9 @@ describe('when working with an app', () => {
 
       await findByTestId('test-this');
 
-      // eslint-disable-next-line testing-library/no-await-sync-query, jest/no-standalone-expect
-      expect(await getNodeText(await getByTestId('test-this'))).toBe(
-        'this is a modular app',
-      );
+      const element = getByTestId('test-this');
+
+      expect(await getNodeText(await element)).toBe('this is a modular app');
     } finally {
       if (browser) {
         await browser.close();
@@ -258,6 +233,5 @@ describe('when working with an app', () => {
         },
       );
     }
-    /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
   });
 });

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -12,11 +12,7 @@ import {
 } from 'pptr-testing-library';
 import getModularRoot from '../utils/getModularRoot';
 import { startApp, DevServer } from './start-app';
-import type {
-  Browser,
-  LaunchOptions,
-  BrowserLaunchArgumentOptions,
-} from 'puppeteer';
+import puppeteer from 'puppeteer';
 
 const rimraf = promisify(_rimraf);
 
@@ -125,25 +121,19 @@ describe('modular-scripts', () => {
     });
   });
 
-  const describeSkipIf: typeof describe = process.env.CI
-    ? describe.skip
-    : describe;
-
-  describeSkipIf('WHEN starting a view', () => {
-    let browser: Browser;
+  describe('WHEN starting a view', () => {
+    let browser: puppeteer.Browser;
     let devServer: DevServer;
     let port: string;
 
     beforeAll(async () => {
-      const launchArgs: LaunchOptions & BrowserLaunchArgumentOptions = {
+      const launchArgs: puppeteer.LaunchOptions &
+        puppeteer.BrowserLaunchArgumentOptions = {
         // always run in headless - if you want to debug this locally use the env var to
         headless: !Boolean(process.env.NO_HEADLESS_TESTS),
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,  @typescript-eslint/no-var-requires
-      const puppeteer = require('puppeteer');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       browser = await puppeteer.launch(launchArgs);
       port = '4000';
       devServer = await startApp(targetedView, { env: { PORT: port } });

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import * as fs from 'fs-extra';
+import * as isCi from 'is-ci';
 import chalk from 'chalk';
 import commander from 'commander';
 import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
@@ -126,12 +127,8 @@ program
   .option('--updateSnapshot, -u', testOptions.updateSnapshot.description)
   .option('--verbose', testOptions.verbose.description)
   .option('--watch', testOptions.watch.description)
-  .option(
-    '--watchAll [value]',
-    testOptions.watchAll.description,
-    !process.env.CI,
-  )
-  .option('--bail [value]', testOptions.bail.description, process.env.CI)
+  .option('--watchAll [value]', testOptions.watchAll.description, !isCi)
+  .option('--bail [value]', testOptions.bail.description, isCi)
   .option('--clearCache', testOptions.clearCache.description)
   .option('--logHeapUsage', testOptions.logHeapUsage.description)
   .option('--no-cache', testOptions.cache.description)


### PR DESCRIPTION
Start running puppeteer tests during CI on GH actions to validate local dev server behaviour and interaction with Chrome. 