### PR TITLE
Add missing dependencies required for esbuild-scripts.

### DIFF
--- a/.changeset/lemon-rules-provide.md
+++ b/.changeset/lemon-rules-provide.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Add missing dependencies required for esbuild-scripts.

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -109,6 +109,7 @@
     "strip-ansi": "6.0.0",
     "style-loader": "1.3.0",
     "terser-webpack-plugin": "4.2.3",
+    "tmp": "^0.2.1",
     "ts-jest": "26.5.6",
     "ts-pnp": "1.2.0",
     "update-notifier": "5.1.0",
@@ -116,7 +117,8 @@
     "webpack": "4.46.0",
     "webpack-dev-server": "3.11.2",
     "webpack-manifest-plugin": "2.2.0",
-    "workbox-webpack-plugin": "5.1.4"
+    "workbox-webpack-plugin": "5.1.4",
+    "ws": "7.4.6"
   },
   "peerDependencies": {
     "typescript": "^4.3.5"


### PR DESCRIPTION
Tactical fix for #1031 so that all the required dependencies are in `modular-scripts` to start using the esbuild implementation. 