### PR TITLE
Fix typos in port and test docs

### DIFF
--- a/docs/commands/port.md
+++ b/docs/commands/port.md
@@ -7,7 +7,7 @@ title: modular port
 
 Takes a relative path from the modular root directory to the targeted
 create-react-app project and ports it over to the current modular project as a
-moudlar app.
+modular app.
 
 ```
 $ modular port ../another-react-app

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -5,7 +5,7 @@ title: modular test
 
 # `modular test`
 
-`test` is an opionated wrapper around [`jest`](https://jestjs.io/) which runs
+`test` is an opinionated wrapper around [`jest`](https://jestjs.io/) which runs
 tests against the entire `modular` project. It comes with out-of-the-box
 configuration and opinionation.
 


### PR DESCRIPTION
Fixes some trivial typos in the `port.md` and `test.md` documents.