### PR TITLE
Remove init commit after create-modular-react-app runs

### DIFF
--- a/.changeset/cool-ravens-listen.md
+++ b/.changeset/cool-ravens-listen.md
@@ -1,0 +1,7 @@
+---
+'create-modular-react-app': patch
+'modular-scripts': patch
+---
+
+Removed initial git commit of create-modular-react-app and upgraded node
+versions in modular-scripts

--- a/packages/create-modular-react-app/src/index.ts
+++ b/packages/create-modular-react-app/src/index.ts
@@ -196,11 +196,6 @@ export default async function createModularApp(argv: {
 
   if (argv.repo) {
     await exec('git', ['add', '.'], newModularRoot);
-
-    // don't try to commit in CI
-    if (!process.env.CI) {
-      await exec('git', ['commit', '-m', 'Initial commit'], newModularRoot);
-    }
   }
 
   return Promise.resolve();

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -13,7 +13,7 @@
     "./tsconfig.json": "./tsconfig.json"
   },
   "engines": {
-    "node": "^12.13.0 || ^14.15.0 || >=15.0.0"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "scripts": {
     "modular": "ts-node src/cli.ts",


### PR DESCRIPTION
Removing the git commit message of "Initial Commit" after project has been scaffolded. This still stages the files, but doesn't commit them to give the developer greater control over their work.