### PR TITLE
Close #644 Add eslint-config-modular-app during convert

### DIFF
--- a/.changeset/empty-islands-speak.md
+++ b/.changeset/empty-islands-speak.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+---
+
+Add eslint-config-modular-app as a dependency when we remove react-scripts
+during `modular convert` to maintain eslint functionality

--- a/packages/modular-scripts/src/__tests__/convert.test.ts
+++ b/packages/modular-scripts/src/__tests__/convert.test.ts
@@ -167,4 +167,13 @@ describe('Converting a react app to modular app', () => {
       rootPackageJson.browserslist as Record<string, string[]>,
     );
   });
+
+  it('should add eslint-config-modular-app to the dependencies', () => {
+    const updatedPackageJson = fs.readJsonSync(
+      path.join(tmpFolderPath, 'package.json'),
+    ) as ModularPackageJson;
+    expect(Object.keys(updatedPackageJson.dependencies || {})).toContain(
+      'eslint-config-modular-app',
+    );
+  });
 });

--- a/packages/modular-scripts/src/convert.ts
+++ b/packages/modular-scripts/src/convert.ts
@@ -148,15 +148,18 @@ export async function convert(cwd: string = process.cwd()): Promise<void> {
       return acc;
     }, {});
 
+    // Deps that need to be reintroduced because we removed react-scripts
+    const additionalDeps = ['eslint-config-modular-app'];
+
     fs.writeJsonSync(path.join(cwd, 'package.json'), rootPackageJson, {
       spaces: 2,
     });
 
-    logger.log(
-      'Modular repo was set up successfully. Running yarn to update dependencies',
-    );
+    logger.log('Running yarn to update dependencies');
 
-    execa.sync('yarnpkg', ['--silent'], { cwd });
+    execa.sync('yarnpkg', ['--silent', 'add', '-W', ...additionalDeps], {
+      cwd,
+    });
 
     logger.log('Validating your modular project...');
     await check();


### PR DESCRIPTION
Add eslint-config-modular-app as a dependency when we remove react-scripts to maintain compatibility with eslint config extensions to react-app