### PR TITLE
Improve `create-modular-react-app` message handling

### DIFF
--- a/.changeset/tame-apricots-repair.md
+++ b/.changeset/tame-apricots-repair.md
@@ -1,0 +1,6 @@
+---
+'create-modular-react-app': minor
+---
+
+Add `--verbose` to create-modular-react-app and improve error handling for
+sub-processes

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 
-yarn format
+yarn format 
+git add .
 yarn lint-staged

--- a/packages/create-modular-react-app/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/packages/create-modular-react-app/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -10,6 +10,7 @@ exports[`Creating a new modular app via the CLI should create the right tree 1`]
 │  ├─ extensions.json #1i4584r
 │  ├─ launch.json #1kk1omt
 │  └─ settings.json #xes41c
+├─ .yarnrc #1orkcoz
 ├─ README.md #1nksyzj
 ├─ modular
 │  ├─ setupEnvironment.ts #m0s4vb

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -66,6 +66,7 @@ describe('create-modular-react-app', () => {
       │  ├─ extensions.json #1i4584r
       │  ├─ launch.json #1kk1omt
       │  └─ settings.json #xes41c
+      ├─ .yarnrc #1orkcoz
       ├─ README.md #1nksyzj
       ├─ modular
       │  ├─ setupEnvironment.ts #m0s4vb
@@ -187,6 +188,7 @@ describe('create-modular-react-app', () => {
       │  ├─ extensions.json #1i4584r
       │  ├─ launch.json #1kk1omt
       │  └─ settings.json #xes41c
+      ├─ .yarnrc #1orkcoz
       ├─ README.md #1nksyzj
       ├─ modular
       │  ├─ setupEnvironment.ts #m0s4vb

--- a/packages/create-modular-react-app/src/cli.ts
+++ b/packages/create-modular-react-app/src/cli.ts
@@ -5,16 +5,23 @@ import { program } from 'commander';
 import * as fs from 'fs-extra';
 import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 
+// this is a bit gross - but there's no better way of doing this.
+let verbose = false;
+
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-// See https://github.com/facebook/create-react-app/blob/f36d61a/packages/react-scripts/bin/react-scripts.js#L11-L16
 process.on('unhandledRejection', (err) => {
-  throw err;
+  if (verbose) {
+    console.error(err);
+  }
+  process.exit(1);
 });
+
 interface Options {
   repo: boolean;
   preferOffline: boolean;
+  verbose: boolean;
 }
 
 program.version(
@@ -28,16 +35,35 @@ program.version(
 program.arguments('<name>');
 program.option('--repo [value]', 'Should a repository be initialized', false);
 program.option('--prefer-offline', 'Yarn --prefer-offline', true);
+program.option('--verbose');
 program.action(async (name: string, options: Options) => {
+  if (options.verbose) {
+    verbose = true;
+  }
+
   await createModularApp({
     name,
     preferOffline: options.preferOffline,
     repo: options.repo,
+    verbose,
   });
 });
 
 try {
-  void program.parseAsync(process.argv);
+  void program
+    .parseAsync(process.argv)
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((err) => {
+      if (verbose) {
+        console.error(err);
+      }
+      process.exit(1);
+    });
 } catch (err) {
-  console.error(err);
+  if (verbose) {
+    console.error(err);
+  }
+  process.exit(1);
 }

--- a/packages/create-modular-react-app/src/cli.ts
+++ b/packages/create-modular-react-app/src/cli.ts
@@ -6,16 +6,13 @@ import * as fs from 'fs-extra';
 import { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 
 // this is a bit gross - but there's no better way of doing this.
-let verbose = false;
+const verbose = process.argv.includes('--verbose');
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
 process.on('unhandledRejection', (err) => {
-  if (verbose) {
-    console.error(err);
-  }
-  process.exit(1);
+  throw err;
 });
 
 interface Options {
@@ -35,12 +32,8 @@ program.version(
 program.arguments('<name>');
 program.option('--repo [value]', 'Should a repository be initialized', false);
 program.option('--prefer-offline', 'Yarn --prefer-offline', true);
-program.option('--verbose');
+program.option('--verbose', 'Run yarn commands with --verbose set');
 program.action(async (name: string, options: Options) => {
-  if (options.verbose) {
-    verbose = true;
-  }
-
   await createModularApp({
     name,
     preferOffline: options.preferOffline,

--- a/packages/create-modular-react-app/src/index.ts
+++ b/packages/create-modular-react-app/src/index.ts
@@ -5,21 +5,19 @@ import * as path from 'path';
 import chalk from 'chalk';
 import * as semver from 'semver';
 
-function execSync(
-  file: string,
-  args: string[],
-  options: { log?: boolean } & execa.SyncOptions = { log: true },
-) {
-  const { log, ...opts } = options;
-  if (log) {
-    console.log(chalk.grey(`$ ${file} ${args.join(' ')}`));
+function exec(file: string, args: string[], cwd: string) {
+  console.log(chalk.grey(`$ ${file} ${args.join(' ')}`));
+  try {
+    return execa(file, args, {
+      stdin: process.stdin,
+      stderr: process.stderr,
+      stdout: process.stdout,
+      cwd,
+    });
+  } catch (e) {
+    console.error(chalk.red(`$ FAILED ${file} ${args.join(' ')}`));
+    throw e;
   }
-  return execa.sync(file, args, {
-    stdin: process.stdin,
-    stderr: process.stderr,
-    stdout: process.stdout,
-    ...opts,
-  });
 }
 
 function isYarnInstalled(): boolean {
@@ -31,10 +29,11 @@ function isYarnInstalled(): boolean {
   }
 }
 
-export default function createModularApp(argv: {
+export default async function createModularApp(argv: {
   name: string;
   repo?: boolean;
   preferOffline?: boolean;
+  verbose?: boolean;
 }): Promise<void> {
   const { engines } = fs.readJSONSync(
     require.resolve('create-modular-react-app/package.json'),
@@ -48,11 +47,13 @@ export default function createModularApp(argv: {
   }
 
   const preferOfflineArg = argv.preferOffline ? ['--prefer-offline'] : [];
+  const verboseArgs = argv.verbose ? ['--verbose'] : [];
+
   if (isYarnInstalled() === false) {
     console.error(
       'Please install `yarn` before attempting to run `create-modular-react-app`.',
     );
-    process.exit(1);
+    throw new Error(`Yarn was not installed`);
   }
 
   const newModularRoot = path.isAbsolute(argv.name)
@@ -68,14 +69,10 @@ export default function createModularApp(argv: {
   //
   // See: https://github.com/facebook/create-react-app/blob/47e9e2c7a07bfe60b52011cf71de5ca33bdeb6e3/packages/react-scripts/scripts/init.js#L48-L50
   if (argv.repo !== false) {
-    execSync('git', ['init'], {
-      cwd: newModularRoot,
-    });
+    await exec('git', ['init'], newModularRoot);
   }
 
-  execSync('yarnpkg', ['init', '-y'], {
-    cwd: newModularRoot,
-  });
+  await exec('yarnpkg', ['init', '-y'], newModularRoot);
 
   fs.writeJsonSync(projectPackageJsonPath, {
     ...fs.readJsonSync(projectPackageJsonPath),
@@ -102,11 +99,12 @@ export default function createModularApp(argv: {
     },
   });
 
-  execSync(
+  await exec(
     'yarnpkg',
     [
       'add',
       '-W',
+      ...verboseArgs,
       ...preferOfflineArg,
       '@testing-library/dom',
       '@testing-library/jest-dom',
@@ -124,18 +122,23 @@ export default function createModularApp(argv: {
       'eslint-config-modular-app',
       'typescript@^4.1.2',
     ],
-    { cwd: newModularRoot },
+    newModularRoot,
   );
 
-  fs.copySync(templatePath, newModularRoot);
+  await fs.copy(templatePath, newModularRoot);
 
   // rename gitgnore to .gitgnore so it actually works
-  fs.moveSync(
+  await fs.move(
     path.join(newModularRoot, 'gitignore'),
     path.join(newModularRoot, '.gitignore'),
   );
 
-  execSync(
+  await fs.move(
+    path.join(newModularRoot, 'yarnrc'),
+    path.join(newModularRoot, '.yarnrc'),
+  );
+
+  await exec(
     'yarnpkg',
     [
       'modular',
@@ -145,22 +148,17 @@ export default function createModularApp(argv: {
       'app',
       '--unstable-name',
       'app',
+      ...verboseArgs,
     ],
-    {
-      cwd: newModularRoot,
-    },
+    newModularRoot,
   );
 
   if (argv.repo !== false) {
-    execSync('git', ['add', '.'], {
-      cwd: newModularRoot,
-    });
+    await exec('git', ['add', '.'], newModularRoot);
 
     // don't try to commit in CI
     if (!process.env.CI) {
-      execSync('git', ['commit', '-m', 'Initial commit'], {
-        cwd: newModularRoot,
-      });
+      await exec('git', ['commit', '-m', 'Initial commit'], newModularRoot);
     }
   }
 

--- a/packages/create-modular-react-app/template/yarnrc
+++ b/packages/create-modular-react-app/template/yarnrc
@@ -1,0 +1,1 @@
+disable-self-update-check true

--- a/packages/modular-scripts/README.md
+++ b/packages/modular-scripts/README.md
@@ -38,7 +38,7 @@ and Tooling together to establish a set of patterns and definitions to enable
 ## Getting Started
 
 ```bash
-  yarn create modular-react-app my-new-modular-project
+  yarn create modular-react-app my-new-modular-project [--verbose]
 ```
 
 Bootstraps a new project, configured to use

--- a/packages/modular-scripts/README.md
+++ b/packages/modular-scripts/README.md
@@ -38,15 +38,22 @@ and Tooling together to establish a set of patterns and definitions to enable
 ## Getting Started
 
 ```bash
-  yarn create modular-react-app my-new-modular-project [--verbose]
+  yarn create modular-react-app my-new-modular-project [--verbose] [--prefer-offline] [--repo]
 ```
 
 Bootstraps a new project, configured to use
 [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/).
 
-This also creates a workspace named 'app' containing a fresh
-[`create-react-app`](https://create-react-app.dev/) application written in
+This also creates a workspace named 'app' which is a new modular app written in
 [TypeScript](https://www.typescriptlang.org/).
+
+It supports three flags:
+
+- `--verbose` enables verbose `yarn` and `modular` logging.
+- `--prefer-offline` will prefer locally cached `node_modules` versions over
+  those from your remote registry.
+- `--repo <value>` will toggle whether a new `git` repo is created and the
+  initial files commited.
 
 ## Commands
 

--- a/packages/modular-scripts/src/addPackage.ts
+++ b/packages/modular-scripts/src/addPackage.ts
@@ -18,6 +18,7 @@ async function addPackage(
   typeArg: string | void,
   nameArg: string | void,
   preferOffline = true,
+  verbose = false,
 ): Promise<void> {
   const { type, name } =
     (typeArg && nameArg ? { type: typeArg, name: nameArg } : null) ||
@@ -92,7 +93,7 @@ async function addPackage(
     );
   }
 
-  const yarnArgs = ['--silent'];
+  const yarnArgs = verbose ? ['--verbose'] : ['--silent'];
   if (preferOffline) {
     yarnArgs.push('--prefer-offline');
   }

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -41,6 +41,7 @@ program
     'Equivalent of --prefer-offline for yarn installations',
     true,
   )
+  .option('--verbose', 'Run yarn commands with --verbose set')
   .action(
     async (
       packageName: string,
@@ -48,6 +49,7 @@ program
         unstableType?: string;
         unstableName?: string;
         preferOffline?: boolean;
+        verbose?: boolean;
       },
     ) => {
       const { default: addPackage } = await import('./addPackage');
@@ -56,6 +58,7 @@ program
         addOptions.unstableType,
         addOptions.unstableName,
         addOptions.preferOffline,
+        addOptions.verbose,
       );
     },
   );
@@ -180,6 +183,7 @@ program
 interface InitOptions {
   y: boolean;
   preferOffline: string;
+  verbose: boolean;
 }
 
 program
@@ -187,9 +191,14 @@ program
   .description('Initialize a new modular root in the current folder')
   .option('-y', 'equivalent to the -y flag in NPM')
   .option('--prefer-offline [value]', 'delegate to offline cache first', true)
+  .option('--verbose', 'Run yarn commands with --verbose set')
   .action(async (options: InitOptions) => {
     const { default: initWorkspace } = await import('./init');
-    await initWorkspace(options.y, JSON.parse(options.preferOffline));
+    await initWorkspace(
+      options.y,
+      JSON.parse(options.preferOffline),
+      options.verbose,
+    );
   });
 
 program

--- a/packages/modular-scripts/src/init.ts
+++ b/packages/modular-scripts/src/init.ts
@@ -8,6 +8,7 @@ export async function initModularFolder(
   folder: string,
   initOverride: boolean,
   preferOffline = true,
+  verbose = false,
 ): Promise<void> {
   const packageJsonPath = path.join(folder, 'package.json');
 
@@ -47,7 +48,7 @@ export async function initModularFolder(
   await fs.mkdirp(path.join(folder, 'modular'));
   await fs.mkdirp(path.join(folder, 'packages'));
 
-  const yarnArgs = ['--silent'];
+  const yarnArgs = verbose ? ['--verbose'] : ['--silent'];
   if (preferOffline) {
     yarnArgs.push('--prefer-offline');
   }
@@ -59,6 +60,7 @@ export async function initModularFolder(
 export default function init(
   initOverride = false,
   preferOffline = true,
+  verbose = false,
 ): Promise<void> {
-  return initModularFolder(process.cwd(), initOverride, preferOffline);
+  return initModularFolder(process.cwd(), initOverride, preferOffline, verbose);
 }

--- a/packages/modular-scripts/src/utils/logger.ts
+++ b/packages/modular-scripts/src/utils/logger.ts
@@ -2,7 +2,8 @@ import chalk from 'chalk';
 
 const prefix = '[modular] ';
 
-const DEBUG = process.env.MODULAR_LOGGER_DEBUG;
+const DEBUG =
+  process.env.MODULAR_LOGGER_DEBUG || process.argv.includes('--verbose');
 const SILENT = process.env.MODULAR_LOGGER_MUTE;
 
 function printStdErr(x: string) {


### PR DESCRIPTION
Improve error message handling when creating a new modular repository. Additionally add a `--verbose` flag which proxies to `yarn --verbose` when installing. 