### PR TITLE
Allow async imports in modular packages

### DIFF
--- a/.changeset/silent-beers-heal.md
+++ b/.changeset/silent-beers-heal.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+---
+
+Fix bug where async imports in packages would mean that builds would fail to due
+not found in chunk validations.

--- a/packages/modular-scripts/src/__tests__/__fixtures__/packages/sample-async-package/index.ts
+++ b/packages/modular-scripts/src/__tests__/__fixtures__/packages/sample-async-package/index.ts
@@ -1,0 +1,5 @@
+export default async function runInAsync(): Promise<void> {
+  const { runAsync } = await import('./runAsync');
+
+  return runAsync();
+}

--- a/packages/modular-scripts/src/__tests__/__fixtures__/packages/sample-async-package/runAsync.ts
+++ b/packages/modular-scripts/src/__tests__/__fixtures__/packages/sample-async-package/runAsync.ts
@@ -1,0 +1,8 @@
+export function runAsync(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      console.log('done');
+      resolve();
+    }, 1000);
+  });
+}

--- a/packages/modular-scripts/src/__tests__/__snapshots__/build.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/__snapshots__/build.test.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WHEN building with preserve modules SHOULD create the correct index.js 1`] = `
+"import { asyncToGenerator as _asyncToGenerator } from './_virtual/_rollupPluginBabelHelpers.js';
+
+function runInAsync() {
+  return _runInAsync.apply(this, arguments);
+}
+
+function _runInAsync() {
+  _runInAsync = _asyncToGenerator(function* () {
+    var {
+      runAsync
+    } = yield import('./runAsync.js');
+    return runAsync();
+  });
+  return _runInAsync.apply(this, arguments);
+}
+
+export { runInAsync as default };
+//# sourceMappingURL=index.js.map
+"
+`;
+
+exports[`WHEN building with preserve modules SHOULD create the correct runAsync.js 1`] = `
+"function runAsync() {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      console.log('done');
+      resolve();
+    }, 1000);
+  });
+}
+
+export { runAsync };
+//# sourceMappingURL=runAsync.js.map
+"
+`;

--- a/packages/modular-scripts/src/__tests__/build.test.ts
+++ b/packages/modular-scripts/src/__tests__/build.test.ts
@@ -1,0 +1,136 @@
+import execa from 'execa';
+import { promisify } from 'util';
+import _rimraf from 'rimraf';
+import tree from 'tree-view-for-tests';
+import path from 'path';
+import fs from 'fs-extra';
+
+import getModularRoot from '../utils/getModularRoot';
+import { ModularPackageJson } from '../utils/isModularType';
+
+const rimraf = promisify(_rimraf);
+
+const modularRoot = getModularRoot();
+
+function modular(str: string, opts: Record<string, unknown> = {}) {
+  return execa('yarnpkg', ['modular', ...str.split(' ')], {
+    cwd: modularRoot,
+    cleanup: true,
+    ...opts,
+  });
+}
+
+async function cleanup() {
+  const packagesPath = path.join(getModularRoot(), 'packages');
+
+  await rimraf(path.join(packagesPath, 'sample-async-package'));
+  // run yarn so yarn.lock gets reset
+  await execa('yarnpkg', ['--silent'], {
+    cwd: modularRoot,
+  });
+}
+
+beforeAll(async () => {
+  await cleanup();
+});
+
+afterAll(async () => {
+  await cleanup();
+});
+
+describe('WHEN building with preserve modules', () => {
+  beforeAll(async () => {
+    await modular(
+      'add sample-async-package --unstable-type package --unstable-name sample-async-package',
+      {
+        stdio: 'inherit',
+      },
+    );
+
+    const packageSrc = path.join(
+      getModularRoot(),
+      'packages',
+      'sample-async-package',
+      'src',
+    );
+    await fs.emptyDir(packageSrc);
+    await fs.copy(
+      path.join(__dirname, '__fixtures__', 'packages', 'sample-async-package'),
+      packageSrc,
+    );
+
+    // build a package too, but preserve modules
+    await modular('build sample-async-package --preserve-modules', {
+      stdio: 'inherit',
+    });
+  });
+
+  it('THEN expects the correct output package.json', async () => {
+    expect(
+      await fs.readJson(
+        path.join(modularRoot, 'dist', 'sample-async-package', 'package.json'),
+      ),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "dependencies": Object {},
+        "files": Array [
+          "README.md",
+          "dist-cjs",
+          "dist-es",
+          "dist-types",
+        ],
+        "license": "UNLICENSED",
+        "main": "dist-cjs/index.js",
+        "module": "dist-es/index.js",
+        "name": "sample-async-package",
+        "typings": "dist-types/index.d.ts",
+        "version": "1.0.0",
+      }
+    `);
+  });
+
+  it('THEN expects the correct output directory structure', () => {
+    expect(tree(path.join(modularRoot, 'dist', 'sample-async-package')))
+      .toMatchInlineSnapshot(`
+      "sample-async-package
+      ├─ README.md #1jv3l2q
+      ├─ dist-cjs
+      │  ├─ _virtual
+      │  │  ├─ _rollupPluginBabelHelpers.js #8zp60f
+      │  │  └─ _rollupPluginBabelHelpers.js.map #1a6wdsa
+      │  ├─ index.js #sb8xfb
+      │  ├─ index.js.map #r9dxe
+      │  ├─ runAsync.js #66wsvj
+      │  └─ runAsync.js.map #16teii4
+      ├─ dist-es
+      │  ├─ _virtual
+      │  │  ├─ _rollupPluginBabelHelpers.js #14tvdhd
+      │  │  └─ _rollupPluginBabelHelpers.js.map #4hotzf
+      │  ├─ index.js #1lz39tw
+      │  ├─ index.js.map #6hlu18
+      │  ├─ runAsync.js #17jkvoa
+      │  └─ runAsync.js.map #u7wk4r
+      ├─ dist-types
+      │  ├─ index.d.ts #12l2tmi
+      │  └─ runAsync.d.ts #1iek7az
+      └─ package.json"
+    `);
+  });
+
+  it.each(['main', 'module', 'typings'])(
+    'THEN validates the typings file exists: %s',
+    async (key: keyof ModularPackageJson) => {
+      const packageJson = (await fs.readJSON(
+        path.join(modularRoot, 'dist', 'sample-async-package', 'package.json'),
+      )) as ModularPackageJson;
+      const value = packageJson[key] as string;
+      expect(
+        fs
+          .statSync(
+            path.join(modularRoot, 'dist', 'sample-async-package', value),
+          )
+          .isFile(),
+      ).toEqual(true);
+    },
+  );
+});

--- a/packages/modular-scripts/src/__tests__/build.test.ts
+++ b/packages/modular-scripts/src/__tests__/build.test.ts
@@ -6,7 +6,6 @@ import path from 'path';
 import fs from 'fs-extra';
 
 import getModularRoot from '../utils/getModularRoot';
-import { ModularPackageJson } from '../utils/isModularType';
 
 const rimraf = promisify(_rimraf);
 
@@ -100,16 +99,16 @@ describe('WHEN building with preserve modules', () => {
       │  │  └─ _rollupPluginBabelHelpers.js.map #1a6wdsa
       │  ├─ index.js #sb8xfb
       │  ├─ index.js.map #r9dxe
-      │  ├─ runAsync.js #66wsvj
-      │  └─ runAsync.js.map #16teii4
+      │  ├─ runAsync.js #1vge02m
+      │  └─ runAsync.js.map #1thrwz0
       ├─ dist-es
       │  ├─ _virtual
       │  │  ├─ _rollupPluginBabelHelpers.js #14tvdhd
       │  │  └─ _rollupPluginBabelHelpers.js.map #4hotzf
       │  ├─ index.js #1lz39tw
       │  ├─ index.js.map #6hlu18
-      │  ├─ runAsync.js #17jkvoa
-      │  └─ runAsync.js.map #u7wk4r
+      │  ├─ runAsync.js #1xha07g
+      │  └─ runAsync.js.map #1u7bzfv
       ├─ dist-types
       │  ├─ index.d.ts #12l2tmi
       │  └─ runAsync.d.ts #1iek7az
@@ -117,20 +116,35 @@ describe('WHEN building with preserve modules', () => {
     `);
   });
 
-  it.each(['main', 'module', 'typings'])(
-    'THEN validates the typings file exists: %s',
-    async (key: keyof ModularPackageJson) => {
-      const packageJson = (await fs.readJSON(
-        path.join(modularRoot, 'dist', 'sample-async-package', 'package.json'),
-      )) as ModularPackageJson;
-      const value = packageJson[key] as string;
-      expect(
-        fs
-          .statSync(
-            path.join(modularRoot, 'dist', 'sample-async-package', value),
-          )
-          .isFile(),
-      ).toEqual(true);
-    },
-  );
+  it('SHOULD create the correct index.js', () => {
+    expect(
+      String(
+        fs.readFileSync(
+          path.join(
+            getModularRoot(),
+            'dist',
+            'sample-async-package',
+            'dist-es',
+            'index.js',
+          ),
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('SHOULD create the correct runAsync.js', () => {
+    expect(
+      String(
+        fs.readFileSync(
+          path.join(
+            getModularRoot(),
+            'dist',
+            'sample-async-package',
+            'dist-es',
+            'runAsync.js',
+          ),
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
There's current a bug where an `import("./relativePath")` would cause builds to fail due to unfound chunks in the output from rollup. 

The fix for this is to add the files which are generated by rollup into the available files when we validate the packages which get imported.