### PR TITLE
Restrict typescript range

### DIFF
--- a/.changeset/cold-hounds-worry.md
+++ b/.changeset/cold-hounds-worry.md
@@ -1,0 +1,5 @@
+---
+"create-modular-react-app": patch
+---
+
+Restrict typescript range for better compatibility with typescript-eslint

--- a/packages/create-modular-react-app/src/index.ts
+++ b/packages/create-modular-react-app/src/index.ts
@@ -142,7 +142,7 @@ export default async function createModularApp(argv: {
       'prettier',
       'modular-scripts',
       'eslint-config-modular-app',
-      'typescript@^4.1.2',
+      'typescript@>=4.2.1 <4.5.0',
     ],
     newModularRoot,
     // We can't pass a stream here if it's not backed by a fd. We need to set it to 'pipe', then pipe it from the ChildProcess to our transformer


### PR DESCRIPTION
We have two problems with the typescript version in the template:

1. it does not play well with modular lint, because we use eslint 4.33.0, which is compatible only with <4.5.0
1. it does not exclude typescript 4.5.0 - 4.5.2, which seems to have a bug that makes our svg definitions throw (while this doesn't happen with 4.4.4 and 4.5.3) - noticed by @cangarugula today.

The solution is to restrict the range to exclude >= 4.5.0, but we must remember to exclude 4.5.0 - 4.5.2 when [we finally bump eslint](https://github.com/jpmorganchase/modular/pull/1161) and it finally can consequently bump `@typescript-eslint/typescript-estree` to be compatible with typescript <4.6.0.