### PR TITLE
Remove CHANGELOG.md files from templates

### DIFF
--- a/.changeset/thirty-dolphins-impress.md
+++ b/.changeset/thirty-dolphins-impress.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': patch
+---
+
+Remove CHANGELOG.md files from templates when they are added to a new modular
+project.

--- a/packages/modular-scripts/src/addPackage.ts
+++ b/packages/modular-scripts/src/addPackage.ts
@@ -16,6 +16,7 @@ import LineFilterOutStream from './utils/LineFilterOutStream';
 import { ModularPackageJson } from './utils/isModularType';
 
 const packagesRoot = 'packages';
+const EXCLUDED_FILENAMES = ['changelog.md', 'package.json'];
 
 interface AddOptions {
   destination: string;
@@ -141,7 +142,7 @@ async function addPackage({
   await fs.copy(packageTypePath, newPackagePath, {
     recursive: true,
     filter(src) {
-      return !(path.basename(src) === 'package.json');
+      return !EXCLUDED_FILENAMES.includes(path.basename(src).toLowerCase());
     },
   });
 


### PR DESCRIPTION
When initializing from a default template we copy the `CHANGELOG.md` file from the template folder into the target directory which is a little bit silly. These files are included by default in `npm-packlist` so we have to manually exclude them when unpacking. 