### PR TITLE
Fix issue where subst file systems on windows 

### DIFF
--- a/.changeset/twelve-cars-collect.md
+++ b/.changeset/twelve-cars-collect.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+---
+
+Fix issue where subst file systems on windows would cause a mismatch in modular
+root and process.cwd() results.

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -10,7 +10,6 @@ import type { LintOptions } from './lint';
 
 import actionPreflightCheck from './utils/actionPreflightCheck';
 import * as logger from './utils/logger';
-import getModularRoot from './utils/getModularRoot';
 
 const program = new commander.Command('modular');
 program.version(
@@ -75,13 +74,6 @@ program
         private: boolean;
       },
     ) => {
-      const modularRoot = getModularRoot();
-      if (process.cwd() !== modularRoot) {
-        throw new Error(
-          'This command can only be run from the root of a modular project',
-        );
-      }
-
       const { default: build } = await import('./build');
       logger.log('building packages at:', packagePaths.join(', '));
 

--- a/packages/modular-scripts/src/utils/getModularRoot.ts
+++ b/packages/modular-scripts/src/utils/getModularRoot.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs-extra';
 import findUp from 'find-up';
 import memoize from './memoize';
 import * as logger from './logger';
-import execa from 'execa';
 
 function isModularRoot(packageJsonPath: string) {
   const packageJson = fs.readJSONSync(packageJsonPath, {
@@ -12,59 +11,31 @@ function isModularRoot(packageJsonPath: string) {
   return packageJson?.modular?.type === 'root';
 }
 
-function findUpModularRoot(): string | undefined {
-  return findUp.sync(
-    (directory: string) => {
-      const packageJsonPath = path.join(directory, 'package.json');
-      if (
-        findUp.sync.exists(packageJsonPath) &&
-        isModularRoot(packageJsonPath)
-      ) {
-        return packageJsonPath;
-      }
-      return;
-    },
-    { type: 'file', allowSymlinks: false },
-  );
-}
-
-/**
- * This is a shortcut - when running in a git repo we bail out and
- * use the git repository root as the modular root. This handles
- * most use cases since people should be tracking their entire repo
- * as a modular repo.
- *
- * @returns string | undefined
- */
-function getGitRoot() {
-  try {
-    const { stdout } = execa.sync(`git`, [`rev-parse`, `--show-toplevel`]);
-    const packageJsonPath = path.join(stdout, 'package.json');
-    if (isModularRoot(packageJsonPath)) {
-      return stdout;
-    }
-  } catch (e) {
-    /// clearly not in a git repo so just use the CWD
-    return undefined;
-  }
-}
-
 function getModularRoot(): string {
   try {
-    let modularRoot: string | undefined = getGitRoot();
-    if (modularRoot) {
-      logger.debug(`Using git located modular root.`);
-    } else {
-      logger.debug('Deferring to find-up to locate modular root');
-      modularRoot = findUpModularRoot();
-      if (modularRoot === undefined) {
-        throw new Error('Could not find modular root.');
-      }
-      modularRoot = path.dirname(modularRoot);
+    logger.debug('Deferring to find-up to locate modular root');
+    let modularRoot = findUp.sync(
+      (directory: string) => {
+        const packageJsonPath = path.join(directory, 'package.json');
+        if (
+          findUp.sync.exists(packageJsonPath) &&
+          isModularRoot(packageJsonPath)
+        ) {
+          return packageJsonPath;
+        }
+        return;
+      },
+      { type: 'file', allowSymlinks: false },
+    );
+
+    if (modularRoot === undefined) {
+      throw new Error('Could not find modular root.');
     }
 
+    modularRoot = path.normalize(path.dirname(modularRoot));
+
     logger.debug(`Located modular root ${modularRoot}`);
-    return path.normalize(modularRoot);
+    return modularRoot;
   } catch (err) {
     throw new Error(err as string);
   }


### PR DESCRIPTION
On windows `subst` drives causes git to resolve to the underlying file system location - not the user facing file system. 

https://github.com/git-for-windows/git/issues/2705 