### PR TITLE
Build views as apps

### DIFF
--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@babel/code-frame": "7.16.7",
+    "@purtuga/esm-webpack-plugin": "1.5.0",
     "@rollup/plugin-babel": "5.3.0",
     "@rollup/plugin-commonjs": "21.0.1",
     "@rollup/plugin-json": "4.1.0",

--- a/packages/modular-scripts/react-scripts/config/webpack.config.js
+++ b/packages/modular-scripts/react-scripts/config/webpack.config.js
@@ -35,15 +35,8 @@ const esbuildTargetFactory = process.env.ESBUILD_TARGET_FACTORY
 
 const appPackageJson = require(paths.appPackageJson);
 
-// Are we building an app or a view?
 const isApp = process.env.MODULAR_PACKAGE_TYPE === 'app';
-
-// If we are building a view and MODULAR_EXTERNAL_VIEW_DEPENDENCIES is not "bundle",
-// take the dependencies from MODULAR_PACKAGE_DEPENDENCIES to use them as externals
-const externals =
-  !isApp && process.env.MODULAR_EXTERNAL_VIEW_DEPENDENCIES !== 'bundle'
-    ? JSON.parse(process.env.MODULAR_PACKAGE_DEPENDENCIES)
-    : [];
+const externals = JSON.parse(process.env.MODULAR_PACKAGE_EXTERNAL_DEPENDENCIES);
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';

--- a/packages/modular-scripts/react-scripts/config/webpack.config.js
+++ b/packages/modular-scripts/react-scripts/config/webpack.config.js
@@ -293,9 +293,11 @@ module.exports = function (webpackEnv) {
       // Keep the runtime chunk separated to enable long term caching
       // https://twitter.com/wSokra/status/969679223278505985
       // https://github.com/facebook/create-react-app/issues/5358
-      runtimeChunk: {
-        name: (entrypoint) => `runtime-${entrypoint.name}`,
-      },
+      runtimeChunk: isApp
+        ? {
+            name: (entrypoint) => `runtime-${entrypoint.name}`,
+          }
+        : undefined,
     },
     resolve: {
       // This allows you to set a fallback for where webpack should look for modules.

--- a/packages/modular-scripts/react-scripts/config/webpack.config.js
+++ b/packages/modular-scripts/react-scripts/config/webpack.config.js
@@ -35,8 +35,15 @@ const esbuildTargetFactory = process.env.ESBUILD_TARGET_FACTORY
 
 const appPackageJson = require(paths.appPackageJson);
 
-// TODO maybe there's a better way to do this
+// Are we building an app or a view?
 const isApp = process.env.MODULAR_PACKAGE_TYPE === 'app';
+
+// If we are building a view and MODULAR_EXTERNAL_VIEW_DEPENDENCIES is not "bundle",
+// take the dependencies from MODULAR_PACKAGE_DEPENDENCIES to use them as externals
+const externals =
+  !isApp && process.env.MODULAR_EXTERNAL_VIEW_DEPENDENCIES !== 'bundle'
+    ? JSON.parse(process.env.MODULAR_PACKAGE_DEPENDENCIES)
+    : [];
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
@@ -146,6 +153,7 @@ module.exports = function (webpackEnv) {
 
   const webpackConfig = {
     mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
+    externals,
     // Stop compilation early in production
     bail: isEnvProduction,
     devtool: isEnvProduction

--- a/packages/modular-scripts/react-scripts/config/webpack.config.js
+++ b/packages/modular-scripts/react-scripts/config/webpack.config.js
@@ -52,8 +52,6 @@ const reactRefreshOverlayEntry = require.resolve(
 // makes for a smoother build process.
 const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 
-console.log({ shouldInlineRuntimeChunk });
-
 const imageInlineSizeLimit = parseInt(
   process.env.IMAGE_INLINE_SIZE_LIMIT || '10000',
 );
@@ -189,7 +187,9 @@ module.exports = function (webpackEnv) {
       // There will be one main bundle, and one file per asynchronous chunk.
       // In development, it does not produce real files.
       filename: isEnvProduction
-        ? 'static/js/[name].[contenthash:8].js'
+        ? isApp
+          ? 'static/js/[name].[contenthash:8].js'
+          : 'static/js/[name].js' // This will create "main.js" for the unchunked view bundle.
         : isEnvDevelopment && 'static/js/bundle.js',
       // TODO: remove this when upgrading to webpack 5
       futureEmitAssets: true,
@@ -286,10 +286,12 @@ module.exports = function (webpackEnv) {
       // Automatically split vendor and commons
       // https://twitter.com/wSokra/status/969633336732905474
       // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-      splitChunks: {
-        chunks: 'all',
-        name: isEnvDevelopment,
-      },
+      splitChunks: isApp
+        ? {
+            chunks: 'all',
+            name: isEnvDevelopment,
+          }
+        : undefined,
       // Keep the runtime chunk separated to enable long term caching
       // https://twitter.com/wSokra/status/969679223278505985
       // https://github.com/facebook/create-react-app/issues/5358

--- a/packages/modular-scripts/react-scripts/scripts/build.js
+++ b/packages/modular-scripts/react-scripts/scripts/build.js
@@ -18,6 +18,8 @@ const formatWebpackMessages = require('../../react-dev-utils/formatWebpackMessag
 const printBuildError = require('../../react-dev-utils/printBuildError');
 const { log } = require('../../react-dev-utils/logger');
 
+console.log(process.env.MODULAR_PACKAGE_TYPE);
+
 const compiler = webpack(configFactory('production'));
 
 compiler.run(async (err, stats) => {

--- a/packages/modular-scripts/react-scripts/scripts/build.js
+++ b/packages/modular-scripts/react-scripts/scripts/build.js
@@ -18,8 +18,6 @@ const formatWebpackMessages = require('../../react-dev-utils/formatWebpackMessag
 const printBuildError = require('../../react-dev-utils/printBuildError');
 const { log } = require('../../react-dev-utils/logger');
 
-console.log(process.env.MODULAR_PACKAGE_TYPE);
-
 const compiler = webpack(configFactory('production'));
 
 compiler.run(async (err, stats) => {

--- a/packages/modular-scripts/src/build/index.ts
+++ b/packages/modular-scripts/src/build/index.ts
@@ -54,8 +54,6 @@ async function buildAppOrView(
 
   const paths = await createPaths(target);
 
-  console.log(paths);
-
   await checkBrowsers(targetDirectory);
 
   let previousFileSizes: Record<string, number>;
@@ -85,6 +83,9 @@ async function buildAppOrView(
   }
 
   let assets: Asset[];
+  // Retrieve dependencies for target to inform the build process
+  const packageDependencies = await getPackageDependencies(target);
+  console.log({ packageDependencies });
 
   if (isEsbuild) {
     const { default: buildEsbuildApp } = await import(
@@ -113,6 +114,9 @@ async function buildAppOrView(
         MODULAR_PACKAGE: target,
         MODULAR_PACKAGE_NAME: targetName,
         MODULAR_PACKAGE_TYPE: type,
+        MODULAR_PACKAGE_DEPENDENCIES: JSON.stringify(
+          Object.keys(packageDependencies),
+        ),
       },
     });
 
@@ -140,7 +144,6 @@ async function buildAppOrView(
   }
 
   // Add dependencies from source and bundled dependencies to target package.json
-  const packageDependencies = await getPackageDependencies(target);
   const targetPackageJson = (await fs.readJSON(
     path.join(targetDirectory, 'package.json'),
   )) as CoreProperties;

--- a/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
@@ -13,8 +13,10 @@ import workerFactoryPlugin from '../plugins/workerFactoryPlugin';
 export default function createEsbuildConfig(
   paths: Paths,
   config: Partial<esbuild.BuildOptions> = {},
+  type: 'app' | 'view' = 'app',
 ): esbuild.BuildOptions {
   const { plugins: configPlugins, ...partialConfig } = config;
+  const isApp = type === 'app';
 
   const plugins: esbuild.Plugin[] = [
     moduleScopePlugin(paths),
@@ -65,7 +67,7 @@ export default function createEsbuildConfig(
     color: !isCi,
     define,
     metafile: true,
-    tsconfig: paths.appTsConfig,
+    tsconfig: isApp ? paths.appTsConfig : undefined,
     minify: true,
     outbase: paths.modularRoot,
     absWorkingDir: paths.modularRoot,

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -5,6 +5,7 @@ import type { CoreProperties } from '@schemastore/package';
 import getModularRoot from './getModularRoot';
 import getLocation from './getLocation';
 import getWorkspaceInfo from './getWorkspaceInfo';
+import memoize from './memoize';
 
 type DependencyManifest = NonNullable<CoreProperties['dependencies']>;
 
@@ -37,47 +38,49 @@ function getDependenciesFromSource(workspaceLocation: string) {
   return Array.from(dependencySet);
 }
 
-export async function getPackageDependencies(
-  target: string,
-): Promise<DependencyManifest> {
-  /* This function is based on the assumption that nested package are not supported, so dependencies can be either declared in the
-   * target's package.json or hoisted up to the workspace root.
-   */
-  const targetLocation = await getLocation(target);
-  const workspaceInfo = getWorkspaceInfo();
+export const getPackageDependencies = memoize(
+  async function getPackageDependencies(
+    target: string,
+  ): Promise<DependencyManifest> {
+    /* This function is based on the assumption that nested package are not supported, so dependencies can be either declared in the
+     * target's package.json or hoisted up to the workspace root.
+     */
+    const targetLocation = await getLocation(target);
+    const workspaceInfo = getWorkspaceInfo();
 
-  const rootPackageJsonDependencies =
-    (
-      fs.readJSONSync(
-        path.join(getModularRoot(), 'package.json'),
-      ) as CoreProperties
-    ).dependencies || {};
+    const rootPackageJsonDependencies =
+      (
+        fs.readJSONSync(
+          path.join(getModularRoot(), 'package.json'),
+        ) as CoreProperties
+      ).dependencies || {};
 
-  const targetPackageJsonDependencies =
-    (
-      fs.readJSONSync(
-        path.join(targetLocation, 'package.json'),
-      ) as CoreProperties
-    ).dependencies || {};
+    const targetPackageJsonDependencies =
+      (
+        fs.readJSONSync(
+          path.join(targetLocation, 'package.json'),
+        ) as CoreProperties
+      ).dependencies || {};
 
-  /* Get regular dependencies from package.json (regular) or root package.json (hoisted)
-   * Exclude workspace dependencies. Error if a dependency is imported in the source code
-   * but not specified in any of the package.jsons
-   */
-  const manifest = getDependenciesFromSource(targetLocation)
-    .filter((depName) => !(depName in workspaceInfo))
-    .reduce<DependencyManifest>((manifest, depName) => {
-      const depVersion =
-        targetPackageJsonDependencies[depName] ??
-        rootPackageJsonDependencies[depName];
-      if (!depVersion) {
-        throw new Error(
-          `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies`,
-        );
-      }
-      manifest[depName] = depVersion;
-      return manifest;
-    }, {});
+    /* Get regular dependencies from package.json (regular) or root package.json (hoisted)
+     * Exclude workspace dependencies. Error if a dependency is imported in the source code
+     * but not specified in any of the package.jsons
+     */
+    const manifest = getDependenciesFromSource(targetLocation)
+      .filter((depName) => !(depName in workspaceInfo))
+      .reduce<DependencyManifest>((manifest, depName) => {
+        const depVersion =
+          targetPackageJsonDependencies[depName] ??
+          rootPackageJsonDependencies[depName];
+        if (!depVersion) {
+          throw new Error(
+            `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies`,
+          );
+        }
+        manifest[depName] = depVersion;
+        return manifest;
+      }, {});
 
-  return manifest;
-}
+    return manifest;
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,6 +1869,13 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@purtuga/esm-webpack-plugin@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@purtuga/esm-webpack-plugin/-/esm-webpack-plugin-1.5.0.tgz#0a01e769ed2e668f9463dfeedb1003cffd845ff5"
+  integrity sha512-v4kKOCQHqS2H8yjlbJBm6km+4Urd21M0uvO5MAMQ7GmqEf745fkQeB4iiPAVUeXxDbB833i5ctv93WGH4mwQLQ==
+  dependencies:
+    webpack-sources "^1.0.0"
+
 "@rollup/plugin-babel@5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"
@@ -13276,7 +13283,7 @@ webpack-manifest-plugin@2.2.0:
     object.entries "^1.1.0"
     tapable "^1.0.0"
 
-webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
+webpack-sources@^1.0.0, webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==


### PR DESCRIPTION
This ⚠️  early stage ⚠️  PR addresses https://github.com/jpmorganchase/modular/discussions/1311

- [ ] `build` command for views uses (slightly adapted) Webpack / Esbuild configuration for apps.
- [ ] all dependencies are externalised by default
- [ ] it is possible to bundle the dependencies (with the newly-introduced `MODULAR_EXTERNAL_VIEW_DEPENDENCIES='bundle'` flag)
- [ ] `bundledDependencies` is populated correctly in the output package manifest
- [ ] output bundle has a predictable name
- [ ] `start` command works for views
- [ ] dynamic imports in views are correctly handled
- [ ] assets (css, images, possibly workers) in views are correctly handled (how? should we inline everything or leave routing to the consumer?)
- [ ] double entry point, aka views generate a "library" entry point that must be imported and a "index" entry point that can be embedded directly into an iframe / html file