### PR TITLE
Web Worker support for esbuild flow

### DIFF
--- a/.changeset/fifty-goats-shave.md
+++ b/.changeset/fifty-goats-shave.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": minor
+---
+
+Web Worker support and docs for esbuild.

--- a/docs/building-apps/index.md
+++ b/docs/building-apps/index.md
@@ -1,0 +1,7 @@
+---
+has_children: true
+title: Building your Apps
+nav_order: 500
+---
+
+# Building your Apps

--- a/docs/building-apps/web workers.md
+++ b/docs/building-apps/web workers.md
@@ -1,0 +1,51 @@
+---
+parent: Building your Apps
+title: Adding web workers
+---
+
+esbuild {: .label .label-yellow }
+
+It is possible to add
+[web workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers)
+to your application just by writing them as normal typescript modules. There are
+some rules to follow to write a worker:
+
+- Your worker module must follow the `<filename>.worker.[ts|js|jsx|tsx]` name
+  pattern for Modular to build it as a worker.
+- Worker extension must be explicitly included in the import statement for the
+  typechecker to correctly type it. `import Worker from './my.worker.ts'` is ok,
+  `import Worker from './my.worker'` is not.
+- A worker can only `import` other modules. Trying to `import` files that have a
+  different extension than `[ts|js|jsx|tsx]` will trigger a build error.
+- If a worker doesn't `import` any other module, it should `export {}` or
+  `export default {}` to avoid being marked as global module by the type
+  checker.
+
+Importing a worker will return a `Class` that, when instantiated, returns a
+worker instance. For example:
+
+```ts
+// ./index.ts
+import DateFormatterCls from './worker/dateFormatter.worker.ts';
+
+// Instantiate the worker
+const worker = new DateFormatterCls();
+
+worker.current.onmessage = (message) =>
+  console.log('Received a message from worker', message.data);
+worker.postMessage(new Date.now());
+```
+
+```ts
+// ./worker/dateFormatter.worker.ts
+import { wait, format } from '../utils/date-utils';
+// These imports are allowed because they refer to other modules
+
+globalThis.self.onmessage = async (message: { data: number }) => {
+  postMessage(`Hello there. Processing date...`);
+  // Simulate work
+  await wait(500);
+  // Send back the formatter date
+  postMessage(`Date is: ${format(message.data)}`);
+};
+```

--- a/packages/modular-scripts/react-app-env.d.ts
+++ b/packages/modular-scripts/react-app-env.d.ts
@@ -11,8 +11,11 @@ declare namespace NodeJS {
   }
 }
 
-declare module '*.worker' {
-  class WebWorkerClass extends Worker {}
+declare module '*.worker.ts' {
+  class WebWorkerClass extends Worker {
+    constructor();
+  }
+
   export default WebWorkerClass;
 }
 

--- a/packages/modular-scripts/react-app-env.d.ts
+++ b/packages/modular-scripts/react-app-env.d.ts
@@ -11,6 +11,11 @@ declare namespace NodeJS {
   }
 }
 
+declare module '*.worker' {
+  class WebWorkerClass extends Worker {}
+  export default WebWorkerClass;
+}
+
 declare module '*.avif' {
   const src: string;
   export default src;

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
@@ -1,3 +1,3 @@
-self.postMessage("I'm alive!");
+globalThis.self.postMessage("I'm alive!");
 
 export {};

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
@@ -1,0 +1,1 @@
+self.postMessage('I\'m alive!');

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
@@ -1,1 +1,3 @@
-self.postMessage('I\'m alive!');
+self.postMessage("I'm alive!");
+
+export {};

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/index.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/index.ts
@@ -1,4 +1,4 @@
-import WorkerCls from 'worker-loader:./alive.worker.ts';
+import WorkerCls from './alive.worker.ts';
 
 const worker = new WorkerCls();
 

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/index.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/index.ts
@@ -1,4 +1,4 @@
-import WorkerCls from './alive.worker.ts';
+import WorkerCls from 'worker-loader:./alive.worker.ts';
 
 const worker = new WorkerCls();
 

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/index.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/index.ts
@@ -1,0 +1,7 @@
+import WorkerCls from './alive.worker';
+
+const worker = new WorkerCls();
+
+worker.addEventListener('message', (event) => {
+    console.log(`Received message from worker: ${event.data}`)
+});

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/index.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/index.ts
@@ -1,7 +1,7 @@
-import WorkerCls from './alive.worker';
+import WorkerCls from './alive.worker.ts';
 
 const worker = new WorkerCls();
 
-worker.addEventListener('message', (event) => {
-    console.log(`Received message from worker: ${event.data}`)
+worker.addEventListener('message', (event: MessageEvent<string>) => {
+  console.log(`Received message from worker: ${event.data}`);
 });

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
@@ -10,7 +10,7 @@ exports[`WHEN running esbuild with the workerFactoryPlugin WHEN there's a url im
 "// worker-url:packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.js
 var alive_worker_default = \\"./alive.worker-T4TLN6IN.js\\";
 
-// web-worker:/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.js
+// web-worker:./packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.js
 var workerPath = new URL(alive_worker_default, import.meta.url);
 var importSrc = 'import \\"' + workerPath + '\\";';
 var blob = new Blob([importSrc], {

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WHEN running esbuild with the workerFactoryPlugin WHEN there's a url import SHOULD ouput the correct alive.worker-MLBJYZMX.ts 1`] = `
+exports[`WHEN running esbuild with the workerFactoryPlugin WHEN there's a url import SHOULD ouput the correct alive.worker-[hash].ts file 1`] = `
 "// packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
 globalThis.self.postMessage(\\"I'm alive!\\");
 "

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WHEN running esbuild with the svgrPlugin WHEN there's a url import SHOULD ouput the correct alive.worker-MLBJYZMX.ts 1`] = `
+"// packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
+self.postMessage(\\"I'm alive!\\");
+"
+`;
+
+exports[`WHEN running esbuild with the svgrPlugin WHEN there's a url import SHOULD ouput the correct index.js 1`] = `
+"// worker-url:packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
+var alive_worker_default = \\"./alive.worker-MLBJYZMX.ts\\";
+
+// web-worker:/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
+var workerPath = new URL(alive_worker_default, import.meta.url);
+var importSrc = 'import \\"' + workerPath + '\\";';
+var blob = new Blob([importSrc], {
+  type: \\"text/javascript\\"
+});
+var alive_worker_default2 = class {
+  constructor() {
+    return new Worker(URL.createObjectURL(blob), { type: \\"module\\" });
+  }
+};
+
+// packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/index.ts
+var worker = new alive_worker_default2();
+worker.addEventListener(\\"message\\", (event) => {
+  console.log(\`Received message from worker: \${event.data}\`);
+});
+"
+`;

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WHEN running esbuild with the svgrPlugin WHEN there's a url import SHOULD ouput the correct alive.worker-MLBJYZMX.ts 1`] = `
+exports[`WHEN running esbuild with the workerFactoryPlugin WHEN there's a url import SHOULD ouput the correct alive.worker-MLBJYZMX.ts 1`] = `
 "// packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
-self.postMessage(\\"I'm alive!\\");
+globalThis.self.postMessage(\\"I'm alive!\\");
 "
 `;
 
-exports[`WHEN running esbuild with the svgrPlugin WHEN there's a url import SHOULD ouput the correct index.js 1`] = `
-"// worker-url:packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
-var alive_worker_default = \\"./alive.worker-MLBJYZMX.ts\\";
+exports[`WHEN running esbuild with the workerFactoryPlugin WHEN there's a url import SHOULD ouput the correct index.js 1`] = `
+"// worker-url:packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.js
+var alive_worker_default = \\"./alive.worker-T4TLN6IN.js\\";
 
-// web-worker:/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.ts
+// web-worker:/packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.js
 var workerPath = new URL(alive_worker_default, import.meta.url);
 var importSrc = 'import \\"' + workerPath + '\\";';
 var blob = new Blob([importSrc], {

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/__snapshots__/workerPlugin.test.ts.snap
@@ -10,7 +10,7 @@ exports[`WHEN running esbuild with the workerFactoryPlugin WHEN there's a url im
 "// worker-url:packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.js
 var alive_worker_default = \\"./alive.worker-T4TLN6IN.js\\";
 
-// web-worker:./packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.js
+// web-worker:packages/modular-scripts/src/__tests__/esbuild-scripts/__fixtures__/worker-plugin/alive.worker.js
 var workerPath = new URL(alive_worker_default, import.meta.url);
 var importSrc = 'import \\"' + workerPath + '\\";';
 var blob = new Blob([importSrc], {

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
@@ -43,7 +43,7 @@ describe('WHEN running esbuild with the workerFactoryPlugin', () => {
       expect(tree(outdir)).toMatchInlineSnapshot(`
         "output
         ├─ alive.worker-T4TLN6IN.js #y0mybi
-        └─ index.js #wd8ozp"
+        └─ index.js #1kx9oa0"
       `);
     });
 

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
@@ -6,10 +6,6 @@ import tree from 'tree-view-for-tests';
 import webworkerPlugin from '../../esbuild-scripts/plugins/workerFactoryPlugin';
 import getModularRoot from '../../utils/getModularRoot';
 
-const emptyDir = async (dirName: string) => {
-  await fs.emptyDir(dirName);
-};
-
 describe('WHEN running esbuild with the workerFactoryPlugin', () => {
   describe("WHEN there's a url import", () => {
     let tmpDir: tmp.DirResult;
@@ -34,7 +30,7 @@ describe('WHEN running esbuild with the workerFactoryPlugin', () => {
     });
 
     afterAll(async () => {
-      await emptyDir(tmpDir.name);
+      await fs.emptyDir(tmpDir.name);
       tmpDir.removeCallback();
     });
 
@@ -57,7 +53,7 @@ describe('WHEN running esbuild with the workerFactoryPlugin', () => {
       expect(content).toMatchSnapshot();
     });
 
-    it('SHOULD ouput the correct alive.worker-MLBJYZMX.ts', () => {
+    it('SHOULD ouput the correct alive.worker-[hash].ts file', () => {
       let content = String(
         fs.readFileSync(path.join(outdir, 'alive.worker-T4TLN6IN.js')),
       );

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
@@ -10,7 +10,7 @@ const emptyDir = async (dirName: string) => {
   await fs.emptyDir(dirName);
 };
 
-describe('WHEN running esbuild with the svgrPlugin', () => {
+describe('WHEN running esbuild with the workerFactoryPlugin', () => {
   describe("WHEN there's a url import", () => {
     let tmpDir: tmp.DirResult;
     let result: esbuild.BuildResult;
@@ -46,8 +46,8 @@ describe('WHEN running esbuild with the svgrPlugin', () => {
     it('SHOULD have the correct output structure', () => {
       expect(tree(outdir)).toMatchInlineSnapshot(`
         "output
-        ├─ alive.worker-MLBJYZMX.ts #1qkw5er
-        └─ index.js #co48du"
+        ├─ alive.worker-T4TLN6IN.js #y0mybi
+        └─ index.js #18u9kun"
       `);
     });
 
@@ -59,7 +59,7 @@ describe('WHEN running esbuild with the svgrPlugin', () => {
 
     it('SHOULD ouput the correct alive.worker-MLBJYZMX.ts', () => {
       let content = String(
-        fs.readFileSync(path.join(outdir, 'alive.worker-MLBJYZMX.ts')),
+        fs.readFileSync(path.join(outdir, 'alive.worker-T4TLN6IN.js')),
       );
       content = content.replaceAll(getModularRoot(), '');
       expect(content).toMatchSnapshot();

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
@@ -1,0 +1,68 @@
+import * as esbuild from 'esbuild';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as tmp from 'tmp';
+import tree from 'tree-view-for-tests';
+import webworkerPlugin from '../../esbuild-scripts/plugins/workerFactoryPlugin';
+import getModularRoot from '../../utils/getModularRoot';
+
+const emptyDir = async (dirName: string) => {
+  await fs.emptyDir(dirName);
+};
+
+describe('WHEN running esbuild with the svgrPlugin', () => {
+  describe("WHEN there's a url import", () => {
+    let tmpDir: tmp.DirResult;
+    let result: esbuild.BuildResult;
+    let outdir: string;
+
+    beforeAll(async () => {
+      tmpDir = tmp.dirSync();
+      outdir = path.join(tmpDir.name, 'output');
+      result = await esbuild.build({
+        entryPoints: [
+          path.join(__dirname, '__fixtures__', 'worker-plugin', 'index.ts'),
+        ],
+        plugins: [webworkerPlugin()],
+        outdir,
+        sourceRoot: getModularRoot(),
+        bundle: true,
+        splitting: true,
+        format: 'esm',
+        target: 'es2021',
+      });
+    });
+
+    afterAll(async () => {
+      await emptyDir(tmpDir.name);
+      tmpDir.removeCallback();
+    });
+
+    it('SHOULD be successful', () => {
+      expect(result.errors).toEqual([]);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('SHOULD have the correct output structure', () => {
+      expect(tree(outdir)).toMatchInlineSnapshot(`
+        "output
+        ├─ alive.worker-MLBJYZMX.ts #1qkw5er
+        └─ index.js #co48du"
+      `);
+    });
+
+    it('SHOULD ouput the correct index.js', () => {
+      let content = String(fs.readFileSync(path.join(outdir, 'index.js')));
+      content = content.replaceAll(getModularRoot(), '');
+      expect(content).toMatchSnapshot();
+    });
+
+    it('SHOULD ouput the correct alive.worker-MLBJYZMX.ts', () => {
+      let content = String(
+        fs.readFileSync(path.join(outdir, 'alive.worker-MLBJYZMX.ts')),
+      );
+      content = content.replaceAll(getModularRoot(), '');
+      expect(content).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
+++ b/packages/modular-scripts/src/__tests__/esbuild-scripts/workerPlugin.test.ts
@@ -47,7 +47,7 @@ describe('WHEN running esbuild with the workerFactoryPlugin', () => {
       expect(tree(outdir)).toMatchInlineSnapshot(`
         "output
         ├─ alive.worker-T4TLN6IN.js #y0mybi
-        └─ index.js #18u9kun"
+        └─ index.js #wd8ozp"
       `);
     });
 

--- a/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
@@ -15,10 +15,11 @@ export default function createEsbuildConfig(
   config: Partial<esbuild.BuildOptions> = {},
 ): esbuild.BuildOptions {
   const { plugins: configPlugins, ...partialConfig } = config;
+  const targetDirectory = partialConfig.outdir ?? paths.appBuild;
   const plugins: esbuild.Plugin[] = [
     moduleScopePlugin(paths),
     svgrPlugin(),
-    workerFactoryPlugin(paths),
+    workerFactoryPlugin(paths, targetDirectory),
   ].concat(configPlugins || []);
 
   const define = Object.assign(

--- a/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
@@ -8,6 +8,7 @@ import * as logger from '../../utils/logger';
 
 import moduleScopePlugin from '../plugins/moduleScopePlugin';
 import svgrPlugin from '../plugins/svgr';
+import workerFactoryPlugin from '../plugins/workerFactoryPlugin';
 
 export default function createEsbuildConfig(
   paths: Paths,
@@ -17,6 +18,7 @@ export default function createEsbuildConfig(
   const plugins: esbuild.Plugin[] = [
     moduleScopePlugin(paths),
     svgrPlugin(),
+    workerFactoryPlugin(paths),
   ].concat(configPlugins || []);
 
   const define = Object.assign(

--- a/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
@@ -15,11 +15,11 @@ export default function createEsbuildConfig(
   config: Partial<esbuild.BuildOptions> = {},
 ): esbuild.BuildOptions {
   const { plugins: configPlugins, ...partialConfig } = config;
-  const targetDirectory = partialConfig.outdir ?? paths.appBuild;
+
   const plugins: esbuild.Plugin[] = [
     moduleScopePlugin(paths),
     svgrPlugin(),
-    workerFactoryPlugin(paths, targetDirectory),
+    workerFactoryPlugin(),
   ].concat(configPlugins || []);
 
   const define = Object.assign(

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
@@ -1,0 +1,30 @@
+import * as esbuild from 'esbuild';
+import * as path from 'path';
+
+// This plugin resolves all the files in the project and excepts if one of the extensions is not in the allow list
+// Please note that implicit (empty) extensions in the importer are always valid.
+
+function createExtensionAllowlistPlugin(
+  allowedExtensions = ['.js', '.jsx', '.ts', '.tsx'],
+): esbuild.Plugin {
+  return {
+    name: 'worker-factory-plugin',
+    setup(build) {
+      // No lookbehind in Go regexp; need to look at all the files and do the check manually.
+      build.onResolve({ filter: /.*/ }, (args) => {
+        // Extract the extension; if not in the allow list, throw.
+        const extension = path.extname(args.path);
+        if (extension && !allowedExtensions.includes(extension)) {
+          throw new Error(
+            `Extension "${extension}" not allowed in web worker ${
+              args.importer
+            }. Permitted extensions are ${JSON.stringify(allowedExtensions)}`,
+          );
+        }
+        return undefined;
+      });
+    },
+  };
+}
+
+export default createExtensionAllowlistPlugin;

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
@@ -4,27 +4,47 @@ import * as path from 'path';
 // This plugin resolves all the files in the project and excepts if one of the extensions is not in the allow list
 // Please note that implicit (empty) extensions in the importer are always valid.
 
-function createExtensionAllowlistPlugin(
+interface ExtensionPluginConf {
+  allowedExtensions?: string[];
+  reason?: string;
+}
+type PluginData = Pick<esbuild.OnResolveArgs, 'importer'>;
+
+function createExtensionAllowlistPlugin({
+  reason,
   allowedExtensions = ['.js', '.jsx', '.ts', '.tsx'],
-): esbuild.Plugin {
+}: ExtensionPluginConf): esbuild.Plugin {
   return {
-    name: 'worker-factory-plugin',
+    name: 'extension-allow-list-plugin',
     setup(build) {
       // No lookbehind in Go regexp; need to look at all the files and do the check manually.
-      build.onLoad({ filter: /.*/ }, (args) => {
+      build.onResolve({ filter: /.*/ }, (args) => {
         // Extract the extension; if not in the allow list, throw.
         const extension = path.extname(args.path);
-        if (!allowedExtensions.includes(extension)) {
-          throw new Error(
-            `Extension for file "${
-              args.path
-            }" not allowed. Permitted extensions are ${JSON.stringify(
-              allowedExtensions,
-            )}`,
-          );
+        if (extension && !allowedExtensions.includes(extension)) {
+          return {
+            namespace: 'extension-not-allowed-error',
+            pluginData: { importer: args.importer },
+            path: args.path,
+          };
         }
         return undefined;
       });
+
+      build.onLoad(
+        { filter: /.*/, namespace: 'extension-not-allowed-error' },
+        (args) => {
+          const pluginData = args.pluginData as PluginData;
+          const errorReason = reason ? ` Reason: ${reason}` : '';
+          throw new Error(
+            `Extension for file "${args.path}", imported by "${
+              pluginData.importer
+            }" not allowed. Permitted extensions are ${JSON.stringify(
+              allowedExtensions,
+            )}.${errorReason}`,
+          );
+        },
+      );
     },
   };
 }

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
@@ -11,14 +11,16 @@ function createExtensionAllowlistPlugin(
     name: 'worker-factory-plugin',
     setup(build) {
       // No lookbehind in Go regexp; need to look at all the files and do the check manually.
-      build.onResolve({ filter: /.*/ }, (args) => {
+      build.onLoad({ filter: /.*/ }, (args) => {
         // Extract the extension; if not in the allow list, throw.
         const extension = path.extname(args.path);
-        if (extension && !allowedExtensions.includes(extension)) {
+        if (!allowedExtensions.includes(extension)) {
           throw new Error(
-            `Extension "${extension}" not allowed in web worker ${
-              args.importer
-            }. Permitted extensions are ${JSON.stringify(allowedExtensions)}`,
+            `Extension for file "${
+              args.path
+            }" not allowed in web worker. Permitted extensions are ${JSON.stringify(
+              allowedExtensions,
+            )}`,
           );
         }
         return undefined;

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
@@ -18,7 +18,7 @@ function createExtensionAllowlistPlugin(
           throw new Error(
             `Extension for file "${
               args.path
-            }" not allowed in web worker. Permitted extensions are ${JSON.stringify(
+            }" not allowed. Permitted extensions are ${JSON.stringify(
               allowedExtensions,
             )}`,
           );

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/extensionAllowList.ts
@@ -18,7 +18,7 @@ function createExtensionAllowlistPlugin({
     setup(build) {
       // No lookbehind in Go regexp; need to look at all the files and do the check manually.
       build.onResolve({ filter: /.*/ }, (args) => {
-        // Extract the extension; if not in the allow list, throw.
+        // Extract the extension; if not in the allow list, return an error.
         const extension = path.extname(args.path);
         if (extension && !allowedExtensions.includes(extension)) {
           const errorReason = reason ? ` Reason: ${reason}` : '';
@@ -29,7 +29,7 @@ function createExtensionAllowlistPlugin({
                 text: `Extension not allowed`,
                 detail: `Extension for file "${args.path}", imported by "${
                   args.importer
-                }" not allowed. Permitted extensions are ${JSON.stringify(
+                }", is not allowed. Permitted extensions are: ${JSON.stringify(
                   allowedExtensions,
                 )}.${errorReason}`,
               },

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
@@ -88,6 +88,7 @@ function createPlugin(): esbuild.Plugin {
 
       build.onLoad({ filter: /.*/, namespace: 'worker-url' }, (args) => {
         const result = workerBuildCache.get(args.path);
+        workerBuildCache.delete(args.path);
         if (result) {
           const { outputFiles } = result;
           if (outputFiles?.length === 1) {

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
@@ -3,13 +3,13 @@ import type { Paths } from '../../utils/createPaths';
 import path from 'path';
 
 /* This plugin builds workers on the fly and exports them like worker-loader for Webpack 4: https://v4.webpack.js.org/loaders/worker-loader/
-  The workers are not inlined, a new file is generated in the bundle. Only files with the *.worker.* pattern are matched.
+   The workers are not inlined, a new file is generated in the bundle. Only files with the *.worker.* pattern are matched.
    This will be deprecated in the future when esbuild supports the Worker signature: see https://github.com/evanw/esbuild/issues/312
    And will probably end up being compatible with Webpack 5 support https://webpack.js.org/guides/web-workers */
 
 type WorkerLoadArgs = Pick<esbuild.OnResolveArgs, 'importer'>;
 
-function createPlugin(paths: Paths): esbuild.Plugin {
+function createPlugin(paths: Paths, targetPath: string): esbuild.Plugin {
   const plugin: esbuild.Plugin = {
     name: 'worker-factory-plugin',
     setup(build) {
@@ -31,7 +31,7 @@ function createPlugin(paths: Paths): esbuild.Plugin {
         const outFileName = path.basename(workerPath).replace(/\.ts$/, '.js');
 
         const outFilePath = path.join(
-          paths.appBuild,
+          targetPath,
           relativeImporterDir,
           importedPath,
           outFileName,
@@ -46,6 +46,7 @@ function createPlugin(paths: Paths): esbuild.Plugin {
           workerPath,
           outFileName,
           outFilePath,
+          targetPath,
         });
 
         // Bundle as if it was a separate entry point, preserving directory structure.

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
@@ -36,10 +36,12 @@ function createPlugin(): esbuild.Plugin {
         // TODO pass the same build params here.
         try {
           const result = await esbuild.build({
+            format: build.initialOptions.format,
+            target: build.initialOptions.target,
+            define: build.initialOptions.define,
             entryPoints: [args.path],
             bundle: true,
             write: false,
-            format: 'esm',
           });
 
           workerFactory.set(relativePath, result);
@@ -101,7 +103,7 @@ function createPlugin(): esbuild.Plugin {
 }
 
 // Resolve worker against an array of possible extension,
-// since require.serolve.extensions is deprecated.
+// since require.resolve.extensions is deprecated.
 // This is asynchronous to not block the esbuild pipeline.
 
 async function resolveWorker(

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
@@ -1,6 +1,7 @@
 import * as esbuild from 'esbuild';
 import * as path from 'path';
 import getModularRoot from '../../utils/getModularRoot';
+import createExtensionAllowlistPlugin from './extensionAllowList';
 
 // This plugin builds Web Workers on the fly and exports them to use like worker-loader for Webpack 4: https://v4.webpack.js.org/loaders/worker-loader/
 // The workers are not inlined, a new file is generated in the bundle. Only files *imported* with the *.worker pattern are matched.
@@ -113,29 +114,6 @@ function createPlugin(): esbuild.Plugin {
   };
 
   return plugin;
-}
-
-function createExtensionAllowlistPlugin(
-  allowedExtensions = ['.js', '.jsx', '.ts', '.tsx'],
-): esbuild.Plugin {
-  return {
-    name: 'worker-factory-plugin',
-    setup(build) {
-      // No lookbehind in Go regexp; need to look at all the files and do the check manually.
-      build.onResolve({ filter: /.*/ }, (args) => {
-        // Extract the extension; if not in the allow list, throw.
-        const extension = path.extname(args.path);
-        if (extension && !allowedExtensions.includes(extension)) {
-          throw new Error(
-            `Extension "${extension}" not allowed in web worker ${
-              args.importer
-            }. Permitted extensions are ${JSON.stringify(allowedExtensions)}`,
-          );
-        }
-        return undefined;
-      });
-    },
-  };
 }
 
 export default createPlugin;

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
@@ -1,0 +1,80 @@
+import * as esbuild from 'esbuild';
+import type { Paths } from '../../utils/createPaths';
+import path from 'path';
+
+/* This plugin builds workers on the fly and exports them like worker-loader for Webpack 4: https://v4.webpack.js.org/loaders/worker-loader/
+  The workers are not inlined, a new file is generated in the bundle. Only files with the *.worker.* pattern are matched.
+   This will be deprecated in the future when esbuild supports the Worker signature: see https://github.com/evanw/esbuild/issues/312
+   And will probably end up being compatible with Webpack 5 support https://webpack.js.org/guides/web-workers */
+
+type WorkerLoadArgs = Pick<esbuild.OnResolveArgs, 'importer'>;
+
+function createPlugin(paths: Paths): esbuild.Plugin {
+  const plugin: esbuild.Plugin = {
+    name: 'worker-factory-plugin',
+    setup(build) {
+      build.onResolve({ filter: /\.worker\./ }, (args) => {
+        return {
+          path: args.path,
+          namespace: 'web-worker',
+          pluginData: { importer: args.importer },
+        };
+      });
+
+      build.onLoad({ filter: /.*/, namespace: 'web-worker' }, async (args) => {
+        const imported = args.path;
+        const { importer } = args.pluginData as WorkerLoadArgs;
+        const importerPath = path.dirname(importer);
+        const importedPath = path.dirname(imported);
+        const relativeImporterDir = path.relative(paths.appSrc, importerPath);
+        const workerPath = path.join(importerPath, imported);
+        const outFileName = path.basename(workerPath).replace(/\.ts$/, '.js');
+
+        const outFilePath = path.join(
+          paths.appBuild,
+          relativeImporterDir,
+          importedPath,
+          outFileName,
+        );
+
+        console.log({
+          importer,
+          imported,
+          importerPath,
+          importedPath,
+          relativeImporterDir,
+          workerPath,
+          outFileName,
+          outFilePath,
+        });
+
+        // Bundle as if it was a separate entry point, preserving directory structure.
+        // TODO pass the same build params here.
+        // TODO would it be possible to cache-break this with hashes?
+        try {
+          await esbuild.build({
+            entryPoints: [workerPath],
+            outfile: outFilePath,
+            bundle: true,
+          });
+          return {
+            contents: `
+                  // Web worker bundled by worker-factory-plugin, mimicking the Worker constructor
+                  export default class {
+                    constructor() {
+                      return new Worker('${imported}');
+                    }
+                  }
+                `,
+          };
+        } catch (e) {
+          console.error('Error building worker script:', e);
+        }
+      });
+    },
+  };
+
+  return plugin;
+}
+
+export default createPlugin;

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
@@ -12,9 +12,9 @@ function createPlugin(): esbuild.Plugin {
   const plugin: esbuild.Plugin = {
     name: 'worker-factory-plugin',
     setup(build) {
-      build.onResolve({ filter: /\.worker\.(js|ts|tsx)$/ }, (args) => {
+      build.onResolve({ filter: /\.worker\.(js|jsx|ts|tsx)$/ }, (args) => {
         return {
-          path: args.path.replace(/\.ts/, '.js'),
+          path: args.path.replace(/\.[jt]sx?$/, '.js'),
           namespace: 'web-worker',
           pluginData: { importer: args.importer },
         };
@@ -40,20 +40,11 @@ function createPlugin(): esbuild.Plugin {
           return {
             contents: builtSrc,
             loader: 'file',
-            namespace: 'post-build-web-worker',
           };
         } catch (e) {
           console.error('Error building worker script:', e);
         }
       });
-
-      build.onResolve(
-        { filter: /.*/, namespace: 'post-build-web-worker' },
-        (args) => {
-          console.log('I am executed for', args);
-          return undefined;
-        },
-      );
     },
   };
 

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
@@ -46,7 +46,11 @@ function createPlugin(): esbuild.Plugin {
             define: build.initialOptions.define,
             minify: build.initialOptions.minify,
             entryPoints: [path.join(getModularRoot(), args.path)],
-            plugins: [createExtensionAllowlistPlugin()],
+            plugins: [
+              createExtensionAllowlistPlugin({
+                reason: 'Web workers can only import other modules.',
+              }),
+            ],
             bundle: true,
             write: false,
           });

--- a/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/plugins/workerFactoryPlugin.ts
@@ -1,54 +1,140 @@
 import * as esbuild from 'esbuild';
-import path from 'path';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import getModularRoot from '../../utils/getModularRoot';
 
 /* This plugin builds workers on the fly and exports them like worker-loader for Webpack 4: https://v4.webpack.js.org/loaders/worker-loader/
    The workers are not inlined, a new file is generated in the bundle. Only files with the *.worker.* pattern are matched.
    This will be deprecated in the future when esbuild supports the Worker signature: see https://github.com/evanw/esbuild/issues/312
    And will probably end up being compatible with Webpack 5 support https://webpack.js.org/guides/web-workers */
 
-type WorkerLoadArgs = Pick<esbuild.OnResolveArgs, 'importer'>;
-
 function createPlugin(): esbuild.Plugin {
   const plugin: esbuild.Plugin = {
     name: 'worker-factory-plugin',
     setup(build) {
-      build.onResolve({ filter: /\.worker\.(js|jsx|ts|tsx)$/ }, (args) => {
+      const workerFactory: Map<string, esbuild.BuildResult> = new Map();
+
+      build.onResolve({ filter: /.*\.worker$/ }, async (args) => {
+        let path: string;
+        try {
+          path = await resolveWorker(args.importer, args.path);
+        } catch (e) {
+          throw new Error(`Could not resolve ${args.path}`);
+        }
+
         return {
-          path: args.path.replace(/\.[jt]sx?$/, '.js'),
+          path,
           namespace: 'web-worker',
-          pluginData: { importer: args.importer },
         };
       });
 
       build.onLoad({ filter: /.*/, namespace: 'web-worker' }, async (args) => {
-        const imported = args.path;
-        const { importer } = args.pluginData as WorkerLoadArgs;
-        const importerPath = path.dirname(importer);
-        const workerPath = path.join(importerPath, imported);
+        console.log('WORKER - ON LOAD', args.path);
+        const relativePath = path.relative(getModularRoot(), args.path);
 
-        let buildResult: esbuild.BuildResult;
+        // Bundle as if it was a separate entry point, preserving directory structure.
+        // TODO pass the same build params here.
         try {
-          buildResult = await esbuild.build({
-            format: build.initialOptions.format,
-            target: build.initialOptions.target,
-            define: build.initialOptions.define,
-            entryPoints: [workerPath],
-            write: false,
+          const result = await esbuild.build({
+            entryPoints: [args.path],
             bundle: true,
+            write: false,
+            format: 'esm',
           });
-          const builtSrc = buildResult.outputFiles?.[0].text as string;
+
+          workerFactory.set(relativePath, result);
+
           return {
-            contents: builtSrc,
-            loader: 'file',
+            contents: `
+                  // Web worker bundled by worker-factory-plugin, mimicking the Worker constructor
+                  import workerUrl from 'worker-url:${relativePath}';
+                  
+                  const workerPath = new URL(workerUrl, import.meta.url);
+                  const importSrc = 'import "' + workerPath + '";';
+
+                  const blob = new Blob([importSrc], {
+                    type: "text/javascript",
+                  });
+
+                  export default class {
+                    constructor() {
+                      return new Worker(URL.createObjectURL(blob), { type: "module" });
+                    }
+                  }
+                `,
           };
         } catch (e) {
           console.error('Error building worker script:', e);
+        }
+      });
+
+      build.onResolve({ filter: /worker-url:.*/ }, (args) => {
+        console.log('WORKER-URL - ON RESOLVE', args.path);
+        return {
+          path: args.path.slice('worker-url:'.length),
+          namespace: 'worker-url',
+        };
+      });
+
+      build.onLoad({ filter: /.*/, namespace: 'worker-url' }, (args) => {
+        console.log('WORKER-URL - ON LOAD', args.path);
+        const result = workerFactory.get(args.path);
+        if (result) {
+          const { outputFiles } = result;
+          if (outputFiles?.length === 1) {
+            const outputFile = outputFiles[0];
+            return {
+              contents: outputFile.contents,
+              loader: 'file',
+            };
+          } else {
+            throw new Error(`Could not read output files`);
+          }
+        } else {
+          throw new Error(`Could not find result for ${args.path}`);
         }
       });
     },
   };
 
   return plugin;
+}
+
+// Resolve worker against an array of possible extension,
+// since require.serolve.extensions is deprecated.
+// This is asynchronous to not block the esbuild pipeline.
+
+async function resolveWorker(
+  importer: string,
+  imported: string,
+  validExtensions: string[] = ['.js', 'jsx', '.ts', '.tsx'],
+): Promise<string> {
+  const basefile = path.join(path.dirname(importer), imported);
+
+  const promiseList = validExtensions.map(async (ext) => {
+    const fileName = basefile + ext;
+    if (await fs.pathExists(fileName)) return fileName;
+    throw new Error('Not found');
+  });
+
+  return promiseAny<string>(promiseList);
+}
+
+// Polyfill promise.any, since Node 14 doesn't support it.
+
+async function promiseAny<T>(
+  iterable: Iterable<T | PromiseLike<T>>,
+): Promise<T> {
+  return Promise.all(
+    [...iterable].map((promise) => {
+      return new Promise((resolve, reject) => {
+        Promise.resolve(promise).then(reject, resolve);
+      });
+    }),
+  ).then(
+    (errors) => Promise.reject(errors),
+    (value) => Promise.resolve<T>(value),
+  );
 }
 
 export default createPlugin;

--- a/packages/modular-scripts/tsconfig.json
+++ b/packages/modular-scripts/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "downlevelIteration": true,
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext", "WebWorker"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13149,7 +13149,7 @@ ts-node@10.4.0:
     make-error "^1.1.1"
     yn "3.1.1"
 
-ts-pnp@1.2.0, ts-pnp@^1.1.6:
+ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==


### PR DESCRIPTION
This PR introduces an esbuild plugin which:

- Builds workers on the fly, matching them with the `worker.[jt]sx?$` pattern
- Trampolines them to work with CORS (thanks @LukeSheard)
- Emits them as separate files
- Exports a class that needs to be instantiated to start the worker
- Allow only js, ts, jsx and tsx extensions to be loaded from a worker

This plugin works similarly to [worker-loader for Webpack 4](https://v4.webpack.js.org/loaders/worker-loader/) (see below). It will probably superseded [when Esbuild supports `new Worker` as an import](https://github.com/evanw/esbuild/issues/312#issuecomment-800730525), but we will still need trampolining.

## Example

```ts
// index.ts
import HelloWorkerCls from './worker/hello.worker.ts';

const worker = new HelloWorkerCls();
workerRef.current.onmessage = (message) => console.log("Message from worker", message.data);
worker.postMessage(new Date.now());
```

```ts
// ./worker/hello.worker.ts
import { wait, format } from '../utils/date-locale';

globalThis.self.onmessage = async (message: { data: number }) => {
  postMessage(`Hello there. Processing date...`);
  // Simulate work
  await wait(500);
  postMessage(`Date is: ${format(message.data)}`);
};
```

## Caveats

- If workers don't import from other files, they need to `export {}` to not be considered global files by `isolatedModules`.