### PR TITLE
Add support for .ttf files to esbuild build

### DIFF
--- a/.changeset/nice-scissors-smell.md
+++ b/.changeset/nice-scissors-smell.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+Add support for .ttf files to esbuild build

--- a/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
@@ -36,6 +36,7 @@ export default function createEsbuildConfig(
       '.jpeg': 'file',
       '.png': 'file',
       '.webp': 'file',
+      '.ttf': 'file',
 
       // enable JSX in js files
       '.js': 'jsx',


### PR DESCRIPTION
Currently we are importing css files in our component library using css imports e.g. import “example.css”. 
This works fine but once it gets to our font definition imports (e.g. `@font-face(my-font.ttf)`) the build breaks because .ttf files do not have a loader to use. This PR assigns .ttf files to the file loader. 