### PR TITLE
Remove mutation of publicPackageJsons

### DIFF
--- a/packages/modular-scripts/src/buildPackage/index.ts
+++ b/packages/modular-scripts/src/buildPackage/index.ts
@@ -16,7 +16,6 @@ import * as fse from 'fs-extra';
 
 import { getLogger } from './getLogger';
 import { getPackageEntryPoints } from './getPackageEntryPoints';
-import getPackageMetadata from '../utils/getPackageMetadata';
 import getModularRoot from '../utils/getModularRoot';
 import { makeBundle } from './makeBundle';
 import { makeTypings } from './makeTypings';
@@ -33,7 +32,6 @@ export async function buildPackage(
 ): Promise<void> {
   const modularRoot = getModularRoot();
   const packagePath = await getRelativeLocation(target);
-  const { publicPackageJsons } = await getPackageMetadata();
 
   if (process.cwd() !== modularRoot) {
     throw new Error(
@@ -60,14 +58,11 @@ export async function buildPackage(
   }
 
   // generate the js files now that we know we have a valid package
-  const didBundle = await makeBundle(
+  const publicPackageJson = await makeBundle(
     packagePath,
     preserveModules,
     includePrivate,
   );
-  if (!didBundle) {
-    return;
-  }
 
   const originalPkgJsonContent = (await fse.readJson(
     path.join(modularRoot, packagePath, 'package.json'),
@@ -77,7 +72,6 @@ export async function buildPackage(
 
   // switch in the special package.json
   try {
-    const publicPackageJson = publicPackageJsons[packageName];
     await fse.writeJson(
       path.join(packagePath, 'package.json'),
       publicPackageJson,

--- a/packages/modular-scripts/src/buildPackage/makeBundle.ts
+++ b/packages/modular-scripts/src/buildPackage/makeBundle.ts
@@ -1,4 +1,3 @@
-import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 import { paramCase as toParamCase } from 'change-case';
 import * as path from 'path';
 import builtinModules from 'builtin-modules';
@@ -16,6 +15,7 @@ import { getLogger } from './getLogger';
 import { getPackageEntryPoints } from './getPackageEntryPoints';
 import getPackageMetadata from '../utils/getPackageMetadata';
 import getModularRoot from '../utils/getModularRoot';
+import { ModularPackageJson } from '../utils/isModularType';
 
 const outputDirectory = 'dist';
 const extensions = ['.ts', '.tsx', '.js', '.jsx'];
@@ -28,7 +28,7 @@ export async function makeBundle(
   packagePath: string,
   preserveModules: boolean,
   includePrivate: boolean,
-): Promise<boolean> {
+): Promise<ModularPackageJson> {
   const modularRoot = getModularRoot();
   const metadata = await getPackageMetadata();
   const {
@@ -36,7 +36,6 @@ export async function makeBundle(
     packageJsons,
     packageJsonsByPackagePath,
     packageNames,
-    publicPackageJsons,
   } = metadata;
   const logger = getLogger(packagePath);
 
@@ -269,7 +268,7 @@ export async function makeBundle(
     });
   }
 
-  let outputFilesPackageJson: Partial<PackageJson>;
+  let outputFilesPackageJson: Partial<ModularPackageJson>;
   if (compilingBin && packageJson.bin) {
     const binName = Object.keys(packageJson.bin)[0];
     const binPath = main
@@ -307,8 +306,10 @@ export async function makeBundle(
     };
   }
 
-  // store the public facing package.json that we'll write to disk later
-  publicPackageJsons[packageJsonName] = {
+  logger.log(`built ${packageJsonName} at ${packagePath}`);
+
+  // return the public facing package.json that we'll write to disk later
+  return {
     ...packageJson,
     ...outputFilesPackageJson,
     dependencies: {
@@ -323,7 +324,4 @@ export async function makeBundle(
       'README.md',
     ]),
   };
-
-  logger.log(`built ${packageJsonName} at ${packagePath}`);
-  return true;
 }

--- a/packages/modular-scripts/src/utils/getPackageMetadata.ts
+++ b/packages/modular-scripts/src/utils/getPackageMetadata.ts
@@ -52,10 +52,6 @@ async function getPackageMetadata() {
   // explicitly included in dependencies
   // maybe that belongs in `modular check`
 
-  const publicPackageJsons: {
-    [name: string]: PackageJson;
-  } = {};
-
   const typescriptConfig: TSConfig = {};
   // validate tsconfig
   // Extract configuration from config file and parse JSON,
@@ -112,7 +108,6 @@ async function getPackageMetadata() {
     packageJsons,
     typescriptConfig,
     packageJsonsByPackagePath,
-    publicPackageJsons,
   };
 }
 


### PR DESCRIPTION
Cleanup of the nit that's been around due to the mutation of the `publicPackageJsons` required for `buildPackage` API. 