### PR TITLE
Builds with large webpack stats stall due to writing large JSON

### DIFF
--- a/packages/modular-scripts/react-dev-utils/typescriptFormatter.js
+++ b/packages/modular-scripts/react-dev-utils/typescriptFormatter.js
@@ -13,7 +13,7 @@ const issueOrigins = {
 function formatter(issue) {
   const { origin, severity, file, line, message, code, character } = issue;
 
-  const colors = new chalk.constructor();
+  const colors = new chalk.Instance();
   const messageColor = severity === 'warning' ? colors.yellow : colors.red;
   const fileAndNumberColor = colors.bold.cyan;
 

--- a/packages/modular-scripts/react-scripts/scripts/build.js
+++ b/packages/modular-scripts/react-scripts/scripts/build.js
@@ -95,8 +95,12 @@ function build() {
         return reject(new Error(messages.warnings.join('\n\n')));
       }
 
+      const { warnings, assets } = stats.toJson();
+
+      const bundleStats = { warnings, assets };
+
       return bfj
-        .write(paths.appBuild + '/bundle-stats.json', stats.toJson())
+        .write(paths.appBuild + '/bundle-stats.json', bundleStats)
         .then(() => resolve())
         .catch((error) => reject(new Error(error)));
     });

--- a/packages/modular-scripts/src/lint.ts
+++ b/packages/modular-scripts/src/lint.ts
@@ -21,7 +21,7 @@ async function lint(
   const { all = false, fix = false } = options;
   const modularRoot = getModularRoot();
   const lintExtensions = ['.ts', '.tsx', '.js', '.jsx'];
-  let targetedFiles = ['<rootDir>/**/src/**/*.{js,jsx,ts,tsx}'];
+  let targetedFiles = ['<rootDir>/**/*.{js,jsx,ts,tsx}'];
 
   if (!all && !isCI && !regexes) {
     const diffedFiles = getDiffedFiles();


### PR DESCRIPTION
- Only write the information that we want to bundle-stats.json file
- Expand the linting to beyond the src folder