### PR TITLE
Implement ModuleScopePluign for esbuild builds.

### DIFF
--- a/.changeset/funny-jeans-agree.md
+++ b/.changeset/funny-jeans-agree.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+Implement ModuleScopePlugin equivalent for esbuild applications.

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/foo.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/foo.ts
@@ -1,0 +1,3 @@
+export function foo(): void {
+  console.log('foo');
+}

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src/index.tsx
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src/index.tsx
@@ -1,0 +1,3 @@
+import { foo } from '../foo';
+
+foo();

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/moduleScopePlugin.test.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/moduleScopePlugin.test.ts
@@ -1,0 +1,105 @@
+import * as esbuild from 'esbuild';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import stripAnsi from 'strip-ansi';
+import * as tmp from 'tmp';
+
+import plugin from '../../esbuild-scripts/plugins/moduleScopePlugin';
+import type { Paths } from '../../utils/createPaths';
+import { formatError } from '../../esbuild-scripts/utils/formatError';
+
+const emptyDir = async (dirName: string) => {
+  await fs.emptyDir(dirName);
+};
+
+describe('WHEN running esbuild with the svgrPlugin', () => {
+  describe("WHEN there's a url import", () => {
+    let tmpDir: tmp.DirResult;
+    let result: esbuild.BuildResult;
+    let outdir: string;
+
+    beforeAll(async () => {
+      tmpDir = tmp.dirSync();
+      outdir = path.join(tmpDir.name, 'output');
+      try {
+        result = await esbuild.build({
+          entryPoints: [
+            path.join(
+              __dirname,
+              '__fixtures__',
+              'module-scope',
+              'src',
+              'index.tsx',
+            ),
+          ],
+          plugins: [
+            plugin({
+              appSrc: path.join(
+                __dirname,
+                '__fixtures__',
+                'module-scope',
+                'src',
+              ),
+            } as unknown as Paths),
+          ],
+          logLevel: 'silent',
+          outdir,
+          bundle: true,
+          splitting: true,
+          format: 'esm',
+          target: 'es2021',
+        });
+      } catch (buildError) {
+        result = buildError as esbuild.BuildResult;
+      }
+    });
+
+    afterAll(async () => {
+      await emptyDir(tmpDir.name);
+      tmpDir.removeCallback();
+    });
+
+    it('SHOULD produce no warnings', () => {
+      expect(result.warnings).toMatchInlineSnapshot(`Array []`);
+    });
+
+    it('SHOULD produce an error', async () => {
+      expect(result.errors).toHaveLength(1);
+      const error = result.errors[0];
+      const { text, ...err } = error;
+      expect(err).toMatchInlineSnapshot(`
+        Object {
+          "detail": undefined,
+          "location": Object {
+            "column": 20,
+            "file": "packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src/index.tsx",
+            "length": 8,
+            "line": 1,
+            "lineText": "import { foo } from '../foo';",
+            "namespace": "",
+            "suggestion": "",
+          },
+          "notes": Array [],
+          "pluginName": "ModuleScopePlugin",
+        }
+      `);
+      expect(stripAnsi(text)).toMatchInlineSnapshot(`
+        "You attempted to import ../foo which falls outside of the project packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src directory. 
+        Relative imports outside of packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src are not supported.
+        You can either move it inside packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src, or move it to another modular package."
+      `);
+
+      const formattedError = stripAnsi(await formatError(error));
+      expect(formattedError).toMatchInlineSnapshot(`
+        "Error:[packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src/index.tsx] You attempted to import ../foo which falls outside of the project packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src directory. 
+        Relative imports outside of packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src are not supported.
+        You can either move it inside packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/module-scope/src, or move it to another modular package.
+          
+        > 1 | import { foo } from '../foo';
+            |                    ^
+          2 | 
+            "
+      `);
+    });
+  });
+});

--- a/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
@@ -3,15 +3,21 @@ import * as path from 'path';
 import * as esbuild from 'esbuild';
 import { Paths } from '../../utils/createPaths';
 import getClientEnvironment from './getClientEnvironment';
-import svgrPlugin from '../plugins/svgr';
 import createEsbuildBrowserslistTarget from '../../utils/createEsbuildBrowserslistTarget';
 import * as logger from '../../utils/logger';
+
+import moduleScopePlugin from '../plugins/moduleScopePlugin';
+import svgrPlugin from '../plugins/svgr';
 
 export default function createEsbuildConfig(
   paths: Paths,
   config: Partial<esbuild.BuildOptions> = {},
 ): esbuild.BuildOptions {
-  const plugins: esbuild.Plugin[] = [svgrPlugin()];
+  const configPlugins = config.plugins || [];
+  const plugins: esbuild.Plugin[] = [
+    moduleScopePlugin(paths),
+    svgrPlugin(),
+  ].concat(configPlugins);
 
   const define = Object.assign(
     {},

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/moduleScopePlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/moduleScopePlugin.ts
@@ -1,0 +1,70 @@
+import chalk from 'chalk';
+import * as esbuild from 'esbuild';
+import * as path from 'path';
+import getModularRoot from '../../utils/getModularRoot';
+import type { Paths } from '../../utils/createPaths';
+
+function createPlugin(paths: Paths): esbuild.Plugin {
+  return {
+    name: 'ModuleScopePlugin',
+    setup(build) {
+      const appSrc = paths.appSrc;
+      const relativeAppSrc = path.relative(getModularRoot(), appSrc);
+      build.onResolve({ filter: /.*/, namespace: 'file' }, (args) => {
+        if (!args.importer) {
+          return {};
+        }
+
+        if (
+          // If this resolves to a node_module, we don't care what happens next
+          args.importer.indexOf('/node_modules/') !== -1 ||
+          args.importer.indexOf('\\node_modules\\') !== -1
+        ) {
+          return {};
+        }
+        const relative = path.relative(appSrc, args.importer);
+
+        if (
+          // If it's not in one of our app src or a subdirectory, not our request!
+          relative.startsWith('../') ||
+          relative.startsWith('..\\')
+        ) {
+          return {};
+        }
+
+        const requestFullPath = path.resolve(
+          path.dirname(args.importer),
+          args.path,
+        );
+        // Find path from src to the requested file
+        // Error if in a parent directory of all given appSrcs
+        const requestRelative = path.relative(appSrc, requestFullPath);
+        if (
+          requestRelative.startsWith('../') ||
+          requestRelative.startsWith('..\\')
+        ) {
+          return {
+            errors: [
+              {
+                pluginName: 'ModuleScopePlugin',
+                text: `You attempted to import ${chalk.cyan(
+                  args.path,
+                )} which falls outside of the project ${chalk.cyan(
+                  relativeAppSrc,
+                )} directory. 
+Relative imports outside of ${chalk.cyan(relativeAppSrc)} are not supported.
+You can either move it inside ${chalk.cyan(
+                  relativeAppSrc,
+                )}, or move it to another ${chalk.cyan('modular')} package.`,
+              },
+            ],
+          };
+        } else {
+          return {};
+        }
+      });
+    },
+  };
+}
+
+export default createPlugin;

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/moduleScopePlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/moduleScopePlugin.ts
@@ -12,7 +12,7 @@ function createPlugin(paths: Paths): esbuild.Plugin {
       const relativeAppSrc = path.relative(getModularRoot(), appSrc);
       build.onResolve({ filter: /.*/, namespace: 'file' }, (args) => {
         if (!args.importer) {
-          return {};
+          return;
         }
 
         if (
@@ -20,7 +20,7 @@ function createPlugin(paths: Paths): esbuild.Plugin {
           args.importer.indexOf('/node_modules/') !== -1 ||
           args.importer.indexOf('\\node_modules\\') !== -1
         ) {
-          return {};
+          return;
         }
         const relative = path.relative(appSrc, args.importer);
 
@@ -29,7 +29,7 @@ function createPlugin(paths: Paths): esbuild.Plugin {
           relative.startsWith('../') ||
           relative.startsWith('..\\')
         ) {
-          return {};
+          return;
         }
 
         const requestFullPath = path.resolve(
@@ -60,7 +60,7 @@ You can either move it inside ${chalk.cyan(
             ],
           };
         } else {
-          return {};
+          return;
         }
       });
     },

--- a/packages/modular-scripts/src/esbuild-scripts/start/index.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/start/index.ts
@@ -16,7 +16,6 @@ import getClientEnvironment, {
   ClientEnvironment,
 } from '../config/getClientEnvironment';
 
-import svgrPlugin from '../plugins/svgr';
 import incrementalCompilePlugin from '../plugins/incrementalCompile';
 import incrementalReporterPlugin from '../plugins/incrementalReporter';
 import websocketReloadPlugin from '../plugins/wsReload';
@@ -200,10 +199,7 @@ class DevServer {
   });
 
   private runEsbuild = async (watch: boolean) => {
-    const plugins: esbuild.Plugin[] = [
-      svgrPlugin(),
-      incrementalReporterPlugin(),
-    ];
+    const plugins: esbuild.Plugin[] = [incrementalReporterPlugin()];
     let resolveIntialBuild;
     if (watch) {
       const { plugin, initialBuildPromise } = incrementalCompilePlugin(


### PR DESCRIPTION
Implement the equivalent of the ModuleScopePlugin which exists for webpack builds but for esbuild code paths. Resolves any relative imports from their current location to ensure that code is contained within the `src` directory. 

See [`packages/modular-scripts/react-dev-utils/ModuleScopePlugin.js`](https://github.com/jpmorganchase/modular/blob/main/packages/modular-scripts/react-dev-utils/ModuleScopePlugin.js) for the original implementation