### PR TITLE
Modular lint targets the proper files

### DIFF
--- a/.changeset/cuddly-readers-allow.md
+++ b/.changeset/cuddly-readers-allow.md
@@ -1,0 +1,7 @@
+---
+'modular-scripts': patch
+---
+
+Modular lint should not check for diffed files if regex is passed in. If there
+are no files that meet the extension criteria (ts, tsx, js, jsx), then end the
+lint.

--- a/packages/modular-scripts/src/lint.ts
+++ b/packages/modular-scripts/src/lint.ts
@@ -23,7 +23,7 @@ async function lint(
   const lintExtensions = ['.ts', '.tsx', '.js', '.jsx'];
   let targetedFiles = ['<rootDir>/**/src/**/*.{js,jsx,ts,tsx}'];
 
-  if (!all && !isCI) {
+  if (!all && !isCI && !regexes) {
     const diffedFiles = getDiffedFiles();
     if (diffedFiles.length === 0) {
       logger.log(
@@ -31,9 +31,18 @@ async function lint(
       );
       return;
     }
-    targetedFiles = diffedFiles
+
+    const targetExts = diffedFiles
       .filter((p: string) => lintExtensions.includes(path.extname(p)))
       .map((p: string) => `<rootDir>/${p}`);
+
+    // if none of the diffed files do not meet the extension criteria, do not lint
+    // end the process early with a success
+    if (!targetExts.length) {
+      logger.debug('No diffed js,jsx,ts,tsx files found');
+      return;
+    }
+    targetedFiles = targetExts;
   }
 
   const jestEslintConfig = {


### PR DESCRIPTION
If there are no diffed files that meet the extension criteria (ts, tsx, js, jsx), then end the linting. If `modular lint` get passed a regex, then it should lint the matched files from the entire code base, not the diffed files only. 
