### PR TITLE
Use non-zero exit codes to determine child process failures 

### DIFF
--- a/packages/modular-scripts/README.md
+++ b/packages/modular-scripts/README.md
@@ -56,7 +56,7 @@ It supports three flags:
 - `--prefer-offline` will prefer locally cached `node_modules` versions over
   those from your remote registry.
 - `--repo <value>` will toggle whether a new `git` repo is created and the
-  initial files commited.
+  initial files committed.
 
 ## Commands
 

--- a/packages/modular-scripts/src/utils/getAllWorkspaces.ts
+++ b/packages/modular-scripts/src/utils/getAllWorkspaces.ts
@@ -21,9 +21,9 @@ export async function getYarnWorkspaceInfo(
     cleanup: true,
   });
 
-  const { stdout, stderr } = result;
+  const { exitCode, stdout, stderr } = result;
 
-  if (stderr) {
+  if (stderr && !!exitCode) {
     logger.error(stderr);
     throw new Error(`Failed to lookup yarn workspace information`);
   }


### PR DESCRIPTION
When running node through some IDE debugging tools, `stderr` will always have content relating to the debugger connecting.

This PR therefore adds a check that the `exitCode` for the `yarnpkg` child process is non-zero when checking for a failed attempt to read yarn workspace details rather than simply the presence of content on `stderr`.

Closes #1021 1021