### PR TITLE
Fix bug that prevents lint diff code from running

### DIFF
--- a/.changeset/twelve-days-mix.md
+++ b/.changeset/twelve-days-mix.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Fix bug that prevented lint diff from running

--- a/packages/modular-scripts/src/lint.ts
+++ b/packages/modular-scripts/src/lint.ts
@@ -23,7 +23,7 @@ async function lint(
   const lintExtensions = ['.ts', '.tsx', '.js', '.jsx'];
   let targetedFiles = ['<rootDir>/**/src/**/*.{js,jsx,ts,tsx}'];
 
-  if (!all && !isCI && !regexes) {
+  if (!all && !isCI && regexes.length === 0) {
     const diffedFiles = getDiffedFiles();
     if (diffedFiles.length === 0) {
       logger.log(


### PR DESCRIPTION
It seems that the intended functionality is that if `modular lint` is run without '--all', in a non-ci environment, and without any file regex parameters, then the 'diff' code will be executed and only the changed files between the default branch and the current branch will be linted.

Currently however, the check for these conditions is faulty and the diff code is never executed.

This is due to a bug on line 26 / line 19, where on line 19 `regexes` is set to an empty array by default and never has the opportunity to be [`falsy`](https://developer.mozilla.org/en-US/docs/Glossary/Falsy). Then on line 26, it checks whether `regexes` is `falsy` before proceeding with the diff code.

My proposed change is that instead of checking whether `regexes` is `falsy`, it should check that the `regexes` array is empty since it can never be `falsy`.

Further reading about default parameters: [TypeScript Docs](https://www.typescriptlang.org/docs/handbook/2/functions.html#optional-parameters).