### PR TITLE
Terminate websocket server when shutting down

### DIFF
--- a/.changeset/fair-apples-warn.md
+++ b/.changeset/fair-apples-warn.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": patch
+---
+
+Fix esbuild start hanging when ctrl-c is pressed to terminate it, due to oustanding ws connection with the browser.

--- a/packages/modular-scripts/src/esbuild-scripts/start/index.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/start/index.ts
@@ -153,6 +153,7 @@ class DevServer {
   shutdown = async () => {
     if (this.started) {
       this.server?.close();
+      this.ws.getWss().close();
     }
     const esbuildServer = await this.esbuildServer();
     esbuildServer?.stop?.();


### PR DESCRIPTION
Esbuild start hangs after a ctrl-c because the websocket server is not stopped. This PR fixes the issue.