### PR TITLE
Fix false positive modular project root error on Windows.

### DIFF
--- a/.changeset/dull-pans-study.md
+++ b/.changeset/dull-pans-study.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Fix false positive modular project root error on Windows.

--- a/packages/modular-scripts/src/utils/getModularRoot.ts
+++ b/packages/modular-scripts/src/utils/getModularRoot.ts
@@ -64,7 +64,7 @@ function getModularRoot(): string {
     }
 
     logger.debug(`Located modular root ${modularRoot}`);
-    return modularRoot;
+    return path.normalize(modularRoot);
   } catch (err) {
     throw new Error(err);
   }


### PR DESCRIPTION
Currently, on windows, you get the error "This command can only be run from the root of a modular project" even if you are in the root folder. This PR fixes that by normalising the path returned from `getModularRoot`.