### PR TITLE
Add support for loading .woff font files.

### DIFF
--- a/.changeset/bright-nails-collect.md
+++ b/.changeset/bright-nails-collect.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Add support for loading .woff font files.

--- a/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
@@ -42,6 +42,9 @@ export default function createEsbuildConfig(
       '.jpeg': 'file',
       '.png': 'file',
       '.webp': 'file',
+
+      // font file format loaders
+      '.woff': 'file',
       '.ttf': 'file',
 
       // enable JSX in js files


### PR DESCRIPTION
Internally noted - `.woff` font files are not supported by `esbuild` out of the box. 