### PR TITLE
Fix "modular start" build failure messaging

### DIFF
--- a/packages/modular-scripts/src/esbuild-scripts/start/index.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/start/index.ts
@@ -238,20 +238,7 @@ class DevServer {
 
   private esbuildServer: () => Promise<esbuild.BuildResult> = memoize(
     async () => {
-      try {
-        await this.runEsbuild(false);
-      } catch (e) {
-        const result = e as esbuild.BuildFailure;
-        logger.log(chalk.red('Failed to compile.\n'));
-        const logs = result.errors.map(async (m) => {
-          logger.log(await formatError(m));
-        });
-
-        await Promise.all(logs);
-
-        throw new Error(`Failed to compile`);
-      }
-
+      await this.runEsbuild(false);
       // if the non-incremental succeeds then
       // we start a watching server
       return this.runEsbuild(true);

--- a/packages/modular-scripts/src/esbuild-scripts/utils/formatError.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/utils/formatError.ts
@@ -17,6 +17,6 @@ ${codeFrame(source, error.location.line, error.location.column, {
 })}
     `;
   } else {
-    return `${chalk.red('Error:')} ${error.text}`;
+    return `${chalk.red('Error:')} ${error.text}\n`;
   }
 }

--- a/packages/modular-scripts/src/esbuild-scripts/utils/formatError.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/utils/formatError.ts
@@ -17,6 +17,6 @@ ${codeFrame(source, error.location.line, error.location.column, {
 })}
     `;
   } else {
-    return `This is a bad error ... lol\n`;
+    return `${chalk.red('Error:')} ${error.text}`;
   }
 }


### PR DESCRIPTION
- Instead of `This is a bad error ... lol`, surface the error message when there is no location file
- Do not message twice when catching a build error on start, since the incremental compilation plugin and the build task will log the errors anyway