### PR TITLE
Remove requirement to transpile to es6-module supported browsers

### DIFF
--- a/.changeset/shiny-kings-smash.md
+++ b/.changeset/shiny-kings-smash.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': major
+---
+
+Remove requirement to transpile to es6-module supported browsers in default
+browserslist configuration.

--- a/packages/modular-scripts/src/__tests__/__snapshots__/init.test.tsx.snap
+++ b/packages/modular-scripts/src/__tests__/__snapshots__/init.test.tsx.snap
@@ -13,13 +13,11 @@ Object {
   "author": "",
   "browserslist": Object {
     "development": Array [
-      "supports es6-module",
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version",
     ],
     "production": Array [
-      "supports es6-module",
       ">0.2%",
       "not dead",
       "not op_mini all",

--- a/packages/modular-scripts/src/utils/checkBrowsers.ts
+++ b/packages/modular-scripts/src/utils/checkBrowsers.ts
@@ -3,9 +3,8 @@ import chalk from 'chalk';
 import * as os from 'os';
 
 export const defaultBrowsers = {
-  production: ['supports es6-module', '>0.2%', 'not dead', 'not op_mini all'],
+  production: ['>0.2%', 'not dead', 'not op_mini all'],
   development: [
-    'supports es6-module',
     'last 1 chrome version',
     'last 1 firefox version',
     'last 1 safari version',


### PR DESCRIPTION
Because of the limitation of `webpack` parsing in version 4 we added a `es6-modules` configuration token in the default browserslist setup of projects when running with modular. Now that we have staged out webpack 5 support we can remove this token and can target newer browsers.