### PR TITLE
#603  Default to `preserve-modules` when building packages

### DIFF
--- a/.changeset/cool-coats-sleep.md
+++ b/.changeset/cool-coats-sleep.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': minor
+---
+
+Default `--preserve-modules` to `true` when building packages to enable `export`
+field in `package.json` files.

--- a/.changeset/many-lions-attend.md
+++ b/.changeset/many-lions-attend.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+---
+
+Fix bug where typings were generated relative to the package directory and not
+the `src` directory.

--- a/.changeset/sweet-waves-relate.md
+++ b/.changeset/sweet-waves-relate.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': minor
+---
+
+Add `--private` argument for building packages marked `private: true` in their
+`package.json`

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+yarn format
 yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "type": "root"
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": "eslint --cache --ext .js,.ts,.tsx --max-warnings 0",
-    "*.{js,json,ts,tsx,css,md,mdx}": "prettier --write"
+    "*.{js,ts,tsx}": "eslint --cache --ext .js,.ts,.tsx --max-warnings 0"
   },
   "resolutions": {
     "rollup": "^2.38.3",

--- a/packages/modular-scripts/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/__snapshots__/index.test.ts.snap
@@ -34,13 +34,13 @@ function SampleView() {
 }
 
 module.exports = SampleView;
-//# sourceMappingURL=sample-view.cjs.js.map
+//# sourceMappingURL=index.js.map
 "
 `;
 
 exports[`modular-scripts WHEN building a view THEN outputs the correct output cjs map file 1`] = `
 Object {
-  "file": "sample-view.cjs.js",
+  "file": "index.js",
   "mappings": ";;;;;;;;;;;;;;;;;;;;;;;;;;AAEe,SAASA,UAAT,GAAmC;AAChD,sBAAOC;AAAK,mBAAY;AAAjB,8BAAP;AACD;;;;",
   "names": Array [
     "SampleView",

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -13,6 +13,7 @@ import {
 import getModularRoot from '../utils/getModularRoot';
 import { startApp, DevServer } from './start-app';
 import puppeteer from 'puppeteer';
+import { ModularPackageJson } from '../utils/isModularType';
 
 const rimraf = promisify(_rimraf);
 
@@ -210,7 +211,7 @@ describe('modular-scripts', () => {
           },
           "module": "dist-es/index.js",
           "name": "sample-view",
-          "typings": "dist-types/src/index.d.ts",
+          "typings": "dist-types/index.d.ts",
           "version": "1.0.0",
         }
       `);
@@ -321,7 +322,7 @@ describe('modular-scripts', () => {
           "main": "dist-cjs/index.js",
           "module": "dist-es/index.js",
           "name": "sample-package",
-          "typings": "dist-types/src/index.d.ts",
+          "typings": "dist-types/index.d.ts",
           "version": "1.0.0",
         }
       `);
@@ -343,6 +344,21 @@ describe('modular-scripts', () => {
         └─ package.json"
       `);
     });
+
+    it.each(['main', 'module', 'typings'])(
+      'THEN validates the typings file exists: %s',
+      async (key: keyof ModularPackageJson) => {
+        const packageJson = (await fs.readJSON(
+          path.join(modularRoot, 'dist', 'sample-package', 'package.json'),
+        )) as ModularPackageJson;
+        const value = packageJson[key] as string;
+        expect(
+          fs
+            .statSync(path.join(modularRoot, 'dist', 'sample-package', value))
+            .isFile(),
+        ).toEqual(true);
+      },
+    );
   });
 
   describe('WHEN building without preserve modules', () => {
@@ -376,7 +392,7 @@ describe('modular-scripts', () => {
           "main": "dist-cjs/nested-sample-package.cjs.js",
           "module": "dist-es/nested-sample-package.es.js",
           "name": "@nested/sample-package",
-          "typings": "dist-types/src/index.d.ts",
+          "typings": "dist-types/index.d.ts",
           "version": "1.0.0",
         }
       `);
@@ -398,5 +414,27 @@ describe('modular-scripts', () => {
         └─ package.json"
       `);
     });
+
+    it.each(['main', 'module', 'typings'])(
+      'THEN validates the typings file exists: %s',
+      async (key: keyof ModularPackageJson) => {
+        const packageJson = (await fs.readJSON(
+          path.join(
+            modularRoot,
+            'dist',
+            'nested-sample-package',
+            'package.json',
+          ),
+        )) as ModularPackageJson;
+        const value = packageJson[key] as string;
+        expect(
+          fs
+            .statSync(
+              path.join(modularRoot, 'dist', 'nested-sample-package', value),
+            )
+            .isFile(),
+        ).toEqual(true);
+      },
+    );
   });
 });

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -204,11 +204,11 @@ describe('modular-scripts', () => {
             "README.md",
           ],
           "license": "UNLICENSED",
-          "main": "dist-cjs/sample-view.cjs.js",
+          "main": "dist-cjs/index.js",
           "modular": Object {
             "type": "view",
           },
-          "module": "dist-es/sample-view.es.js",
+          "module": "dist-es/index.js",
           "name": "sample-view",
           "typings": "dist-types/src/index.d.ts",
           "version": "1.0.0",
@@ -225,7 +225,7 @@ describe('modular-scripts', () => {
               'dist',
               'sample-view',
               'dist-cjs',
-              'sample-view.cjs.js',
+              'index.js',
             ),
           ),
         ),
@@ -240,7 +240,7 @@ describe('modular-scripts', () => {
             'dist',
             'sample-view',
             'dist-cjs',
-            'sample-view.cjs.js.map',
+            'index.js.map',
           ),
         ),
       ).toMatchSnapshot();
@@ -252,14 +252,13 @@ describe('modular-scripts', () => {
         "sample-view
         ├─ README.md #11adaka
         ├─ dist-cjs
-        │  ├─ sample-view.cjs.js #10vycz1
-        │  └─ sample-view.cjs.js.map #15ks78h
+        │  ├─ index.js #l140cq
+        │  └─ index.js.map #b9qv26
         ├─ dist-es
-        │  ├─ sample-view.es.js #1rtqi2k
-        │  └─ sample-view.es.js.map #1sky7si
+        │  ├─ index.js #ru9c3p
+        │  └─ index.js.map #171l8pf
         ├─ dist-types
-        │  └─ src
-        │     └─ index.d.ts #1vloh7q
+        │  └─ index.d.ts #1vloh7q
         └─ package.json"
       `);
     });
@@ -340,8 +339,7 @@ describe('modular-scripts', () => {
         │  ├─ index.js #1gjntzw
         │  └─ index.js.map #b17359
         ├─ dist-types
-        │  └─ src
-        │     └─ index.d.ts #f68aj
+        │  └─ index.d.ts #f68aj
         └─ package.json"
       `);
     });
@@ -350,7 +348,7 @@ describe('modular-scripts', () => {
   describe('WHEN building without preserve modules', () => {
     beforeAll(async () => {
       // build the nested package
-      await modular('build @nested/sample-package', {
+      await modular('build @nested/sample-package --preserve-modules false', {
         stdio: 'inherit',
       });
     });
@@ -396,8 +394,7 @@ describe('modular-scripts', () => {
         │  ├─ nested-sample-package.es.js #40jnpo
         │  └─ nested-sample-package.es.js.map #11g8lh9
         ├─ dist-types
-        │  └─ src
-        │     └─ index.d.ts #f68aj
+        │  └─ index.d.ts #f68aj
         └─ package.json"
       `);
     });

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -9,7 +9,11 @@ import isModularType from './utils/isModularType';
 import execSync from './utils/execSync';
 import getLocation from './utils/getLocation';
 
-async function build(target: string, preserveModules?: boolean): Promise<void> {
+async function build(
+  target: string,
+  preserveModules = true,
+  includePrivate = false,
+): Promise<void> {
   const modularRoot = getModularRoot();
   const targetPath = await getLocation(target);
 
@@ -39,7 +43,7 @@ async function build(target: string, preserveModules?: boolean): Promise<void> {
     const { buildPackage } = await import('./buildPackage');
     // ^ we do a dynamic import here to defer the module's initial side effects
     // till when it's actually needed (i.e. now)
-    await buildPackage(target, preserveModules);
+    await buildPackage(target, preserveModules, includePrivate);
   }
 }
 

--- a/packages/modular-scripts/src/build.ts
+++ b/packages/modular-scripts/src/build.ts
@@ -17,16 +17,15 @@ async function build(
   const modularRoot = getModularRoot();
   const targetPath = await getLocation(target);
 
+  const targetName = toParamCase(target);
+
   if (isModularType(targetPath, 'app')) {
+    // create-react-app doesn't support plain module outputs yet,
+    // so --preserve-modules has no effect here
+
     const buildScript = require.resolve(
       'modular-scripts/react-scripts/scripts/build.js',
     );
-
-    const targetName = toParamCase(target);
-
-    // create-react-app doesn't support plain module outputs yet,
-    // so --preserve-modules has no effect here
-    await fs.remove(path.join(outputDirectory, targetName));
 
     // TODO: this shouldn't be sync
     execSync('node', [buildScript], {
@@ -40,6 +39,8 @@ async function build(
       },
     });
   } else {
+    await fs.emptyDir(path.join(outputDirectory, targetName));
+
     const { buildPackage } = await import('./buildPackage');
     // ^ we do a dynamic import here to defer the module's initial side effects
     // till when it's actually needed (i.e. now)

--- a/packages/modular-scripts/src/buildPackage/index.ts
+++ b/packages/modular-scripts/src/buildPackage/index.ts
@@ -28,7 +28,8 @@ const rimraf = promisify(_rimraf);
 
 export async function buildPackage(
   target: string,
-  preserveModules = false,
+  preserveModules = true,
+  includePrivate = false,
 ): Promise<void> {
   const modularRoot = getModularRoot();
   const packagePath = await getRelativeLocation(target);
@@ -56,7 +57,11 @@ export async function buildPackage(
   }
 
   // generate the js files now that we know we have a valid package
-  const didBundle = await makeBundle(packagePath, preserveModules);
+  const didBundle = await makeBundle(
+    packagePath,
+    preserveModules,
+    includePrivate,
+  );
   if (!didBundle) {
     return;
   }

--- a/packages/modular-scripts/src/buildPackage/index.ts
+++ b/packages/modular-scripts/src/buildPackage/index.ts
@@ -51,7 +51,10 @@ export async function buildPackage(
   await rimraf(path.join(modularRoot, packagePath, `${outputDirectory}-types`));
 
   // Generate the typings for a package first so that we can do type checking and don't waste time bundling otherwise
-  const { compilingBin } = await getPackageEntryPoints(packagePath);
+  const { compilingBin } = await getPackageEntryPoints(
+    packagePath,
+    includePrivate,
+  );
   if (!compilingBin) {
     await makeTypings(packagePath);
   }

--- a/packages/modular-scripts/src/buildPackage/makeBundle.ts
+++ b/packages/modular-scripts/src/buildPackage/makeBundle.ts
@@ -28,6 +28,7 @@ function distinct<T>(arr: T[]): T[] {
 export async function makeBundle(
   packagePath: string,
   preserveModules: boolean,
+  includePrivate: boolean,
 ): Promise<boolean> {
   const modularRoot = getModularRoot();
   const metadata = await getPackageMetadata();
@@ -47,7 +48,7 @@ export async function makeBundle(
   if (!packageJson) {
     throw new Error(`no package.json in ${packagePath}, bailing...`);
   }
-  if (packageJson.private === true) {
+  if (!includePrivate && packageJson.private === true) {
     throw new Error(`${packagePath} is marked private, bailing...`);
   }
 

--- a/packages/modular-scripts/src/buildPackage/makeBundle.ts
+++ b/packages/modular-scripts/src/buildPackage/makeBundle.ts
@@ -1,6 +1,5 @@
 import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 import { paramCase as toParamCase } from 'change-case';
-import * as fse from 'fs-extra';
 import * as path from 'path';
 import builtinModules from 'builtin-modules';
 import chalk from 'chalk';
@@ -43,45 +42,13 @@ export async function makeBundle(
 
   const packageJson = packageJsonsByPackagePath[packagePath];
 
-  const { main, compilingBin } = await getPackageEntryPoints(packagePath);
+  const { main, compilingBin } = await getPackageEntryPoints(
+    packagePath,
+    includePrivate,
+  );
 
-  if (!packageJson) {
-    throw new Error(`no package.json in ${packagePath}, bailing...`);
-  }
-  if (!includePrivate && packageJson.private === true) {
-    throw new Error(`${packagePath} is marked private, bailing...`);
-  }
-
-  if (!fse.existsSync(path.join(modularRoot, packagePath, main))) {
-    throw new Error(
-      `package.json at ${packagePath} does not have a main file that points to an existing source file, bailing...`,
-    );
-  }
-
-  if (!packageJson.name) {
-    throw new Error(
-      `package.json at ${packagePath} does not have a valid "name", bailing...`,
-    );
-  }
-
-  if (!packageJson.version) {
-    throw new Error(
-      `package.json at ${packagePath} does not have a valid "version", bailing...`,
-    );
-  }
-
-  if (packageJson.module) {
-    throw new Error(
-      `package.json at ${packagePath} shouldn't have a "module" field, bailing...`,
-    );
-  }
-
-  if (packageJson.typings) {
-    throw new Error(
-      `package.json at ${packagePath} shouldn't have a "typings" field, bailing...`,
-    );
-  }
-  logger.log(`building ${packageJson.name} at ${packagePath}...`);
+  const packageJsonName = packageJson.name as string;
+  logger.log(`building ${packageJsonName} at ${packagePath}...`);
 
   const bundle = await rollup.rollup({
     input: path.join(modularRoot, packagePath, main),
@@ -274,7 +241,7 @@ export async function makeBundle(
             modularRoot,
             packagePath,
             `${outputDirectory}-cjs`,
-            toParamCase(packageJson.name) + '.cjs.js',
+            toParamCase(packageJsonName) + '.cjs.js',
           ),
         }),
     format: 'cjs',
@@ -294,7 +261,7 @@ export async function makeBundle(
               modularRoot,
               packagePath,
               `${outputDirectory}-es`,
-              toParamCase(packageJson.name) + '.es.js',
+              toParamCase(packageJsonName) + '.es.js',
             ),
           }),
       format: 'es',
@@ -324,7 +291,7 @@ export async function makeBundle(
               .replace(/\.tsx?$/, '.js')
               .replace(path.dirname(main) + '/', ''),
           )
-        : `${outputDirectory}-cjs/${toParamCase(packageJson.name) + '.cjs.js'}`,
+        : `${outputDirectory}-cjs/${toParamCase(packageJsonName) + '.cjs.js'}`,
       module: preserveModules
         ? path.join(
             `${outputDirectory}-es`,
@@ -332,16 +299,16 @@ export async function makeBundle(
               .replace(/\.tsx?$/, '.js')
               .replace(path.dirname(main) + '/', ''),
           )
-        : `${outputDirectory}-es/${toParamCase(packageJson.name) + '.es.js'}`,
+        : `${outputDirectory}-es/${toParamCase(packageJsonName) + '.es.js'}`,
       typings: path.join(
         `${outputDirectory}-types`,
-        main.replace(/\.tsx?$/, '.d.ts'),
+        path.relative('src', main).replace(/\.tsx?$/, '.d.ts'),
       ),
     };
   }
 
   // store the public facing package.json that we'll write to disk later
-  publicPackageJsons[packageJson.name] = {
+  publicPackageJsons[packageJsonName] = {
     ...packageJson,
     ...outputFilesPackageJson,
     dependencies: {
@@ -357,6 +324,6 @@ export async function makeBundle(
     ]),
   };
 
-  logger.log(`built ${packageJson.name} at ${packagePath}`);
+  logger.log(`built ${packageJsonName} at ${packagePath}`);
   return true;
 }

--- a/packages/modular-scripts/src/buildPackage/makeTypings.ts
+++ b/packages/modular-scripts/src/buildPackage/makeTypings.ts
@@ -30,7 +30,7 @@ export async function makeTypings(packagePath: string): Promise<void> {
   tsconfig.compilerOptions = {
     ...tsconfig.compilerOptions,
     declarationDir: `${packagePath}/${outputDirectory}-types`,
-    rootDir: packagePath,
+    rootDir: `${packagePath}/src`,
   };
 
   // Extract config information

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -65,12 +65,18 @@ program
   .description(
     'Build a list of packages (multiple package names can be supplied separated by space)',
   )
-  .option('--preserve-modules')
+  .option(
+    '--preserve-modules [value]',
+    'Preserve module structure in generated modules',
+    'true',
+  )
+  .option('--private', 'Enable the building of private packages', false)
   .action(
     async (
       packagePaths: string[],
       options: {
-        preserveModules?: boolean;
+        preserveModules: string;
+        private: boolean;
       },
     ) => {
       const { default: build } = await import('./build');
@@ -78,7 +84,11 @@ program
 
       for (let i = 0; i < packagePaths.length; i++) {
         try {
-          await build(packagePaths[i], options['preserveModules']);
+          await build(
+            packagePaths[i],
+            JSON.parse(options.preserveModules) as boolean,
+            options.private,
+          );
         } catch (err) {
           logger.error(`building ${packagePaths[i]} failed`);
           throw err;


### PR DESCRIPTION
- Default `--preserve-modules` to `true` when building packages to enable `export`

field in `package.json` files.

- Fix bug where typings were generated relative to the package directory and not
the `src` directory.

- Add `--private` argument for building packages marked `private: true` in their
`package.json`