### PR TITLE
Bump Typescript, @typescript-eslint, eslint-plugin-jest, eslint-plugin-testing-library and update tests and definitions

### DIFF
--- a/.changeset/twenty-cameras-develop.md
+++ b/.changeset/twenty-cameras-develop.md
@@ -1,0 +1,9 @@
+---
+"create-modular-react-app": major
+"eslint-config-modular-app": major
+"modular-scripts": major
+"modular-site": patch
+"modular-views.macro": patch
+---
+
+Bump Typescript, @typescript-eslint, eslint-plugin-jest, eslint-plugin-testing-library and update tests and definitions

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "semver": "7.3.5",
     "string.prototype.replaceall": "^1.0.6",
     "ts-node": "10.4.0",
-    "typescript": "4.4.4"
+    "typescript": "4.5.4"
   },
   "resolutions": {
     "esbuild": "0.14.2",

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -307,7 +307,7 @@ describe('create-modular-react-app', () => {
       name: destination,
       repo: false,
     });
-    expect(fs.existsSync(path.join(destination, '.git'))).toEqual(false);
+    expect(fs.existsSync(path.join(destination, '.git'))).toBe(false);
   });
   it('should create a project prefer offline without git metadata', async () => {
     await createModularApp({
@@ -315,6 +315,6 @@ describe('create-modular-react-app', () => {
       repo: false,
       preferOffline: true,
     });
-    expect(fs.existsSync(path.join(destination, '.git'))).toEqual(false);
+    expect(fs.existsSync(path.join(destination, '.git'))).toBe(false);
   });
 });

--- a/packages/create-modular-react-app/src/index.ts
+++ b/packages/create-modular-react-app/src/index.ts
@@ -142,7 +142,7 @@ export default async function createModularApp(argv: {
       'prettier',
       'modular-scripts',
       'eslint-config-modular-app',
-      'typescript@^4.1.2',
+      'typescript@^4.5.4',
     ],
     newModularRoot,
     // We can't pass a stream here if it's not backed by a fd. We need to set it to 'pipe', then pipe it from the ChildProcess to our transformer

--- a/packages/eslint-config-modular-app/package.json
+++ b/packages/eslint-config-modular-app/package.json
@@ -15,12 +15,12 @@
     "eslint-config-react-app": "6.0.0",
     "eslint-plugin-flowtype": "5.10.0",
     "eslint-plugin-import": "2.25.3",
-    "eslint-plugin-jest": "24.4.0",
+    "eslint-plugin-jest": "25.3.0",
     "eslint-plugin-jest-dom": "3.9.2",
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.27.0",
     "eslint-plugin-react-hooks": "4.3.0",
-    "eslint-plugin-testing-library": "4.12.4"
+    "eslint-plugin-testing-library": "5.0.1"
   },
   "peerDependencies": {
     "typescript": "^4.5.4"

--- a/packages/eslint-config-modular-app/package.json
+++ b/packages/eslint-config-modular-app/package.json
@@ -23,9 +23,9 @@
     "eslint-plugin-testing-library": "4.12.4"
   },
   "peerDependencies": {
-    "typescript": "^4.3.5"
+    "typescript": "^4.5.4"
   },
   "devDependencies": {
-    "typescript": "4.4.4"
+    "typescript": "4.5.4"
   }
 }

--- a/packages/eslint-config-modular-app/package.json
+++ b/packages/eslint-config-modular-app/package.json
@@ -8,8 +8,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "4.33.0",
-    "@typescript-eslint/parser": "4.33.0",
+    "@typescript-eslint/eslint-plugin": "5.7.0",
+    "@typescript-eslint/parser": "5.7.0",
     "@babel/eslint-parser": "7.16.3",
     "babel-eslint": "10.1.0",
     "eslint-config-react-app": "6.0.0",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -122,7 +122,7 @@
   "peerDependencies": {
     "react": "^16 || ^17",
     "react-dom": "^16 || ^17",
-    "typescript": "^4.3.5"
+    "typescript": "^4.5.4"
   },
   "files": [
     "dist-cjs",
@@ -139,6 +139,6 @@
     "@schemastore/tsconfig": "0.0.9",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "typescript": "4.4.4"
+    "typescript": "4.5.4"
   }
 }

--- a/packages/modular-scripts/src/__tests__/__fixtures__/test/InvalidTest.test.ts
+++ b/packages/modular-scripts/src/__tests__/__fixtures__/test/InvalidTest.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line jest/no-disabled-tests
 describe.skip('A failing test', () => {
   it('should fail', () => {
-    expect(true).toEqual(false);
+    expect(true).toBe(false);
   });
 });
 

--- a/packages/modular-scripts/src/__tests__/__fixtures__/test/ValidTest.test.ts
+++ b/packages/modular-scripts/src/__tests__/__fixtures__/test/ValidTest.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line jest/no-disabled-tests
 describe.skip('A passing test', () => {
   it('should pass', () => {
-    expect(true).toEqual(true);
+    expect(true).toBe(true);
   });
 });
 

--- a/packages/modular-scripts/src/__tests__/buildPackage/getPackageEntryPoints.test.ts
+++ b/packages/modular-scripts/src/__tests__/buildPackage/getPackageEntryPoints.test.ts
@@ -37,7 +37,7 @@ describe('WHEN given a package.json which is private', () => {
         name: packagePath,
         version: '1.0.0',
       }),
-    ).toEqual('src/index.ts');
+    ).toBe('src/index.ts');
   });
 
   it('SHOULD give an error if the includePrivate flag is false', () => {

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -117,7 +117,7 @@ describe('modular-scripts', () => {
         ├─ package.json
         └─ src
            ├─ __tests__
-           │  ├─ index.test.ts #1qvvmz7
+           │  ├─ index.test.ts #1t39yxy
            │  └─ mock-util.tsx #rjzbd3
            └─ index.ts #1woe74n"
       `);
@@ -131,7 +131,7 @@ describe('modular-scripts', () => {
         ├─ package.json
         └─ src
            ├─ __tests__
-           │  └─ index.test.ts #1qvvmz7
+           │  └─ index.test.ts #1t39yxy
            └─ index.ts #1woe74n"
       `);
     });
@@ -371,7 +371,7 @@ describe('modular-scripts', () => {
           fs
             .statSync(path.join(modularRoot, 'dist', 'sample-package', value))
             .isFile(),
-        ).toEqual(true);
+        ).toBe(true);
       },
     );
   });
@@ -448,7 +448,7 @@ describe('modular-scripts', () => {
               path.join(modularRoot, 'dist', 'nested-sample-package', value),
             )
             .isFile(),
-        ).toEqual(true);
+        ).toBe(true);
       },
     );
   });

--- a/packages/modular-scripts/src/__tests__/init.test.tsx
+++ b/packages/modular-scripts/src/__tests__/init.test.tsx
@@ -30,12 +30,12 @@ describe('Creating a new modular folder', () => {
   });
 
   it('should create a modular folder', async () => {
-    expect(fs.existsSync(path.join(folder, 'modular'))).toEqual(true);
+    expect(fs.existsSync(path.join(folder, 'modular'))).toBe(true);
     expect(await fs.readdir(path.join(folder, 'modular'))).toEqual([]);
   });
 
   it('should create a packages folder', async () => {
-    expect(fs.existsSync(path.join(folder, 'packages'))).toEqual(true);
+    expect(fs.existsSync(path.join(folder, 'packages'))).toBe(true);
     expect(await fs.readdir(path.join(folder, 'packages'))).toEqual([]);
   });
 

--- a/packages/modular-scripts/src/__tests__/lint.test.ts
+++ b/packages/modular-scripts/src/__tests__/lint.test.ts
@@ -76,7 +76,7 @@ describe('Modular lint', () => {
         modularLogs = (stderr as string).split('\n');
       }
       eslintLogs.forEach((el) => {
-        expect(modularLogs.find((ml) => el.includes(ml))).not.toBeUndefined();
+        expect(modularLogs.find((ml) => el.includes(ml))).toBeDefined();
       });
     });
     it('should not pass lint test', async () => {

--- a/packages/modular-scripts/src/__tests__/test.test.ts
+++ b/packages/modular-scripts/src/__tests__/test.test.ts
@@ -42,7 +42,7 @@ describe('Modular test', () => {
       try {
         await execa(
           'yarnpkg',
-          ['modular', 'test', 'test/InvalidTest.test.ts'],
+          ['modular', 'test', '--watchAll=false', 'test/InvalidTest.test.ts'],
           {
             all: true,
             cleanup: true,
@@ -51,7 +51,7 @@ describe('Modular test', () => {
       } catch (error) {
         errorNumber = (error as ExecaError).exitCode;
       }
-      expect(errorNumber).toEqual(1);
+      expect(errorNumber).toBe(1);
     });
   });
 
@@ -59,14 +59,18 @@ describe('Modular test', () => {
     it('should exit with no error', async () => {
       let errorNumber = 0;
       try {
-        await execa('yarnpkg', ['modular', 'test', 'test/ValidTest.test.ts'], {
-          all: true,
-          cleanup: true,
-        });
+        await execa(
+          'yarnpkg',
+          ['modular', 'test', '--watchAll=false', 'test/ValidTest.test.ts'],
+          {
+            all: true,
+            cleanup: true,
+          },
+        );
       } catch (error) {
         errorNumber = (error as ExecaError).exitCode;
       }
-      expect(errorNumber).toEqual(0);
+      expect(errorNumber).toBe(0);
     });
   });
 });

--- a/packages/modular-scripts/src/esbuild-scripts/start/runtime/index.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/start/runtime/index.ts
@@ -58,7 +58,7 @@ interface WebSocketMessage {
   building: boolean;
 }
 
-connection.onmessage = (m: MessageEvent) => {
+connection.onmessage = (m: MessageEvent<string>) => {
   const message = JSON.parse(m.data) as WebSocketMessage;
   const { building, result } = message;
 

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -190,7 +190,7 @@ program
     const { default: initWorkspace } = await import('./init');
     await initWorkspace(
       options.y,
-      JSON.parse(options.preferOffline),
+      JSON.parse(options.preferOffline) as boolean,
       options.verbose,
     );
   });
@@ -226,7 +226,7 @@ program
   .description(
     'Ports the react app in specified directory over into the current modular project as a modular app',
   )
-  .action(async (relativePath) => {
+  .action(async (relativePath: string) => {
     const { port } = await import('./port');
     await port(relativePath);
   });

--- a/packages/modular-scripts/src/utils/actionPreflightCheck.ts
+++ b/packages/modular-scripts/src/utils/actionPreflightCheck.ts
@@ -16,7 +16,7 @@ function actionPreflightCheck(fn: ModularAction): ModularAction {
         'Preflight check is skipped. Modular repository may be invalid.',
       );
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return fn(...args);
   };
 

--- a/packages/modular-scripts/src/utils/memoize.ts
+++ b/packages/modular-scripts/src/utils/memoize.ts
@@ -3,7 +3,7 @@
 export default function memoize<R, T extends (...args: any[]) => R>(f: T): T {
   const memory = new Map<string, R>();
 
-  const g = (...args: any[]) => {
+  const g = (...args: unknown[]) => {
     if (!memory.has(args.join())) {
       memory.set(args.join(), f(...args));
     }

--- a/packages/modular-scripts/types/package/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/types/package/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import add from '../index';
 
 test('it should add two numbers', () => {
-  expect(add(0.1, 0.2)).toEqual(0.30000000000000004);
+  expect(add(0.1, 0.2)).toBe(0.30000000000000004);
 });

--- a/packages/modular-site/src/App.tsx
+++ b/packages/modular-site/src/App.tsx
@@ -20,7 +20,7 @@ import './App.css';
 const worker = perspective.shared_worker();
 
 async function getTable(): Promise<Table> {
-  const req = fetch(superstore);
+  const req = fetch(superstore as RequestInfo);
   const resp = await req;
   const buffer = await resp.arrayBuffer();
   return worker.table(buffer);

--- a/packages/modular-site/src/__tests__/index.test.tsx
+++ b/packages/modular-site/src/__tests__/index.test.tsx
@@ -2,5 +2,5 @@
 import App from '../App';
 
 test('just a stub for now', () => {
-  expect(1 + 2).toEqual(3);
+  expect(1 + 2).toBe(3);
 });

--- a/packages/modular-views.macro/src/index.macro.ts
+++ b/packages/modular-views.macro/src/index.macro.ts
@@ -42,8 +42,8 @@ const output = execa.sync('yarnpkg', ['workspaces', 'info'], {
   cleanup: true,
 });
 
-const workspaces: Array<[string, { location: string }]> = Object.entries(
-  JSON.parse(output.stdout),
+const workspaces = Object.entries(
+  JSON.parse(output.stdout) as { location: string }[],
 );
 
 for (const [name, { location }] of workspaces) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12984,10 +12984,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
 ua-parser-js@0.7.28, ua-parser-js@^0.7.30:
   version "0.7.28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2610,7 +2610,7 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
@@ -2917,7 +2917,7 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@5.7.0":
+"@typescript-eslint/experimental-utils@5.7.0", "@typescript-eslint/experimental-utils@^5.0.0", "@typescript-eslint/experimental-utils@^5.5.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.7.0.tgz#2b1633e6613c3238036156f70c32634843ad034f"
   integrity sha512-u57eZ5FbEpzN5kSjmVrSesovWslH2ZyNPnaXQMXWgH57d5+EVHEt76W75vVuI9qKZ5BMDKNfRN+pxcPEjQjb2A==
@@ -2926,18 +2926,6 @@
     "@typescript-eslint/scope-manager" "5.7.0"
     "@typescript-eslint/types" "5.7.0"
     "@typescript-eslint/typescript-estree" "5.7.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-
-"@typescript-eslint/experimental-utils@^4.0.1", "@typescript-eslint/experimental-utils@^4.30.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
-  integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
-  dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.33.0"
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/typescript-estree" "4.33.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -2951,14 +2939,6 @@
     "@typescript-eslint/typescript-estree" "5.7.0"
     debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
-  integrity sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==
-  dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/visitor-keys" "4.33.0"
-
 "@typescript-eslint/scope-manager@5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.7.0.tgz#70adf960e5a58994ad50438ba60d98ecadd79452"
@@ -2967,28 +2947,10 @@
     "@typescript-eslint/types" "5.7.0"
     "@typescript-eslint/visitor-keys" "5.7.0"
 
-"@typescript-eslint/types@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
-  integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
-
 "@typescript-eslint/types@5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.7.0.tgz#2d4cae0105ba7d08bffa69698197a762483ebcbe"
   integrity sha512-5AeYIF5p2kAneIpnLFve8g50VyAjq7udM7ApZZ9JYjdPjkz0LvODfuSHIDUVnIuUoxafoWzpFyU7Sqbxgi79mA==
-
-"@typescript-eslint/typescript-estree@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz#0dfb51c2908f68c5c08d82aefeaf166a17c24609"
-  integrity sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==
-  dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/visitor-keys" "4.33.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@5.7.0":
   version "5.7.0"
@@ -3002,14 +2964,6 @@
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
-  integrity sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==
-  dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@5.7.0":
   version "5.7.0"
@@ -5526,7 +5480,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.3.2, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@4.3.2, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -6268,12 +6222,12 @@ eslint-plugin-jest-dom@3.9.2:
     "@testing-library/dom" "^7.28.1"
     requireindex "^1.2.0"
 
-eslint-plugin-jest@24.4.0:
-  version "24.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz#fa4b614dbd46a98b652d830377971f097bda9262"
-  integrity sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==
+eslint-plugin-jest@25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.3.0.tgz#6c04bbf13624a75684a05391a825b58e2e291950"
+  integrity sha512-79WQtuBsTN1S8Y9+7euBYwxIOia/k7ykkl9OCBHL3xuww5ecursHy/D8GCIlvzHVWv85gOkS5Kv6Sh7RxOgK1Q==
   dependencies:
-    "@typescript-eslint/experimental-utils" "^4.0.1"
+    "@typescript-eslint/experimental-utils" "^5.0.0"
 
 eslint-plugin-jsx-a11y@6.5.1:
   version "6.5.1"
@@ -6318,12 +6272,12 @@ eslint-plugin-react@7.27.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
-eslint-plugin-testing-library@4.12.4:
-  version "4.12.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-4.12.4.tgz#86b2abebeb0a6d4a2f1e5f0a515ad824bb9fa627"
-  integrity sha512-XZtoeyIZKFTiH8vhwnCaTo/mNrLHoLyufY4kkNg+clzZFeThWPjp+0QfrLam1on1k3JGwiRvoLH/V4QdBaB2oA==
+eslint-plugin-testing-library@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.1.tgz#2c963211dd6e9e7cd196a8096000f20ecf846712"
+  integrity sha512-8ZV4HbbacvOwu+adNnGpYd8E64NRcil2a11aFAbc/TZDUB/xxK2c8Z+LoeoHUbxNBGbTUdpAE4YUugxK85pcwQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "^4.30.0"
+    "@typescript-eslint/experimental-utils" "^5.5.0"
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -7198,7 +7152,7 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@11.0.4, globby@^11.0.0, globby@^11.0.1, globby@^11.0.3, globby@^11.0.4:
+globby@11.0.4, globby@^11.0.0, globby@^11.0.1, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2903,21 +2903,33 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
-  integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
+"@typescript-eslint/eslint-plugin@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.7.0.tgz#12d54709f8ea1da99a01d8a992cd0474ad0f0aa9"
+  integrity sha512-8RTGBpNn5a9M628wBPrCbJ+v3YTEOE2qeZb7TDkGKTDXSj36KGRg92SpFFaR/0S3rSXQxM0Og/kV9EyadsYSBg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.33.0"
-    "@typescript-eslint/scope-manager" "4.33.0"
-    debug "^4.3.1"
+    "@typescript-eslint/experimental-utils" "5.7.0"
+    "@typescript-eslint/scope-manager" "5.7.0"
+    debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
     ignore "^5.1.8"
-    regexpp "^3.1.0"
+    regexpp "^3.2.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.33.0", "@typescript-eslint/experimental-utils@^4.0.1", "@typescript-eslint/experimental-utils@^4.30.0":
+"@typescript-eslint/experimental-utils@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.7.0.tgz#2b1633e6613c3238036156f70c32634843ad034f"
+  integrity sha512-u57eZ5FbEpzN5kSjmVrSesovWslH2ZyNPnaXQMXWgH57d5+EVHEt76W75vVuI9qKZ5BMDKNfRN+pxcPEjQjb2A==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.7.0"
+    "@typescript-eslint/types" "5.7.0"
+    "@typescript-eslint/typescript-estree" "5.7.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/experimental-utils@^4.0.1", "@typescript-eslint/experimental-utils@^4.30.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
   integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
@@ -2929,15 +2941,15 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
-  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
+"@typescript-eslint/parser@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.7.0.tgz#4dca6de463d86f02d252e681136a67888ea3b181"
+  integrity sha512-m/gWCCcS4jXw6vkrPQ1BjZ1vomP01PArgzvauBqzsoZ3urLbsRChexB8/YV8z9HwE3qlJM35FxfKZ1nfP/4x8g==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.33.0"
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/typescript-estree" "4.33.0"
-    debug "^4.3.1"
+    "@typescript-eslint/scope-manager" "5.7.0"
+    "@typescript-eslint/types" "5.7.0"
+    "@typescript-eslint/typescript-estree" "5.7.0"
+    debug "^4.3.2"
 
 "@typescript-eslint/scope-manager@4.33.0":
   version "4.33.0"
@@ -2947,10 +2959,23 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
+"@typescript-eslint/scope-manager@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.7.0.tgz#70adf960e5a58994ad50438ba60d98ecadd79452"
+  integrity sha512-7mxR520DGq5F7sSSgM0HSSMJ+TFUymOeFRMfUfGFAVBv8BR+Jv1vHgAouYUvWRZeszVBJlLcc9fDdktxb5kmxA==
+  dependencies:
+    "@typescript-eslint/types" "5.7.0"
+    "@typescript-eslint/visitor-keys" "5.7.0"
+
 "@typescript-eslint/types@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
+"@typescript-eslint/types@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.7.0.tgz#2d4cae0105ba7d08bffa69698197a762483ebcbe"
+  integrity sha512-5AeYIF5p2kAneIpnLFve8g50VyAjq7udM7ApZZ9JYjdPjkz0LvODfuSHIDUVnIuUoxafoWzpFyU7Sqbxgi79mA==
 
 "@typescript-eslint/typescript-estree@4.33.0":
   version "4.33.0"
@@ -2965,6 +2990,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.7.0.tgz#968fad899050ccce4f08a40cd5fabc0798525006"
+  integrity sha512-aO1Ql+izMrTnPj5aFFlEJkpD4jRqC4Gwhygu2oHK2wfVQpmOPbyDSveJ+r/NQo+PWV43M6uEAeLVbTi09dFLhg==
+  dependencies:
+    "@typescript-eslint/types" "5.7.0"
+    "@typescript-eslint/visitor-keys" "5.7.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/visitor-keys@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
@@ -2972,6 +3010,14 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.7.0.tgz#e05164239eb7cb8aa9fa06c516ede480ce260178"
+  integrity sha512-hdohahZ4lTFcglZSJ3DGdzxQHBSxsLVqHzkiOmKi7xVAWC4y2c1bIMKmPJSrA4aOEoRUPOKQ87Y/taC7yVHpFg==
+  dependencies:
+    "@typescript-eslint/types" "5.7.0"
+    eslint-visitor-keys "^3.0.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -6319,6 +6365,11 @@ eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
+eslint-visitor-keys@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
+  integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
+
 eslint@7.32.0:
   version "7.32.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
@@ -7147,7 +7198,7 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@11.0.4, globby@^11.0.0, globby@^11.0.1, globby@^11.0.3:
+globby@11.0.4, globby@^11.0.0, globby@^11.0.1, globby@^11.0.3, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
@@ -11364,7 +11415,7 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regexpp@^3.1.0:
+regexpp@^3.1.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==


### PR DESCRIPTION
This PR supersedes https://github.com/jpmorganchase/modular/pull/1186 and https://github.com/jpmorganchase/modular/pull/1166

This PR originated from a bug noticed by @cangarugula, where our Typescript svg definitions were not working. I discovered that the problem happens only with `typescript@>4.5.0 <=4.5.2`. Additionally, I discovered that the tilde definition of our typescript dependency conflicts with `@typescript-eslint` (`yarn lint` printing warnings), now that `4.5`  is out.

There are two possible ways of fixing this: the easy one is constricting our `typescript` dependency to be strictly less than `4.5.0` and dealing with excluding the faulty versions later (https://github.com/jpmorganchase/modular/pull/1166/files). The longer one is to upgrade typescript, force it to be greater or equal to than `4.5.3` to exclude the faulty versions and update all the incompatible dependencies (this PR).

This PR updates:
- `@typescript-eslint` to the latest version + fixes many `any` definitions that are not allowed any more
- `eslint-plugin-jest, eslint-plugin-testing-library` to the latest version + fixes test expectations to align with it (eg `toEqual` becomes `toBe` etc)

This is breaking, since we're bumping `modular-scripts` to use a stricter linter that can break builds and tests.