### PR TITLE
Update commands.md with new commands and options 

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -105,7 +105,107 @@ attempt.
 
 - Relocates setupTests file from `src/` to `modular/`
 
-- Updates the react-app-env.d.ts file within the modular app to reference
+- Updates the `react-app-env.d.ts` file within the modular app to reference
   modular-scripts for types
 
-- Updates tsconfig.json to include the modular packages workspace
+- Updates `tsconfig.json` to include the modular packages workspace
+
+- Removes `react-scripts` as a dependency and installs
+  eslint-config-modular-app. You can point to it by adding 'modular-app' to the
+  extends array in your eslint config.
+
+## `modular port <relativePath>`
+
+Takes a relative path from the modular root directory to the targeted
+create-react-app project and ports it over to the current modular project as a
+moudlar app.
+
+```
+$ modular port ../another-react-app
+```
+
+This action is `atomic` so if an error occurs while porting, it will stash any
+changes made and bring the repo back to the previous state prior to the attempt.
+
+- Creates a new folder in packages workspace, named using your targeted app's
+  package.json name
+
+- Moves the `src` and `public` folders into the new workspace
+
+- If present, updates the `react-app-env.d.ts` file within the new workspace to
+  reference modular-scripts for types of static assets (e.g. svgs)
+
+- Creates a tsconfig.json within the new workspace to extend the root
+  `tsconfig.json`
+
+- If you do not have a `modular/setupTests` file and the targeted app has a
+  `src/setupTests` file, it will move it into the `modular` folder to load
+  before executing `modular test`
+
+- Resolves dependencies between the two repos.
+
+#### Dependency Resolution
+
+`modular port` does not set up `nohoist` in `package.json` for mismatched
+versions.
+
+If the targeted app has a `dependency` that is versioned differently than the
+modular root dependency, the package@version in modular root will take
+precedence.
+
+If the targeted app has a `devDependency` that is marked as a `dependency` in
+modular root, it will not be ported over into the modular app as a
+`devDependency` but instead be kept as a dependency in modular root. During this
+resolution, if modular root has the package in its dependencies, the version in
+modular root will take precedence.
+
+Given the case that the app you are porting over has a dependency that is a
+local package in modular worktree, if the target app's dep has a different
+version than the local version, that package would not be symlinked to the local
+package at all if brought over directly. It would get its own copy in its
+node_modules.
+(https://github.com/yarnpkg/yarn/issues/6898#issuecomment-478188695)
+
+Example: TargetApp's dependency: foo@^1.0.5
+
+Modular package foo's local version: 2.0.1
+
+TargetApp will have copy of foo@1.0.5 in its workspace node_modules.
+
+It will be marked as a `mismatchedWorkspaceDependencies` in yarn workspaces. We
+do not allow `mismatchedWorkspaceDependencies` in the modular workspace.
+
+If the targeted app has a `dependency` or `devDependency` of a package that is a
+local workspace in your modular repo, we will remove that dependency from the
+target app and have it use the local symlinked version instead.
+
+## `modular typecheck`
+
+`modular typecheck` will programmatically report the semantic, syntactic, and
+declaration type errors found in your code, based on your tsconfig.json.
+
+In a CI environment, it will print condensed errors if they are present.
+
+In non-CI environments, it will print the full details of the error, line, and
+small snapshot of the offending line in question.
+
+## `modular lint`
+
+`modular lint` will check the diff between the current branch and your remote
+origin default branch (i.e. `master` or `main`) and only lint the `.ts`, `.tsx`,
+`.js`, `.jsx` files that have changes.
+
+It uses your project eslint config to lint and jest runner to report on the lint
+status of each file (`PASS` or `FAIL`). If a file has a lint warning, the
+command will be marked as failed, with printed eslint errors for each
+warning/error.
+
+When in CI, it will default to lint the entire codebase. When not in CI, it will
+default to only lint the diffed files.
+
+### Options:
+
+`--all`: Lints the entire codebase
+
+`--fix`: Allows eslint to fix the errors and warnings that do not require manual
+intervention wherever possible

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,9 @@ without all of the interactive processes.
 
 `--prefer-offline`: Uses offline yarn cache when possible
 
+`--verbose`: Run yarn commands with --verbose set and sets
+`MODULAR_LOGGER_DEBUG` to true
+
 ## `modular add <packagePath>`
 
 Adds a new package by creating a new workspace at `packages/<packagePath>`
@@ -40,6 +43,9 @@ Packages can currently be one of 3 types:
 ### Options:
 
 `--prefer-offline`: Uses offline yarn cache when possible
+
+`--verbose`: Run yarn commands with --verbose set and sets
+`MODULAR_LOGGER_DEBUG` to true
 
 ## `modular start <packageName>`
 
@@ -77,6 +83,12 @@ this-is-param-case) in `dist/`
 
 (i.e. `modular build @scoped/package-a` will output built artifacts into
 `dist/scoped-package-a`)
+
+### Options:
+
+`--private`: Allows the building of private packages
+
+`--preserve-modules`: Preserve module structure in generated modules
 
 ## `modular workspace`
 


### PR DESCRIPTION
Add `modular port`, `modular lint`, `modular typecheck` docs, with options. Copied over notes from modular port dependency resolution.