### PR TITLE
[BREAKING/v3] Exclude node builtins from build

### DIFF
--- a/.changeset/odd-ants-appear.md
+++ b/.changeset/odd-ants-appear.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": major
+---
+
+Exclude node builtins from build

--- a/packages/modular-scripts/react-scripts/config/webpack.config.js
+++ b/packages/modular-scripts/react-scripts/config/webpack.config.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const resolve = require('resolve');
+const builtinModules = require('builtin-modules');
 const PnpWebpackPlugin = require('pnp-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
@@ -632,16 +633,10 @@ module.exports = function (webpackEnv) {
     ].filter(Boolean),
     // Some libraries import Node modules but don't use them in the browser.
     // Tell webpack to provide empty mocks for them so importing them works.
-    node: {
-      module: 'empty',
-      dgram: 'empty',
-      dns: 'mock',
-      fs: 'empty',
-      http2: 'empty',
-      net: 'empty',
-      tls: 'empty',
-      child_process: 'empty',
-    },
+    node: builtinModules.reduce((acc, next) => {
+      acc[next] = false;
+      return acc;
+    }, {}),
     // Turn off performance processing because we utilize
     // our own hints via the FileSizeReporter
     performance: false,

--- a/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
+++ b/packages/modular-scripts/src/esbuild-scripts/config/createEsbuildConfig.ts
@@ -1,6 +1,7 @@
 import isCi from 'is-ci';
 import * as path from 'path';
 import * as esbuild from 'esbuild';
+import builtinModules from 'builtin-modules';
 import type { Paths } from '../../utils/createPaths';
 import getClientEnvironment from './getClientEnvironment';
 import createEsbuildBrowserslistTarget from '../../utils/createEsbuildBrowserslistTarget';
@@ -33,6 +34,11 @@ export default function createEsbuildConfig(
   const target = createEsbuildBrowserslistTarget(paths.appPath);
 
   logger.debug(`Using target: ${target.join(', ')}`);
+
+  // merge and de-duplicate node builtins with external in the parameters
+  const external = [
+    ...new Set((partialConfig.external ?? []).concat(builtinModules)),
+  ];
 
   return {
     entryPoints: [paths.appIndexJs],
@@ -72,5 +78,7 @@ export default function createEsbuildConfig(
     publicPath: paths.publicUrlOrPath,
     nodePaths: (process.env.NODE_PATH || '').split(path.delimiter),
     ...partialConfig,
+    // this was merged previously; do not override.
+    external,
   };
 }


### PR DESCRIPTION
TL;DR: exclude node builtins from build to make packages that import them but don't use them at runtime work. Works in esbuild mode and webpack mode, althought slightly differently.

---

Webpack v5 has stopped providing polyfills for imported Node builtins, as it's considered bad practice to import a "node" package in a "browser" app. [Create React App is similarly opinionated](https://github.com/facebook/create-react-app/issues/11756), and doesn't provide any polyfill or fallback. I think modular should follow this opinion, unless we get overwhelming feedback indicating the contrary.

The problem is that some third party packages that provide both browser and node implementation don't distribute it into different files ([there's a mechanism to do that](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser), but it's not widely used yet), but they expose a single file that initially `require()`s everything (built-in modules included) and decides what to use at runtime, based - I guess - on capability sniffing (`require(builtin); if (isNode) { useBuiltin() } else { useBrowseEquivalent() }`). These modules, that would normally work without polyfills, now break the build. This happens, for example, with `solclientjs` and `dotenv`.

This PR adds `fallback: false` for all the node builtins required in the build, so that they get a non-meaningful value at runtime. If they're never used, that won't make a difference, but they won't break the build. **This is breaking in respect to what modular v2 does (-> modular v2 uses webpack 4 that automatically provides polyfills)**

This PR also externalises all node builtins in esbuild mode. This is analogous to what we do in Webpack mode, with the difference that if there is an npm module with the same name as a npm builtin in the extended dependencies, it will be excluded from the build (while webpack will use the homonym npm module instead). [npm packages that are homonym to builtin packages](https://github.com/juliangruber/stream) [are a legacy residue](https://github.com/DiegoRBaquero/node-vm) and are mainly deprecated, but if they're used by any third party library, they won't work in esbuild mode. I don't know a way to provide a fallback behaviour similar to webpack with esbuild. **This is breaking in respect to what modular v2 in esbuild mode does (-> modular v2 always breaks when there is a builtin package in the build)**



