### PR TITLE
Remove `bin` discovery for selecting entry files to build.

### DIFF
--- a/.changeset/gentle-islands-work.md
+++ b/.changeset/gentle-islands-work.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': major
+---
+
+Remove compiling binaries from "bin" field in package.json.

--- a/packages/modular-scripts/src/__tests__/buildPackage/getPackageEntryPoints.test.ts
+++ b/packages/modular-scripts/src/__tests__/buildPackage/getPackageEntryPoints.test.ts
@@ -1,0 +1,110 @@
+import { getMain } from '../../build/buildPackage/getPackageEntryPoints';
+
+jest.mock('../../utils/getModularRoot', () => {
+  return {
+    __esModule: true,
+    default() {
+      return __dirname;
+    },
+  };
+});
+
+jest.mock('fs-extra', () => {
+  return {
+    __esModule: true,
+    existsSync() {
+      return true;
+    },
+  };
+});
+
+const packagePath = 'modular-scripts';
+
+describe('WHEN given a package.json which doesnt exist', () => {
+  it('SHOULD give an error', () => {
+    expect(() => getMain(packagePath, true, undefined)).toThrow(
+      `no package.json in ${packagePath}, bailing...`,
+    );
+  });
+});
+
+describe('WHEN given a package.json which is private', () => {
+  it('SHOULD give the main if includePrivate is true', () => {
+    expect(
+      getMain(packagePath, true, {
+        private: true,
+        main: 'src/index.ts',
+        name: packagePath,
+        version: '1.0.0',
+      }),
+    ).toEqual('src/index.ts');
+  });
+
+  it('SHOULD give an error if the includePrivate flag is false', () => {
+    expect(() =>
+      getMain(packagePath, false, {
+        private: true,
+        main: 'src/index.ts',
+        name: packagePath,
+        version: '1.0.0',
+      }),
+    ).toThrow(`${packagePath} is marked private, bailing...`);
+  });
+});
+
+describe('WHEN given a package.json without a name', () => {
+  it('SHOULD give an error', () => {
+    expect(() => getMain(packagePath, true, {})).toThrow(
+      `package.json does not have a valid "name", bailing...`,
+    );
+  });
+});
+
+describe('WHEN given a package.json without a version', () => {
+  it('SHOULD give an error', () => {
+    expect(() =>
+      getMain(packagePath, true, {
+        name: packagePath,
+      }),
+    ).toThrow(`package.json does not have a valid "version", bailing...`);
+  });
+});
+
+describe('WHEN given a package.json with a module', () => {
+  it('SHOULD give an error', () => {
+    expect(() =>
+      getMain(packagePath, true, {
+        name: packagePath,
+        version: '1.0.0',
+        main: 'src/index.ts',
+        module: 'src/index.ts',
+      }),
+    ).toThrow(`package.json shouldn't have a "module" field, bailing...`);
+  });
+});
+
+describe('WHEN given a package.json with a typings', () => {
+  it('SHOULD give an error', () => {
+    expect(() =>
+      getMain(packagePath, true, {
+        name: packagePath,
+        version: '1.0.0',
+        main: 'src/index.ts',
+        typings: 'src/index.d.ts',
+      }),
+    ).toThrow(`package.json shouldn't have a "typings" field, bailing...`);
+  });
+});
+
+describe('WHEN given a package.json without a main', () => {
+  it('SHOULD give an error', () => {
+    expect(() =>
+      getMain(packagePath, true, {
+        name: packagePath,
+        version: '1.0.0',
+      }),
+    ).toThrow(
+      `package.json at ${packagePath} does not have a "main" field, bailing...`,
+    );
+  });
+});

--- a/packages/modular-scripts/src/build/buildPackage/getPackageEntryPoints.ts
+++ b/packages/modular-scripts/src/build/buildPackage/getPackageEntryPoints.ts
@@ -1,54 +1,19 @@
-import getPackageMetadata from '../../utils/getPackageMetadata';
+import { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
 import * as path from 'path';
 import * as fse from 'fs-extra';
-import getModularRoot from '../../utils/getModularRoot';
 
-export async function getPackageEntryPoints(
+import getModularRoot from '../../utils/getModularRoot';
+import getPackageMetadata from '../../utils/getPackageMetadata';
+
+export function getMain(
   packagePath: string,
   includePrivate: boolean,
-): Promise<{
-  main: string;
-  compilingBin: boolean;
-}> {
-  const modularRoot = getModularRoot();
-  const { packageJsonsByPackagePath } = await getPackageMetadata();
-
-  const packageJson = packageJsonsByPackagePath[packagePath];
-
-  let compilingBin = false;
+  packageJson: JSONSchemaForNPMPackageJsonFiles | undefined,
+): string {
   let main: string | undefined;
-
-  if (packageJson.main) {
-    main = packageJson.main;
-  } else {
-    if (packageJson.bin) {
-      const bins: string[] = Object.values(packageJson.bin) as string[];
-      if (bins.length === 1) {
-        compilingBin = true;
-        main = bins[0];
-      } else {
-        throw new Error(
-          `package.json contains multiple "bin" values, bailing...`,
-        );
-      }
-    } else {
-      throw new Error(
-        `package.json does not have a "main" or "bin" field, bailing...`,
-      );
-    }
-  }
 
   if (!packageJson) {
     throw new Error(`no package.json in ${packagePath}, bailing...`);
-  }
-  if (!includePrivate && packageJson.private === true) {
-    throw new Error(`${packagePath} is marked private, bailing...`);
-  }
-
-  if (!fse.existsSync(path.join(modularRoot, packagePath, main))) {
-    throw new Error(
-      `package.json does not have a main file that points to an existing source file, bailing...`,
-    );
   }
 
   if (!packageJson.name) {
@@ -69,5 +34,34 @@ export async function getPackageEntryPoints(
     );
   }
 
-  return { main, compilingBin };
+  if (!includePrivate && packageJson.private === true) {
+    throw new Error(`${packagePath} is marked private, bailing...`);
+  }
+
+  if (packageJson.main) {
+    main = packageJson.main;
+  } else {
+    throw new Error(
+      `package.json at ${packagePath} does not have a "main" field, bailing...`,
+    );
+  }
+
+  if (!fse.existsSync(path.join(getModularRoot(), packagePath, main))) {
+    throw new Error(
+      `package.json does not have a main file that points to an existing source file, bailing...`,
+    );
+  }
+
+  return main;
+}
+
+export async function getPackageEntryPoints(
+  packagePath: string,
+  includePrivate: boolean,
+): Promise<string> {
+  const { packageJsonsByPackagePath } = await getPackageMetadata();
+
+  const packageJson = packageJsonsByPackagePath[packagePath];
+
+  return getMain(packagePath, includePrivate, packageJson);
 }

--- a/packages/modular-scripts/src/build/buildPackage/index.ts
+++ b/packages/modular-scripts/src/build/buildPackage/index.ts
@@ -48,7 +48,7 @@ export async function buildPackage(
   await fs.emptyDir(targetOutputDirectory);
 
   // Generate the typings for a package first so that we can do type checking and don't waste time bundling otherwise
-  await makeTypings(packagePath);
+  await makeTypings(target);
 
   // generate the js files now that we know we have a valid package
   const publicPackageJson = await makeBundle(

--- a/packages/modular-scripts/src/build/buildPackage/index.ts
+++ b/packages/modular-scripts/src/build/buildPackage/index.ts
@@ -12,7 +12,6 @@ import npmPacklist from 'npm-packlist';
 import micromatch from 'micromatch';
 
 import getPrefixedLogger from '../../utils/getPrefixedLogger';
-import { getPackageEntryPoints } from './getPackageEntryPoints';
 import getModularRoot from '../../utils/getModularRoot';
 import { makeBundle } from './makeBundle';
 import { makeTypings } from './makeTypings';
@@ -49,13 +48,7 @@ export async function buildPackage(
   await fs.emptyDir(targetOutputDirectory);
 
   // Generate the typings for a package first so that we can do type checking and don't waste time bundling otherwise
-  const { compilingBin } = await getPackageEntryPoints(
-    packagePath,
-    includePrivate,
-  );
-  if (!compilingBin) {
-    await makeTypings(target);
-  }
+  await makeTypings(packagePath);
 
   // generate the js files now that we know we have a valid package
   const publicPackageJson = await makeBundle(

--- a/packages/modular-scripts/src/build/buildPackage/makeBundle.ts
+++ b/packages/modular-scripts/src/build/buildPackage/makeBundle.ts
@@ -11,8 +11,9 @@ import json from '@rollup/plugin-json';
 import postcss from 'rollup-plugin-postcss';
 import resolve from '@rollup/plugin-node-resolve';
 
-import getPrefixedLogger from '../../utils/getPrefixedLogger';
 import { getPackageEntryPoints } from './getPackageEntryPoints';
+
+import getPrefixedLogger from '../../utils/getPrefixedLogger';
 import getPackageMetadata from '../../utils/getPackageMetadata';
 import getModularRoot from '../../utils/getModularRoot';
 import { ModularPackageJson } from '../../utils/isModularType';
@@ -51,10 +52,7 @@ export async function makeBundle(
 
   const packageJson = packageJsonsByPackagePath[packagePath];
 
-  const { main, compilingBin } = await getPackageEntryPoints(
-    packagePath,
-    includePrivate,
-  );
+  const main = await getPackageEntryPoints(packagePath, includePrivate);
 
   logger.log(`building ${target}...`);
 
@@ -272,59 +270,39 @@ export async function makeBundle(
     exports: 'auto',
   });
 
-  if (!compilingBin) {
-    await bundle.write({
-      ...outputOptions,
-      ...(preserveModules
-        ? {
-            preserveModules: true,
-            dir: path.join(targetOutputDirectory, `${outputDirectory}-es`),
-          }
-        : {
-            file: path.join(
-              targetOutputDirectory,
-              `${outputDirectory}-es`,
-              paramCaseTarget + '.es.js',
-            ),
-          }),
-      format: 'es',
-      exports: 'auto',
-    });
-  }
+  await bundle.write({
+    ...outputOptions,
+    ...(preserveModules
+      ? {
+          preserveModules: true,
+          dir: path.join(targetOutputDirectory, `${outputDirectory}-es`),
+        }
+      : {
+          file: path.join(
+            targetOutputDirectory,
+            `${outputDirectory}-es`,
+            paramCaseTarget + '.es.js',
+          ),
+        }),
+    format: 'es',
+    exports: 'auto',
+  });
 
-  let outputFilesPackageJson: Partial<ModularPackageJson>;
-  if (compilingBin && packageJson.bin) {
-    const binName = Object.keys(packageJson.bin)[0];
-    const binPath = main
-      .replace(/\.tsx?$/, '.js')
-      .replace(path.dirname(main) + '/', '');
-
-    outputFilesPackageJson = {
-      bin: {
-        [binName]: binPath,
-      },
-    };
-  } else {
-    const outputPath = buildOutput[0].fileName;
-    outputFilesPackageJson = {
-      // TODO: what of 'bin' fields?
-      main: preserveModules
-        ? path.posix.join(`${outputDirectory}-cjs`, outputPath)
-        : `${outputDirectory}-cjs/${paramCaseTarget + '.cjs.js'}`,
-      module: preserveModules
-        ? path.posix.join(`${outputDirectory}-es`, outputPath)
-        : `${outputDirectory}-es/${paramCaseTarget + '.es.js'}`,
-      typings: path.posix.join(
-        `${outputDirectory}-types`,
-        path.posix.relative('src', main).replace(/\.tsx?$/, '.d.ts'),
-      ),
-    };
-  }
+  const outputPath = buildOutput[0].fileName;
 
   // return the public facing package.json that we'll write to disk later
   return {
     ...packageJson,
-    ...outputFilesPackageJson,
+    main: preserveModules
+      ? path.posix.join(`${outputDirectory}-cjs`, outputPath)
+      : `${outputDirectory}-cjs/${paramCaseTarget + '.cjs.js'}`,
+    module: preserveModules
+      ? path.posix.join(`${outputDirectory}-es`, outputPath)
+      : `${outputDirectory}-es/${paramCaseTarget + '.es.js'}`,
+    typings: path.posix.join(
+      `${outputDirectory}-types`,
+      path.posix.relative('src', main).replace(/\.tsx?$/, '.d.ts'),
+    ),
     dependencies: {
       ...packageJson.dependencies,
       ...localImports,


### PR DESCRIPTION
Previously there were two ways to expose an entry point when `modular build <packageName>` was run. In the `package.json` for the directory you could expose `main: "<path to file>` or via a CLI
```{
   "bin": {
      "cli-name": <path to file>
   }
}
```

Modular would prefer `main` over `bin` fields - however the use case for `bin` was redundant given that users could expose via pointing the `bin` field to `dist-{es|cjs}/<path to output>`. 