### PR TITLE
Relax our dependency criteria

### DIFF
--- a/.changeset/twenty-clouds-invite.md
+++ b/.changeset/twenty-clouds-invite.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": patch
+---
+
+Relax our dependency discovery criteria to include dev dependencies and just warn when a dependency is not found.

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -74,7 +74,7 @@ export async function getPackageDependencies(
         rootPackageJsonDevDependencies[depName];
       if (!depVersion) {
         logger.error(
-          `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies`,
+          `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from continuing in the next release of modular`,
         );
       }
       manifest[depName] = depVersion;

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -74,7 +74,7 @@ export async function getPackageDependencies(
         rootPackageJsonDevDependencies[depName];
       if (!depVersion) {
         logger.error(
-          `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from continuing in the next release of modular`,
+          `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move packages in the next release of modular`,
         );
       }
       manifest[depName] = depVersion;

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -55,10 +55,12 @@ export async function getPackageDependencies(
     path.join(targetLocation, 'package.json'),
   ) as CoreProperties;
 
-  const rootPackageJsonDependencies = rootManifest.dependencies || {};
-  const targetPackageJsonDependencies = targetManifest.dependencies || {};
-  const rootPackageJsonDevDependencies = rootManifest.devDependencies || {};
-  const targetPackageJsonDevDependencies = targetManifest.devDependencies || {};
+  const deps = {
+    ...rootManifest.dependencies,
+    ...targetManifest.dependencies,
+    ...rootManifest.devDependencies,
+    ...targetManifest.devDependencies,
+  };
 
   /* Get regular dependencies from package.json (regular) or root package.json (hoisted)
    * Exclude workspace dependencies. Error if a dependency is imported in the source code
@@ -67,11 +69,7 @@ export async function getPackageDependencies(
   const manifest = getDependenciesFromSource(targetLocation)
     .filter((depName) => !(depName in workspaceInfo))
     .reduce<DependencyManifest>((manifest, depName) => {
-      const depVersion =
-        targetPackageJsonDependencies[depName] ??
-        rootPackageJsonDependencies[depName] ??
-        targetPackageJsonDevDependencies[depName] ??
-        rootPackageJsonDevDependencies[depName];
+      const depVersion = deps[depName];
       if (!depVersion) {
         logger.error(
           `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move packages in the next release of modular`,

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { Project } from 'ts-morph';
-import type { CoreProperties } from '@schemastore/package';
+import type { CoreProperties, Dependency } from '@schemastore/package';
 import getModularRoot from './getModularRoot';
 import getLocation from './getLocation';
 import getWorkspaceInfo from './getWorkspaceInfo';
@@ -55,12 +55,13 @@ export async function getPackageDependencies(
     path.join(targetLocation, 'package.json'),
   ) as CoreProperties;
 
-  const deps = {
-    ...rootManifest.dependencies,
-    ...targetManifest.dependencies,
-    ...rootManifest.devDependencies,
-    ...targetManifest.devDependencies,
-  };
+  const deps = Object.assign(
+    Object.create(null),
+    targetManifest.devDependencies,
+    rootManifest.devDependencies,
+    targetManifest.dependencies,
+    rootManifest.dependencies,
+  ) as Dependency;
 
   /* Get regular dependencies from package.json (regular) or root package.json (hoisted)
    * Exclude workspace dependencies. Error if a dependency is imported in the source code


### PR DESCRIPTION
- Allow devDependencies to be in the dependency manifest
- Prevent throwing when generating the manifest if there are transitive deps, show a warning that this will be an error in next major