### PR TITLE
Chore/replace yarnpkg with yarn

### DIFF
--- a/.changeset/gentle-bananas-fix.md
+++ b/.changeset/gentle-bananas-fix.md
@@ -1,0 +1,7 @@
+---
+'create-modular-react-app': patch
+'modular-scripts': patch
+'modular-views.macro': patch
+---
+
+Replace use of `yarnpkg` with `yarn`

--- a/packages/create-modular-react-app/src/__tests__/cli.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/cli.test.ts
@@ -9,7 +9,7 @@ describe('Creating a new modular app via the CLI', () => {
   beforeEach(async () => {
     cwd = path.join(tmp.dirSync().name, 'new-modular-app');
 
-    await execa('yarnpkg', ['create-modular-react-app', cwd], {
+    await execa('yarn', ['create-modular-react-app', cwd], {
       cwd: __dirname,
       cleanup: true,
       stderr: process.stderr,
@@ -31,7 +31,7 @@ describe('Creating a new modular app via the CLI with --empty', () => {
   beforeEach(async () => {
     cwd = path.join(tmp.dirSync().name, 'another-new-modular-app');
 
-    await execa('yarnpkg', ['create-modular-react-app', cwd, '--empty'], {
+    await execa('yarn', ['create-modular-react-app', cwd, '--empty'], {
       cwd: __dirname,
       cleanup: true,
       stderr: process.stderr,

--- a/packages/create-modular-react-app/src/__tests__/repo-integrity.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/repo-integrity.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import tmp from 'tmp';
 
 function modular(str: string, cwd: string, opts: Record<string, unknown> = {}) {
-  return execa('yarnpkg', ['modular', ...str.split(' ')], {
+  return execa('yarn', ['modular', ...str.split(' ')], {
     cwd,
     cleanup: true,
     ...opts,

--- a/packages/create-modular-react-app/src/index.ts
+++ b/packages/create-modular-react-app/src/index.ts
@@ -36,7 +36,7 @@ function exec(
 
 function isYarnInstalled(): boolean {
   try {
-    execa.sync('yarnpkg', ['-v']);
+    execa.sync('yarn', ['-v']);
     return true;
   } catch (err) {
     return false;
@@ -87,7 +87,7 @@ export default async function createModularApp(argv: {
     await exec('git', ['init'], newModularRoot);
   }
 
-  await exec('yarnpkg', ['init', '-y'], newModularRoot);
+  await exec('yarn', ['init', '-y'], newModularRoot);
 
   fs.writeJsonSync(projectPackageJsonPath, {
     ...fs.readJsonSync(projectPackageJsonPath),
@@ -123,7 +123,7 @@ export default async function createModularApp(argv: {
   });
 
   const subprocess = exec(
-    'yarnpkg',
+    'yarn',
     [
       'add',
       '-W',

--- a/packages/modular-scripts/src/__tests__/app.esbuild.test.ts
+++ b/packages/modular-scripts/src/__tests__/app.esbuild.test.ts
@@ -14,7 +14,7 @@ const modularRoot = getModularRoot();
 const packagesPath = path.join(getModularRoot(), 'packages');
 
 function modular(str: string, opts: Record<string, unknown> = {}) {
-  return execa('yarnpkg', ['modular', ...str.split(' ')], {
+  return execa('yarn', ['modular', ...str.split(' ')], {
     cwd: modularRoot,
     cleanup: true,
     // @ts-ignore
@@ -30,7 +30,7 @@ function cleanup() {
   rimraf.sync(path.join(modularRoot, 'dist/sample-esbuild-app'));
 
   // run yarn so yarn.lock gets reset
-  return execa.sync('yarnpkg', ['--silent'], {
+  return execa.sync('yarn', ['--silent'], {
     cwd: modularRoot,
   });
 }

--- a/packages/modular-scripts/src/__tests__/app.node-env.test.ts
+++ b/packages/modular-scripts/src/__tests__/app.node-env.test.ts
@@ -13,7 +13,7 @@ const modularRoot = getModularRoot();
 const packagesPath = path.join(getModularRoot(), 'packages');
 
 function modular(str: string, opts: Record<string, unknown> = {}) {
-  return execa('yarnpkg', ['modular', ...str.split(' ')], {
+  return execa('yarn', ['modular', ...str.split(' ')], {
     cwd: modularRoot,
     cleanup: true,
     ...opts,
@@ -25,7 +25,7 @@ function cleanup() {
   rimraf.sync(path.join(modularRoot, 'dist/node-env-app'));
 
   // run yarn so yarn.lock gets reset
-  return execa.sync('yarnpkg', ['--silent'], {
+  return execa.sync('yarn', ['--silent'], {
     cwd: modularRoot,
   });
 }

--- a/packages/modular-scripts/src/__tests__/app.test.ts
+++ b/packages/modular-scripts/src/__tests__/app.test.ts
@@ -27,7 +27,7 @@ const modularRoot = getModularRoot();
 const packagesPath = path.join(getModularRoot(), 'packages');
 
 function modular(str: string, opts: Record<string, unknown> = {}) {
-  return execa('yarnpkg', ['modular', ...str.split(' ')], {
+  return execa('yarn', ['modular', ...str.split(' ')], {
     cwd: modularRoot,
     cleanup: true,
     ...opts,
@@ -45,7 +45,7 @@ function cleanup() {
   rimraf.sync(path.join(modularRoot, 'dist/scoped-sample-app'));
 
   // run yarn so yarn.lock gets reset
-  return execa.sync('yarnpkg', ['--silent'], {
+  return execa.sync('yarn', ['--silent'], {
     cwd: modularRoot,
   });
 }

--- a/packages/modular-scripts/src/__tests__/esmView.test.ts
+++ b/packages/modular-scripts/src/__tests__/esmView.test.ts
@@ -29,7 +29,7 @@ const { getNodeText } = queries;
 const packagesPath = path.join(getModularRoot(), 'packages');
 
 function modular(str: string, opts: Record<string, unknown> = {}) {
-  return execa('yarnpkg', ['modular', ...str.split(' ')], {
+  return execa('yarn', ['modular', ...str.split(' ')], {
     cwd: modularRoot,
     cleanup: true,
     ...opts,
@@ -40,7 +40,7 @@ async function cleanup() {
   await rimraf(path.join(packagesPath, 'sample-esm-view'));
   await rimraf(path.join(modularRoot, 'dist/sample-esm-view'));
   // run yarn so yarn.lock gets reset
-  await execa('yarnpkg', ['--silent'], {
+  await execa('yarn', ['--silent'], {
     cwd: modularRoot,
   });
 }
@@ -271,7 +271,7 @@ describe('modular-scripts', () => {
         }),
       );
 
-      await execa('yarnpkg', [], {
+      await execa('yarn', [], {
         cwd: modularRoot,
         cleanup: true,
       });
@@ -353,7 +353,7 @@ describe('modular-scripts', () => {
         }),
       );
 
-      await execa('yarnpkg', [], {
+      await execa('yarn', [], {
         cwd: modularRoot,
         cleanup: true,
       });
@@ -429,7 +429,7 @@ describe('modular-scripts', () => {
         }),
       );
 
-      await execa('yarnpkg', [], {
+      await execa('yarn', [], {
         cwd: modularRoot,
         cleanup: true,
       });

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -28,7 +28,7 @@ const { getNodeText } = queries;
 const packagesPath = path.join(getModularRoot(), 'packages');
 
 function modular(str: string, opts: Record<string, unknown> = {}) {
-  return execa('yarnpkg', ['modular', ...str.split(' ')], {
+  return execa('yarn', ['modular', ...str.split(' ')], {
     cwd: modularRoot,
     cleanup: true,
     ...opts,
@@ -43,7 +43,7 @@ async function cleanup() {
   await rimraf(path.join(modularRoot, 'dist/sample-package'));
   await rimraf(path.join(modularRoot, 'dist/nested'));
   // run yarn so yarn.lock gets reset
-  await execa('yarnpkg', ['--silent'], {
+  await execa('yarn', ['--silent'], {
     cwd: modularRoot,
   });
 }

--- a/packages/modular-scripts/src/__tests__/lint.test.ts
+++ b/packages/modular-scripts/src/__tests__/lint.test.ts
@@ -67,7 +67,7 @@ describe('Modular lint', () => {
       }
       let modularLogs: string[] = [];
       try {
-        await execa('yarnpkg', ['modular', 'lint', '__fixtures__/lint'], {
+        await execa('yarn', ['modular', 'lint', '__fixtures__/lint'], {
           all: true,
           cleanup: true,
           cwd: modularRoot,
@@ -82,7 +82,7 @@ describe('Modular lint', () => {
     it('should not pass lint test', async () => {
       let modularLogs: string[] = [];
       try {
-        await execa('yarnpkg', ['modular', 'lint', '__fixtures__/lint'], {
+        await execa('yarn', ['modular', 'lint', '__fixtures__/lint'], {
           all: true,
           cleanup: true,
           cwd: modularRoot,
@@ -102,7 +102,7 @@ describe('Modular lint', () => {
     it('should pass the lint tests', async () => {
       const files = fs.readdirSync(path.join(fixturesFolder));
       const result = await execa(
-        'yarnpkg',
+        'yarn',
         ['modular', 'lint', '__fixtures__/lint'],
         {
           all: true,

--- a/packages/modular-scripts/src/__tests__/start-app.ts
+++ b/packages/modular-scripts/src/__tests__/start-app.ts
@@ -4,7 +4,7 @@ import getModularRoot from '../utils/getModularRoot';
 import * as logger from '../utils/logger';
 
 function modular(str: string, opts: Record<string, unknown> = {}) {
-  return execa('yarnpkg', ['modular', ...str.split(' ')], {
+  return execa('yarn', ['modular', ...str.split(' ')], {
     cwd: modularRoot,
     cleanup: true,
     ...opts,

--- a/packages/modular-scripts/src/__tests__/test.test.ts
+++ b/packages/modular-scripts/src/__tests__/test.test.ts
@@ -40,14 +40,10 @@ describe('Modular test', () => {
     it('should exit with an error', async () => {
       let errorNumber = 0;
       try {
-        await execa(
-          'yarnpkg',
-          ['modular', 'test', 'test/InvalidTest.test.ts'],
-          {
-            all: true,
-            cleanup: true,
-          },
-        );
+        await execa('yarn', ['modular', 'test', 'test/InvalidTest.test.ts'], {
+          all: true,
+          cleanup: true,
+        });
       } catch (error) {
         errorNumber = (error as ExecaError).exitCode;
       }
@@ -59,7 +55,7 @@ describe('Modular test', () => {
     it('should exit with no error', async () => {
       let errorNumber = 0;
       try {
-        await execa('yarnpkg', ['modular', 'test', 'test/ValidTest.test.ts'], {
+        await execa('yarn', ['modular', 'test', 'test/ValidTest.test.ts'], {
           all: true,
           cleanup: true,
         });

--- a/packages/modular-scripts/src/__tests__/typecheck.test.ts
+++ b/packages/modular-scripts/src/__tests__/typecheck.test.ts
@@ -49,7 +49,7 @@ describe('Modular typecheck', () => {
         }
         let modularStdErr = '';
         try {
-          await execa('yarnpkg', ['modular', 'typecheck'], {
+          await execa('yarn', ['modular', 'typecheck'], {
             all: true,
             cleanup: true,
           });
@@ -76,7 +76,7 @@ describe('Modular typecheck', () => {
         }
         let modularStdErr = '';
         try {
-          await execa('yarnpkg', ['modular', 'typecheck'], {
+          await execa('yarn', ['modular', 'typecheck'], {
             all: true,
             cleanup: true,
           });
@@ -93,7 +93,7 @@ describe('Modular typecheck', () => {
   });
   describe('when there are no type errors', () => {
     it('should print a one line success message', async () => {
-      const result = await execa('yarnpkg', ['modular', 'typecheck'], {
+      const result = await execa('yarn', ['modular', 'typecheck'], {
         all: true,
         cleanup: true,
       });

--- a/packages/modular-scripts/src/addPackage.ts
+++ b/packages/modular-scripts/src/addPackage.ts
@@ -149,7 +149,7 @@ async function addPackage({
   } catch (e) {
     logger.log('Installing package template, this may take a moment...');
     const templateInstallSubprocess = execAsync(
-      'yarnpkg',
+      'yarn',
       ['add', templateName, '--prefer-offline', '--silent', '-W'],
       {
         cwd: modularRoot,
@@ -254,7 +254,7 @@ async function addPackage({
   if (preferOffline) {
     yarnArgs.push('--prefer-offline');
   }
-  const subprocess = execAsync('yarnpkg', yarnArgs, {
+  const subprocess = execAsync('yarn', yarnArgs, {
     cwd: modularRoot,
     stderr: 'pipe',
   });

--- a/packages/modular-scripts/src/convert.ts
+++ b/packages/modular-scripts/src/convert.ts
@@ -158,7 +158,7 @@ export async function convert(cwd: string = process.cwd()): Promise<void> {
 
     logger.log('Running yarn to update dependencies');
 
-    execa.sync('yarnpkg', ['--silent', 'add', '-W', ...additionalDeps], {
+    execa.sync('yarn', ['--silent', 'add', '-W', ...additionalDeps], {
       cwd,
     });
 

--- a/packages/modular-scripts/src/init.ts
+++ b/packages/modular-scripts/src/init.ts
@@ -57,7 +57,7 @@ export async function initModularFolder(
   if (preferOffline) {
     yarnArgs.push('--prefer-offline');
   }
-  await execAsync('yarnpkg', yarnArgs, { cwd: folder });
+  await execAsync('yarn', yarnArgs, { cwd: folder });
 
   logger.log('Modular repository initialized!');
 }

--- a/packages/modular-scripts/src/port.ts
+++ b/packages/modular-scripts/src/port.ts
@@ -304,7 +304,7 @@ export async function port(relativePath: string): Promise<void> {
 
     logger.log('Installing dependencies...');
 
-    execa.sync('yarnpkg', ['--silent'], { cwd: modularRoot });
+    execa.sync('yarn', ['--silent'], { cwd: modularRoot });
 
     logger.log('Validating your modular project...');
 

--- a/packages/modular-scripts/src/rename.ts
+++ b/packages/modular-scripts/src/rename.ts
@@ -84,7 +84,7 @@ async function rename(
     );
 
     logger.log(`Refreshing packages`);
-    execa.sync('yarnpkg', ['--silent'], { cwd: getModularRoot() });
+    execa.sync('yarn', ['--silent'], { cwd: getModularRoot() });
   } catch (err) {
     logger.error(err as string);
     stashChanges();

--- a/packages/modular-scripts/src/test/utils.ts
+++ b/packages/modular-scripts/src/test/utils.ts
@@ -14,7 +14,7 @@ export function modular(
   str: string,
   opts: Record<string, unknown> = {},
 ): execa.ExecaChildProcess<string> {
-  return execa('yarnpkg', ['modular', ...str.split(' ')], {
+  return execa('yarn', ['modular', ...str.split(' ')], {
     cwd: modularRoot,
     cleanup: true,
     ...opts,
@@ -31,7 +31,7 @@ export async function cleanup(packageNames: Array<string>): Promise<void> {
   }
 
   // run yarn so yarn.lock gets reset
-  await execa('yarnpkg', ['--silent'], {
+  await execa('yarn', ['--silent'], {
     cwd: modularRoot,
   });
 }

--- a/packages/modular-scripts/src/utils/getAllWorkspaces.ts
+++ b/packages/modular-scripts/src/utils/getAllWorkspaces.ts
@@ -42,15 +42,15 @@ export interface PackageManagerInfo {
 
 const supportedPackageManagers: SupportedPackageManagers = {
   yarn1: {
-    getWorkspaceCommand: 'yarnpkg --silent workspaces info',
+    getWorkspaceCommand: 'yarn --silent workspaces info',
     formatWorkspaceCommandOutput: formatYarn1Workspace,
   },
   yarn2: {
-    getWorkspaceCommand: 'yarnpkg workspaces list --json -v',
+    getWorkspaceCommand: 'yarn workspaces list --json -v',
     formatWorkspaceCommandOutput: formatNewYarnWorkspace,
   },
   yarn3: {
-    getWorkspaceCommand: 'yarnpkg workspaces list --json -v',
+    getWorkspaceCommand: 'yarn workspaces list --json -v',
     formatWorkspaceCommandOutput: formatNewYarnWorkspace,
   },
 };
@@ -79,7 +79,7 @@ async function getCommandOutput(
 
 async function getPackageManagerInfo(cwd: string, packageManager: string) {
   if (packageManager === 'yarn') {
-    const yarnVersion = await getCommandOutput(cwd, 'yarnpkg', ['--version']);
+    const yarnVersion = await getCommandOutput(cwd, 'yarn', ['--version']);
     if (yarnVersion.startsWith('1.')) {
       return supportedPackageManagers.yarn1;
     }

--- a/packages/modular-scripts/src/utils/startupCheck.ts
+++ b/packages/modular-scripts/src/utils/startupCheck.ts
@@ -9,7 +9,7 @@ import * as semver from 'semver';
 
 async function isYarnInstalled(): Promise<boolean> {
   try {
-    await execa('yarnpkg', ['-v']);
+    await execa('yarn', ['-v']);
     return true;
   } catch (err) {
     return false;

--- a/packages/modular-views.macro/src/__tests__/index.test.ts
+++ b/packages/modular-views.macro/src/__tests__/index.test.ts
@@ -20,7 +20,7 @@ async function transform() {
 
 async function modularAddView(name: string) {
   return await execa(
-    'yarnpkg',
+    'yarn',
     `modular add ${name} --unstable-type view`.split(' '),
     {
       cleanup: true,
@@ -32,7 +32,7 @@ async function modularAddView(name: string) {
 }
 
 beforeAll(async () => {
-  await execa('yarnpkg', ['build'], {
+  await execa('yarn', ['build'], {
     cleanup: true,
     cwd: path.join(__dirname, '..', '..'),
     stderr: process.stderr,
@@ -44,7 +44,7 @@ afterAll(async () => {
   rimraf.sync(path.join(packagesPath, 'view-1'));
   rimraf.sync(path.join(packagesPath, 'view-2'));
   // run yarn so yarn.lock gets reset
-  await execa('yarnpkg', [], {
+  await execa('yarn', [], {
     cwd: modularRoot,
     stderr: process.stderr,
     stdout: process.stdout,

--- a/packages/modular-views.macro/src/index.macro.ts
+++ b/packages/modular-views.macro/src/index.macro.ts
@@ -18,10 +18,10 @@ type ModularPackageJson = PackageJson & {
 };
 
 function getWorkspaces(): Array<[string, { location: string }]> {
-  const { stdout: yarnVersion } = execa.sync('yarnpkg', ['--version']);
+  const { stdout: yarnVersion } = execa.sync('yarn', ['--version']);
 
   if (yarnVersion.startsWith('1.')) {
-    const output = execa.sync('yarnpkg', ['workspaces', 'info'], {
+    const output = execa.sync('yarn', ['workspaces', 'info'], {
       all: true,
       reject: false,
       cwd: modularRootDir,
@@ -35,7 +35,7 @@ function getWorkspaces(): Array<[string, { location: string }]> {
     return workspaces;
   }
 
-  const output = execa.sync('yarnpkg', ['workspaces', 'list', '--json'], {
+  const output = execa.sync('yarn', ['workspaces', 'list', '--json'], {
     all: true,
     reject: false,
     cwd: modularRootDir,


### PR DESCRIPTION
yarnpkg` points to `yarn` by default and `yarnpkg` itself is deprecated so we should point to yarn directly instead of pointing to `yarnpkg`