### PR TITLE
Export `tsconfig.json`

### DIFF
--- a/.changeset/mighty-tools-taste.md
+++ b/.changeset/mighty-tools-taste.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Export `tsconfig.json`

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -9,7 +9,8 @@
     "./jest-runner-eslint": "./jest-runner-eslint/index.js",
     "./react-scripts/scripts/build.js": "./react-scripts/scripts/build.js",
     "./react-scripts/scripts/start.js": "./react-scripts/scripts/start.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./tsconfig.json": "./tsconfig.json"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || >=15.0.0"


### PR DESCRIPTION
Allows you to extend `modular-scripts/tsconfig.json` in project `tsconfig.json`.