### PR TITLE
Fix runtime reload

### DIFF
--- a/packages/modular-scripts/src/esbuild-scripts/runtime/index.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/runtime/index.ts
@@ -1,21 +1,25 @@
-import ErrorOverlay from 'react-error-overlay';
+// import {
+//   setEditorHandler,
+//   startReportingRuntimeErrors,
+//   reportBuildError,
+// } from 'react-error-overlay';
 import stripAnsi from 'strip-ansi';
 
 const isFirstCompilation: Record<string, boolean> = {};
 let hasCompileErrors = false;
 
-ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
-  // Keep this sync with errorOverlayMiddleware.js
-  void fetch(
-    '/__open_editor' +
-      '?fileName=' +
-      window.encodeURIComponent(errorLocation.fileName) +
-      '&lineNumber=' +
-      window.encodeURIComponent(errorLocation.lineNumber || 1) +
-      '&colNumber=' +
-      window.encodeURIComponent(errorLocation.colNumber || 1),
-  );
-});
+// setEditorHandler(function editorHandler(errorLocation) {
+//   // Keep this sync with errorOverlayMiddleware.js
+//   void fetch(
+//     '/__open_editor' +
+//       '?fileName=' +
+//       window.encodeURIComponent(errorLocation.fileName) +
+//       '&lineNumber=' +
+//       window.encodeURIComponent(errorLocation.lineNumber || 1) +
+//       '&colNumber=' +
+//       window.encodeURIComponent(errorLocation.colNumber || 1),
+//   );
+// });
 
 function clearOutdatedErrors() {
   if (!isFirstCompilation.app) {
@@ -28,9 +32,9 @@ function clearOutdatedErrors() {
   }
 }
 
-ErrorOverlay.startReportingRuntimeErrors({
-  filename: '/index.js',
-});
+// startReportingRuntimeErrors({
+//   filename: '/index.js',
+// });
 
 const url = new URL('/_ws', window.location.href);
 url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -75,8 +79,7 @@ connection.onmessage = (m: MessageEvent) => {
     if (building) {
       clearOutdatedErrors();
     } else {
-      hasCompileErrors =
-        result && !result.errors.length && !result.warnings.length;
+      hasCompileErrors = !!(result?.errors.length || result?.warnings.length);
 
       if (!hasCompileErrors && !isFirstCompilation[name]) {
         window.location.reload();
@@ -110,7 +113,7 @@ connection.onmessage = (m: MessageEvent) => {
           }
         }
 
-        ErrorOverlay.reportBuildError(formatted.errors[0]);
+        // reportBuildError(formatted.errors[0]);
       }
     }
   }

--- a/packages/modular-scripts/src/esbuild-scripts/runtime/index.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/runtime/index.ts
@@ -1,25 +1,25 @@
-// import {
-//   setEditorHandler,
-//   startReportingRuntimeErrors,
-//   reportBuildError,
-// } from 'react-error-overlay';
+import {
+  setEditorHandler,
+  startReportingRuntimeErrors,
+  reportBuildError,
+} from 'react-error-overlay';
 import stripAnsi from 'strip-ansi';
 
 const isFirstCompilation: Record<string, boolean> = {};
 let hasCompileErrors = false;
 
-// setEditorHandler(function editorHandler(errorLocation) {
-//   // Keep this sync with errorOverlayMiddleware.js
-//   void fetch(
-//     '/__open_editor' +
-//       '?fileName=' +
-//       window.encodeURIComponent(errorLocation.fileName) +
-//       '&lineNumber=' +
-//       window.encodeURIComponent(errorLocation.lineNumber || 1) +
-//       '&colNumber=' +
-//       window.encodeURIComponent(errorLocation.colNumber || 1),
-//   );
-// });
+setEditorHandler(function editorHandler(errorLocation) {
+  // Keep this sync with errorOverlayMiddleware.js
+  void fetch(
+    '/__open_editor' +
+      '?fileName=' +
+      window.encodeURIComponent(errorLocation.fileName) +
+      '&lineNumber=' +
+      window.encodeURIComponent(errorLocation.lineNumber || 1) +
+      '&colNumber=' +
+      window.encodeURIComponent(errorLocation.colNumber || 1),
+  );
+});
 
 function clearOutdatedErrors() {
   if (!isFirstCompilation.app) {
@@ -32,9 +32,9 @@ function clearOutdatedErrors() {
   }
 }
 
-// startReportingRuntimeErrors({
-//   filename: '/index.js',
-// });
+startReportingRuntimeErrors({
+  filename: '/index.js',
+});
 
 const url = new URL('/_ws', window.location.href);
 url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -113,7 +113,7 @@ connection.onmessage = (m: MessageEvent) => {
           }
         }
 
-        // reportBuildError(formatted.errors[0]);
+        reportBuildError(formatted.errors[0]);
       }
     }
   }

--- a/packages/modular-scripts/src/esbuild-scripts/start/index.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/start/index.ts
@@ -224,7 +224,6 @@ class DevServer {
         metafile: true,
         incremental: watch,
         minify: false,
-        write: !watch,
         outdir: this.outdir,
       }),
     );

--- a/patches/react-error-overlay+6.0.9.patch
+++ b/patches/react-error-overlay+6.0.9.patch
@@ -1,9 +1,9 @@
 diff --git a/node_modules/react-error-overlay/index.d.ts b/node_modules/react-error-overlay/index.d.ts
 new file mode 100644
-index 0000000..2904a53
+index 0000000..04929fb
 --- /dev/null
 +++ b/node_modules/react-error-overlay/index.d.ts
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,20 @@
 +export type ErrorLocation = {
 +  fileName: string;
 +  lineNumber: number;
@@ -17,20 +17,10 @@ index 0000000..2904a53
 +
 +type EditorHandler = (errorLoc: ErrorLocation) => void;
 +
-+interface ErrorOverlayImpl {
-+  setEditorHandler(handler: EditorHandler | null): void,
-+  reportBuildError(error: string): void,
-+  reportRuntimeError(
-+    error: Error,
-+    options: RuntimeReportingOptions
-+  ): void,
-+  dismissBuildError(): void,
-+  startReportingRuntimeErrors(options: RuntimeReportingOptions): void,
-+  dismissRuntimeErrors(): void,
-+  stopReportingRuntimeErrors(): void,
-+}
-+
-+declare const ErrorOverlay: ErrorOverlayImpl;
-+
-+export default ErrorOverlay;
-\ No newline at end of file
++export const setEditorHandler: (handler: EditorHandler | null) => void;
++export const reportBuildError: (error: string) => void;
++export const reportRuntimeError: (error: Error, options: RuntimeReportingOptions) =>  void;
++export const dismissBuildError: () => void;
++export const startReportingRuntimeErrors: (options: RuntimeReportingOptions) => void;
++export const dismissRuntimeErrors: () => void;
++export const stopReportingRuntimeErrors: () => void;


### PR DESCRIPTION
Fix runtime reload not working in esbuild mode (page not reloading after a file save)

Done:

1. Fix a faulty condition that prevents the page from reloading on a websocket message (runtime thinks there are compile errors when there aren't).
1. Since we're serving the temporary `outDir`, always `write` when watching.
1. Fix the patched definitions of `react-error-overlay` and fix the fact that it excepts early because `default` is undefined.

This doesn't fix the integration with `react-error-overlay` that's still not working and will be tackled in another PR (it errors with `Could not get the stack frames of error: Error: "packages/app/src/App.tsx" is not in the SourceMap` instead of showing the overlay. Source maps are there).