### PR TITLE
Fix package resolutions with workspace dependencies

### DIFF
--- a/.changeset/three-kings-invite.md
+++ b/.changeset/three-kings-invite.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": patch
+---
+
+Fix package resolutions for local (workspace) dependencies - this fixes the `build`, `start` and `analyze` commands when an esm-view or an app has workspace dependencies.

--- a/docs/building-apps/esm-views.md
+++ b/docs/building-apps/esm-views.md
@@ -3,7 +3,7 @@ parent: Building your Apps
 title: ESM Views
 ---
 
-modular builds packages of `"type": "esm-view"` as
+Modular builds packages of `"type": "esm-view"` as
 [ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules),
 rewriting all of a subset of their imports to make use of a configurable ESM CDN
 (e.g. [Skypack](https://www.skypack.dev) or [esm.sh](https://esm.sh/)). This
@@ -107,6 +107,9 @@ bundled. This logic can be controlled using two environment variables:
 
 The allow / block lists are parsed and processed according to this logic:
 
+- If a dependency is local to the workspace and the version specified in the
+  dependent package.json matches the verion in the dependency package.json
+  (either exactly or by wildcard), it will be bundled
 - If a dependency is only in the allow list, it will be rewritten
 - If a dependency is only in the block list, it will be bundled
 - If a dependency is in both lists, it will be bundled (`EXTERNAL_BLOCK_LIST`

--- a/docs/building-apps/esm-views.md
+++ b/docs/building-apps/esm-views.md
@@ -108,7 +108,7 @@ bundled. This logic can be controlled using two environment variables:
 The allow / block lists are parsed and processed according to this logic:
 
 - If a dependency is local to the workspace and the version specified in the
-  dependent package.json matches the verion in the dependency package.json
+  depending `package.json` matches the version in the dependency `package.json`
   (either exactly or by wildcard), it will be bundled
 - If a dependency is only in the allow list, it will be rewritten
 - If a dependency is only in the block list, it will be bundled

--- a/packages/modular-scripts/src/__tests__/partitionDependencies.test.ts
+++ b/packages/modular-scripts/src/__tests__/partitionDependencies.test.ts
@@ -14,9 +14,10 @@ describe('partitionDependencies', () => {
       const blockList = ['fake2'];
       expect(
         partitionDependencies({
-          packageDependencies: fakePkg,
+          dependencies: fakePkg,
           allowList,
           blockList,
+          workspaceInfo: {},
         }),
       ).toEqual({
         bundled: {
@@ -42,9 +43,10 @@ describe('partitionDependencies', () => {
       const blockList = ['*-typeb'];
       expect(
         partitionDependencies({
-          packageDependencies: fakePkg,
+          dependencies: fakePkg,
           allowList,
           blockList,
+          workspaceInfo: {},
         }),
       ).toEqual({
         bundled: {
@@ -65,7 +67,8 @@ describe('partitionDependencies', () => {
       };
       expect(
         partitionDependencies({
-          packageDependencies: fakePkg,
+          dependencies: fakePkg,
+          workspaceInfo: {},
         }),
       ).toEqual({
         bundled: {},

--- a/packages/modular-scripts/src/__tests__/partitionDependencies.test.ts
+++ b/packages/modular-scripts/src/__tests__/partitionDependencies.test.ts
@@ -68,11 +68,38 @@ describe('partitionDependencies', () => {
       expect(
         partitionDependencies({
           dependencies: fakePkg,
-          // TODO test this
           workspaceInfo: {},
         }),
       ).toEqual({
         bundled: {},
+        external: {
+          '@somescope/fake1': '^2.0.1',
+          '@somescope/fake2': '^1.0.1',
+        },
+      });
+    });
+    it('THEN expects workspace packages to be blocked by default', () => {
+      const fakePkg = {
+        '@somescope/fake1': '^2.0.1',
+        '@somescope/fake2': '^1.0.1',
+        '@workspacescope/my-local-pkg': '7.7.7',
+      };
+      expect(
+        partitionDependencies({
+          dependencies: fakePkg,
+          workspaceInfo: {
+            '@workspacescope/my-local-pkg': {
+              location: '',
+              version: '7.7.7',
+              type: 'esm-view',
+              workspaceDependencies: [],
+              mismatchedWorkspaceDependencies: [],
+              public: false,
+            },
+          },
+        }),
+      ).toEqual({
+        bundled: { '@workspacescope/my-local-pkg': '7.7.7' },
         external: {
           '@somescope/fake1': '^2.0.1',
           '@somescope/fake2': '^1.0.1',

--- a/packages/modular-scripts/src/__tests__/partitionDependencies.test.ts
+++ b/packages/modular-scripts/src/__tests__/partitionDependencies.test.ts
@@ -106,5 +106,86 @@ describe('partitionDependencies', () => {
         },
       });
     });
+    it('THEN expects workspace packages to be blocked with workspace versions', () => {
+      const fakePkg = {
+        '@somescope/fake1': '^2.0.1',
+        '@somescope/fake2': '^1.0.1',
+        '@workspacescope/my-local-pkg': 'workspace:^7.7.7',
+        '@workspacescope/my-other-local-pkg': 'workspace:*',
+      };
+      expect(
+        partitionDependencies({
+          dependencies: fakePkg,
+          workspaceInfo: {
+            '@workspacescope/my-local-pkg': {
+              location: '',
+              version: '7.7.12',
+              type: 'esm-view',
+              workspaceDependencies: [],
+              mismatchedWorkspaceDependencies: [],
+              public: false,
+            },
+            '@workspacescope/my-other-local-pkg': {
+              location: '',
+              version: '1.2.3',
+              type: 'esm-view',
+              workspaceDependencies: [],
+              mismatchedWorkspaceDependencies: [],
+              public: false,
+            },
+          },
+        }),
+      ).toEqual({
+        bundled: {
+          '@workspacescope/my-local-pkg': 'workspace:^7.7.7',
+          '@workspacescope/my-other-local-pkg': 'workspace:*',
+        },
+        external: {
+          '@somescope/fake1': '^2.0.1',
+          '@somescope/fake2': '^1.0.1',
+        },
+      });
+    });
+
+    it('THEN expects workspace packages to be blocked with workspace versions not satisfying semver', () => {
+      const fakePkg = {
+        '@somescope/fake1': '^2.0.1',
+        '@somescope/fake2': '^1.0.1',
+        '@workspacescope/my-local-pkg': '^7.7.7',
+        '@workspacescope/my-other-local-pkg': 'workspace:*',
+      };
+      expect(
+        partitionDependencies({
+          dependencies: fakePkg,
+          workspaceInfo: {
+            '@workspacescope/my-local-pkg': {
+              location: '',
+              version: '7.6.52',
+              type: 'esm-view',
+              workspaceDependencies: [],
+              mismatchedWorkspaceDependencies: [],
+              public: false,
+            },
+            '@workspacescope/my-other-local-pkg': {
+              location: '',
+              version: '1.2.3',
+              type: 'esm-view',
+              workspaceDependencies: [],
+              mismatchedWorkspaceDependencies: [],
+              public: false,
+            },
+          },
+        }),
+      ).toEqual({
+        bundled: {
+          '@workspacescope/my-other-local-pkg': 'workspace:*',
+        },
+        external: {
+          '@workspacescope/my-local-pkg': '^7.7.7',
+          '@somescope/fake1': '^2.0.1',
+          '@somescope/fake2': '^1.0.1',
+        },
+      });
+    });
   });
 });

--- a/packages/modular-scripts/src/__tests__/partitionDependencies.test.ts
+++ b/packages/modular-scripts/src/__tests__/partitionDependencies.test.ts
@@ -68,6 +68,7 @@ describe('partitionDependencies', () => {
       expect(
         partitionDependencies({
           dependencies: fakePkg,
+          // TODO test this
           workspaceInfo: {},
         }),
       ).toEqual({

--- a/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
@@ -7,6 +7,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": true,
     "type": "package",
+    "version": "3.0.0",
     "workspaceDependencies": Array [],
   },
   "eslint-config-modular-app": Object {
@@ -14,6 +15,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": true,
     "type": "package",
+    "version": "3.0.1",
     "workspaceDependencies": Array [],
   },
   "modular-scripts": Object {
@@ -21,6 +23,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": true,
     "type": "package",
+    "version": "3.1.1",
     "workspaceDependencies": Array [],
   },
   "modular-site": Object {
@@ -28,6 +31,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": false,
     "type": "app",
+    "version": "1.0.1",
     "workspaceDependencies": Array [],
   },
   "modular-template-app": Object {
@@ -35,6 +39,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": true,
     "type": "template",
+    "version": "1.1.0",
     "workspaceDependencies": Array [],
   },
   "modular-template-esm-view": Object {
@@ -42,6 +47,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": true,
     "type": "template",
+    "version": "1.0.0",
     "workspaceDependencies": Array [],
   },
   "modular-template-node-env-app": Object {
@@ -49,6 +55,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": false,
     "type": "template",
+    "version": "0.2.0",
     "workspaceDependencies": Array [],
   },
   "modular-template-package": Object {
@@ -56,6 +63,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": true,
     "type": "template",
+    "version": "1.1.0",
     "workspaceDependencies": Array [],
   },
   "modular-template-view": Object {
@@ -63,6 +71,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": true,
     "type": "template",
+    "version": "1.1.0",
     "workspaceDependencies": Array [],
   },
   "modular-views.macro": Object {
@@ -70,6 +79,7 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": true,
     "type": "package",
+    "version": "3.1.1",
     "workspaceDependencies": Array [],
   },
   "tree-view-for-tests": Object {
@@ -77,6 +87,15 @@ Object {
     "mismatchedWorkspaceDependencies": Array [],
     "public": false,
     "type": "package",
+    "version": "2.0.0",
+    "workspaceDependencies": Array [],
+  },
+  "view-1": Object {
+    "location": "packages/view-1",
+    "mismatchedWorkspaceDependencies": Array [],
+    "public": true,
+    "type": "view",
+    "version": "1.0.0",
     "workspaceDependencies": Array [],
   },
 }

--- a/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
@@ -90,13 +90,5 @@ Object {
     "version": "2.0.0",
     "workspaceDependencies": Array [],
   },
-  "view-1": Object {
-    "location": "packages/view-1",
-    "mismatchedWorkspaceDependencies": Array [],
-    "public": true,
-    "type": "view",
-    "version": "1.0.0",
-    "workspaceDependencies": Array [],
-  },
 }
 `;

--- a/packages/modular-scripts/src/__tests__/utils/getPackageDependencies.test.ts
+++ b/packages/modular-scripts/src/__tests__/utils/getPackageDependencies.test.ts
@@ -1,0 +1,164 @@
+import {
+  parseYarnLock,
+  resolvePackageDependencies,
+} from '../../utils/getPackageDependencies';
+
+describe('Resolve dependencies', () => {
+  it('should resolve dependencies', () => {
+    const { manifest, resolutions, manifestMiss, lockFileMiss } =
+      resolvePackageDependencies({
+        dependenciesfromSource: ['dependency-1', 'dependency-2'],
+        packageDeps: {
+          'dependency-1': '^1.1.2',
+          'dependency-2': '^2.3.4',
+          'dependency-3': '>4.5.6',
+        },
+        lockDeps: {
+          'dependency-1': '1.1.8',
+          'dependency-2': '2.4.0',
+          'dependency-3': '4.9.8',
+        },
+        workspaceInfo: {
+          'other-dependency': {
+            location: '',
+            version: '3.0.0',
+            workspaceDependencies: [],
+            mismatchedWorkspaceDependencies: [],
+            type: 'esm-view',
+            public: false,
+          },
+        },
+      });
+    expect(manifest).toEqual({
+      'dependency-1': '^1.1.2',
+      'dependency-2': '^2.3.4',
+    });
+    expect(resolutions).toEqual({
+      'dependency-1': '1.1.8',
+      'dependency-2': '2.4.0',
+    });
+    expect(lockFileMiss).toEqual([]);
+    expect(manifestMiss).toEqual([]);
+  });
+
+  it('should resolve dependencies with pacxkage and lockfile misses', () => {
+    const { manifest, resolutions, manifestMiss, lockFileMiss } =
+      resolvePackageDependencies({
+        dependenciesfromSource: [
+          'dependency-1',
+          'dependency-2',
+          'dependency-missing',
+        ],
+        packageDeps: {
+          'dependency-1': '^1.1.2',
+          'dependency-2': '^2.3.4',
+          'dependency-3': '>4.5.6',
+        },
+        lockDeps: {
+          'dependency-1': '1.1.8',
+          'dependency-2': '2.4.0',
+          'dependency-3': '4.9.8',
+        },
+        workspaceInfo: {
+          'other-dependency': {
+            location: '',
+            version: '3.0.0',
+            workspaceDependencies: [],
+            mismatchedWorkspaceDependencies: [],
+            type: 'esm-view',
+            public: false,
+          },
+        },
+      });
+    expect(manifest).toEqual({
+      'dependency-1': '^1.1.2',
+      'dependency-2': '^2.3.4',
+    });
+    expect(resolutions).toEqual({
+      'dependency-1': '1.1.8',
+      'dependency-2': '2.4.0',
+    });
+    expect(lockFileMiss).toEqual(['dependency-missing']);
+    expect(manifestMiss).toEqual(['dependency-missing']);
+  });
+});
+
+describe('Parse yarn lockfiles', () => {
+  it('should parse correctly a Yarn v3 (yaml) lockfile either', () => {
+    const yarnV3Contents = `
+__metadata:
+  version: 5
+  cacheKey: 8
+
+"yaml@npm:^1.10.0, yaml@npm:^1.10.2, yaml@npm:^1.7.2":
+  version: 1.10.2
+  resolution: "yaml@npm:1.10.2"
+  checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:20.x, yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.9":
+  version: 20.2.9
+  resolution: "yargs-parser@npm:20.2.9"
+  checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^13.1.2":
+  version: 13.1.2
+  resolution: "yargs-parser@npm:13.1.2"
+  dependencies:
+    camelcase: ^5.0.0
+    decamelize: ^1.2.0
+  checksum: c8bb6f44d39a4acd94462e96d4e85469df865de6f4326e0ab1ac23ae4a835e5dd2ddfe588317ebf80c3a7e37e741bd5cb0dc8d92bcc5812baefb7df7c885e86b
+  languageName: node
+  linkType: hard
+`;
+
+    const deps = {
+      yaml: '^1.7.2',
+      'yargs-parser': '^20.2.2',
+      'not-existing': '7.7.7',
+    };
+
+    const resolutions = parseYarnLock(yarnV3Contents, deps);
+    expect(resolutions).toEqual({
+      yaml: '1.10.2',
+      'yargs-parser': '20.2.9',
+    });
+  });
+
+  it('should parse correctly a Yarn v1 lockfile', () => {
+    const yarnV1Contents = `
+yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yargs-parser@20.x:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+`;
+
+    const deps = {
+      yaml: '^1.7.2',
+      'yargs-parser': '20.x',
+      'not-existing': '7.7.7',
+    };
+
+    const resolutions = parseYarnLock(yarnV1Contents, deps);
+    expect(resolutions).toEqual({
+      yaml: '1.10.2',
+      'yargs-parser': '20.2.9',
+    });
+  });
+});

--- a/packages/modular-scripts/src/__tests__/utils/getPackageDependencies.test.ts
+++ b/packages/modular-scripts/src/__tests__/utils/getPackageDependencies.test.ts
@@ -41,7 +41,7 @@ describe('Resolve dependencies', () => {
     expect(manifestMiss).toEqual([]);
   });
 
-  it('should resolve dependencies with pacxkage and lockfile misses', () => {
+  it('should resolve dependencies with package and lockfile misses', () => {
     const { manifest, resolutions, manifestMiss, lockFileMiss } =
       resolvePackageDependencies({
         dependenciesfromSource: [

--- a/packages/modular-scripts/src/build/index.ts
+++ b/packages/modular-scripts/src/build/index.ts
@@ -8,6 +8,7 @@ import getModularRoot from '../utils/getModularRoot';
 import actionPreflightCheck from '../utils/actionPreflightCheck';
 import { getModularType } from '../utils/isModularType';
 import { filterDependencies } from '../utils/filterDependencies';
+import getWorkspaceInfo from '../utils/getWorkspaceInfo';
 import type { ModularType } from '../utils/isModularType';
 import execAsync from '../utils/execAsync';
 import getLocation from '../utils/getLocation';
@@ -97,23 +98,37 @@ async function buildStandalone(
   // Retrieve dependencies for target to inform the build process
   const { manifest: packageDependencies, resolutions: packageResolutions } =
     await getPackageDependencies(target);
+  // Get workspace info to automatically bundle workspace dependencies
+  const workspaceInfo = await getWorkspaceInfo();
   // Split dependencies between external and bundled
   const { external: externalDependencies, bundled: bundledDependencies } =
-    filterDependencies(packageDependencies, isApp);
+    filterDependencies({
+      dependencies: packageDependencies,
+      isApp,
+      workspaceInfo,
+    });
   const { external: externalResolutions, bundled: bundledResolutions } =
-    filterDependencies(packageResolutions, isApp);
+    filterDependencies({
+      dependencies: packageResolutions,
+      isApp,
+      workspaceInfo,
+    });
 
   logger.debug(
-    `These are the external dependencies and their resolutions: ${{
-      externalDependencies,
-      externalResolutions,
-    }}`,
+    `These are the external dependencies and their resolutions: ${JSON.stringify(
+      {
+        externalDependencies,
+        externalResolutions,
+      },
+    )}`,
   );
   logger.debug(
-    `These are the bundled dependencies and their resolutions: ${{
-      bundledDependencies,
-      bundledResolutions,
-    }}`,
+    `These are the bundled dependencies and their resolutions: ${JSON.stringify(
+      {
+        bundledDependencies,
+        bundledResolutions,
+      },
+    )}`,
   );
 
   const browserTarget = createEsbuildBrowserslistTarget(targetDirectory);

--- a/packages/modular-scripts/src/start.ts
+++ b/packages/modular-scripts/src/start.ts
@@ -19,9 +19,10 @@ import { filterDependencies } from './utils/filterDependencies';
 
 async function start(packageName: string): Promise<void> {
   let target = packageName;
+  const workspaceInfo = await getWorkspaceInfo();
 
   if (!target) {
-    const availablePackages = Object.keys(await getWorkspaceInfo());
+    const availablePackages = Object.keys(workspaceInfo);
     const chosenTarget = await prompts<string>({
       type: 'select',
       name: 'value',
@@ -73,9 +74,17 @@ async function start(packageName: string): Promise<void> {
   const { manifest: packageDependencies, resolutions: packageResolutions } =
     await getPackageDependencies(target);
   const { external: externalDependencies, bundled: bundledDependencies } =
-    filterDependencies(packageDependencies, !isEsmView);
+    filterDependencies({
+      dependencies: packageDependencies,
+      isApp: !isEsmView,
+      workspaceInfo,
+    });
   const { external: externalResolutions, bundled: bundledResolutions } =
-    filterDependencies(packageResolutions, !isEsmView);
+    filterDependencies({
+      dependencies: packageResolutions,
+      isApp: !isEsmView,
+      workspaceInfo,
+    });
 
   // If you want to use webpack then we'll always use webpack. But if you've indicated
   // you want esbuild - then we'll switch you to the new fancy world.

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -77,30 +77,31 @@ export async function getPackageDependencies(
    * Exclude workspace dependencies. Warn if a dependency is imported in the source code
    * but not specified in any of the package.jsons
    */
-  const { manifest, resolutions } = getDependenciesFromSource(targetLocation)
-    .filter((depName) => !(depName in workspaceInfo))
-    .reduce<{ manifest: DependencyManifest; resolutions: DependencyManifest }>(
-      (acc, depName) => {
-        const depManifestVersion = deps[depName];
-        if (!depManifestVersion) {
-          logger.error(
-            `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular`,
-          );
-        }
-        const resolutionVersion = lockDeps[depName];
-        if (!resolutionVersion) {
-          logger.error(
-            `Package ${depName} imported in ${target} source but not found in lockfile - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular. Have you installed your dependencies?`,
-          );
-        }
-        acc.manifest[depName] = depManifestVersion;
-        if (resolutionVersion) {
-          acc.resolutions[depName] = resolutionVersion;
-        }
-        return acc;
-      },
-      { manifest: {}, resolutions: {} },
-    );
+  const { manifest, resolutions } = getDependenciesFromSource(
+    targetLocation,
+  ).reduce<{ manifest: DependencyManifest; resolutions: DependencyManifest }>(
+    (acc, depName) => {
+      const depManifestVersion = deps[depName];
+      if (!depManifestVersion) {
+        logger.error(
+          `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular`,
+        );
+      }
+      const resolutionVersion =
+        lockDeps[depName] ?? workspaceInfo[depName]?.version;
+      if (!resolutionVersion) {
+        logger.error(
+          `Package ${depName} imported in ${target} source but not found in lockfile - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular. Have you installed your dependencies?`,
+        );
+      }
+      acc.manifest[depName] = depManifestVersion;
+      if (resolutionVersion) {
+        acc.resolutions[depName] = resolutionVersion;
+      }
+      return acc;
+    },
+    { manifest: {}, resolutions: {} },
+  );
   return { manifest, resolutions };
 }
 

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -7,10 +7,18 @@ import * as yaml from 'js-yaml';
 import type { CoreProperties, Dependency } from '@schemastore/package';
 import getModularRoot from './getModularRoot';
 import getLocation from './getLocation';
-import getWorkspaceInfo from './getWorkspaceInfo';
+import getWorkspaceInfo, { WorkspaceInfo } from './getWorkspaceInfo';
 import * as logger from './logger';
 
 type DependencyManifest = NonNullable<CoreProperties['dependencies']>;
+interface DependencyResolution {
+  manifest: DependencyManifest;
+  resolutions: DependencyManifest;
+}
+interface DependencyResolutionWithErrors extends DependencyResolution {
+  manifestMiss: string[];
+  lockFileMiss: string[];
+}
 type LockFileEntries = Record<string, { version: string }>;
 
 const npmPackageMatcher =
@@ -66,7 +74,8 @@ export async function getPackageDependencies(
     },
   );
 
-  const deps = Object.assign(
+  // Package dependencies can be either local to the package or in the root package (hoisted)
+  const packageDeps = Object.assign(
     Object.create(null),
     rootManifest.devDependencies,
     rootManifest.dependencies,
@@ -74,43 +83,78 @@ export async function getPackageDependencies(
     targetManifest.dependencies,
   ) as Dependency;
 
-  const lockDeps = parseYarnLock(lockFileContents, deps);
+  const lockDeps = parseYarnLock(lockFileContents, packageDeps);
+  const dependenciesfromSource = getDependenciesFromSource(targetLocation);
+  const packageResolvedDependencies = resolvePackageDependencies({
+    dependenciesfromSource,
+    packageDeps,
+    lockDeps,
+    workspaceInfo,
+  });
 
-  /* Get dependencies from package.json (regular), root package.json (hoisted) or pinned version in lockfile (resolution)
+  // Log the errors
+  packageResolvedDependencies.manifestMiss.forEach((depName) =>
+    logger.error(
+      `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular`,
+    ),
+  );
+  packageResolvedDependencies.lockFileMiss.forEach((depName) =>
+    logger.error(
+      `Package ${depName} imported in ${target} source but not found in lockfile - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular. Have you installed your dependencies?`,
+    ),
+  );
+
+  // Return resolutions, omitting the errors
+  return {
+    manifest: packageResolvedDependencies.manifest,
+    resolutions: packageResolvedDependencies.resolutions,
+  };
+}
+
+export function parseYarnLock(lockFile: string, deps: Dependency): Dependency {
+  return parseYarnLockV1(lockFile, deps) || parseYarnLockV3(lockFile, deps);
+}
+
+interface ResolveDependencyArguments {
+  dependenciesfromSource: string[];
+  packageDeps: Dependency;
+  lockDeps: Dependency;
+  workspaceInfo: WorkspaceInfo;
+}
+
+export function resolvePackageDependencies({
+  dependenciesfromSource,
+  packageDeps,
+  lockDeps,
+  workspaceInfo,
+}: ResolveDependencyArguments): DependencyResolutionWithErrors {
+  /* Get dependencies from package.json or pinned version in lockfile (resolution)
    * Exclude workspace dependencies. Warn if a dependency is imported in the source code
    * but not specified in any of the package.jsons
    */
-  const { manifest, resolutions } = getDependenciesFromSource(
-    targetLocation,
-  ).reduce<{ manifest: DependencyManifest; resolutions: DependencyManifest }>(
-    (acc, depName) => {
-      const depManifestVersion = deps[depName];
-      if (depManifestVersion) {
-        acc.manifest[depName] = depManifestVersion;
-      } else {
-        logger.error(
-          `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular`,
-        );
-      }
-      // Resolve either from lockfile or from workspace info. Precedence is given to lockfile.
-      const resolutionVersion =
-        lockDeps[depName] ?? workspaceInfo[depName]?.version;
-      if (resolutionVersion) {
-        acc.resolutions[depName] = resolutionVersion;
-      } else {
-        logger.error(
-          `Package ${depName} imported in ${target} source but not found in lockfile - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular. Have you installed your dependencies?`,
-        );
-      }
-      return acc;
-    },
-    { manifest: {}, resolutions: {} },
-  );
-  return { manifest, resolutions };
-}
-
-function parseYarnLock(lockFile: string, deps: Dependency): Dependency {
-  return parseYarnLockV1(lockFile, deps) || parseYarnLockV3(lockFile, deps);
+  const accumulator: DependencyResolutionWithErrors = {
+    manifest: {},
+    resolutions: {},
+    manifestMiss: [],
+    lockFileMiss: [],
+  };
+  return dependenciesfromSource.reduce((acc, depName) => {
+    const depManifestVersion = packageDeps[depName];
+    if (depManifestVersion) {
+      acc.manifest[depName] = depManifestVersion;
+    } else {
+      acc.manifestMiss.push(depName);
+    }
+    // Resolve either from lockfile or from workspace info. Precedence is given to lockfile.
+    const resolutionVersion =
+      lockDeps[depName] ?? workspaceInfo[depName]?.version;
+    if (resolutionVersion) {
+      acc.resolutions[depName] = resolutionVersion;
+    } else {
+      acc.lockFileMiss.push(depName);
+    }
+    return acc;
+  }, accumulator);
 }
 
 function parseYarnLockV1(
@@ -123,14 +167,10 @@ function parseYarnLockV1(
   } catch (e) {
     return null;
   }
+  const lockFileEntries = parsedLockfile.object as LockFileEntries;
   return Object.entries(deps).reduce<Record<string, string>>(
     (acc, [name, version]) => {
-      const resolution = (parsedLockfile.object as LockFileEntries)[
-        `${name}@${version}`
-      ]?.version;
-      if (resolution !== undefined) {
-        acc[name] = resolution;
-      }
+      acc[name] = lockFileEntries[`${name}@${version}`]?.version;
       return acc;
     },
     {},
@@ -142,19 +182,21 @@ function parseYarnLockV3(
   deps: Dependency,
 ): Dependency {
   const dependencyArray = Object.entries(deps);
+  const npmDependencyList = new Map(
+    dependencyArray.map(([name, version]) => [`${name}@npm:${version}`, name]),
+  );
+  const lockFileEntries = yaml.load(lockFileContents) as LockFileEntries;
   // This function loops over all the dependency ranges listed in the lockfile and tries to match the given dependencies with an exact version.
-  return Object.entries(
-    yaml.load(lockFileContents) as LockFileEntries,
-  ).reduce<Dependency>((acc, [name, { version }]) => {
-    // Yarn v3 lockfile comes with keys like "'yargs@npm:^15.0.2, yargs@npm:^15.1.0, yargs@npm:^15.3.1, yargs@npm:^15.4.1'" - split them
-    const entryDependencies = name.split(', ');
-    for (const [dependencyName, dependencyVersion] of dependencyArray) {
-      if (
-        entryDependencies.includes(`${dependencyName}@npm:${dependencyVersion}`)
-      ) {
-        acc[dependencyName] = version;
-      }
-    }
-    return acc;
-  }, {});
+  return Object.entries(lockFileEntries).reduce<Dependency>(
+    (acc, [name, { version }]) => {
+      // Yarn v3 lockfile comes with keys like "'yargs@npm:^15.0.2, yargs@npm:^15.1.0, yargs@npm:^15.3.1, yargs@npm:^15.4.1'" - split them
+      const entryDependencies = name.split(', ');
+      entryDependencies.some((dep) => {
+        const npmName = npmDependencyList.get(dep);
+        return !!(npmName && (acc[npmName] = version));
+      });
+      return acc;
+    },
+    {},
+  );
 }

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -87,6 +87,7 @@ export async function getPackageDependencies(
           `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular`,
         );
       }
+      // Resolve either from lockfile or from workspace info. Precedence is given to lockfile.
       const resolutionVersion =
         lockDeps[depName] ?? workspaceInfo[depName]?.version;
       if (!resolutionVersion) {

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -85,7 +85,7 @@ export async function getPackageDependencies(
 
   const lockDeps = parseYarnLock(lockFileContents, packageDeps);
   const dependenciesfromSource = getDependenciesFromSource(targetLocation);
-  const packageResolvedDependencies = resolvePackageDependencies({
+  const resolvedPackageDependencies = resolvePackageDependencies({
     dependenciesfromSource,
     packageDeps,
     lockDeps,
@@ -93,12 +93,12 @@ export async function getPackageDependencies(
   });
 
   // Log the errors
-  packageResolvedDependencies.manifestMiss.forEach((depName) =>
+  resolvedPackageDependencies.manifestMiss.forEach((depName) =>
     logger.error(
       `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular`,
     ),
   );
-  packageResolvedDependencies.lockFileMiss.forEach((depName) =>
+  resolvedPackageDependencies.lockFileMiss.forEach((depName) =>
     logger.error(
       `Package ${depName} imported in ${target} source but not found in lockfile - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular. Have you installed your dependencies?`,
     ),
@@ -106,8 +106,8 @@ export async function getPackageDependencies(
 
   // Return resolutions, omitting the errors
   return {
-    manifest: packageResolvedDependencies.manifest,
-    resolutions: packageResolvedDependencies.resolutions,
+    manifest: resolvedPackageDependencies.manifest,
+    resolutions: resolvedPackageDependencies.resolutions,
   };
 }
 

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -95,12 +95,12 @@ export async function getPackageDependencies(
   // Log the errors
   resolvedPackageDependencies.manifestMiss.forEach((depName) =>
     logger.error(
-      `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular`,
+      `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully building, starting or moving esm-views and will cause an error in the next release of modular`,
     ),
   );
   resolvedPackageDependencies.lockFileMiss.forEach((depName) =>
     logger.error(
-      `Package ${depName} imported in ${target} source but not found in lockfile - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular. Have you installed your dependencies?`,
+      `Package ${depName} imported in ${target} source but not found in lockfile - this will prevent you from successfully building, starting or moving esm-views and will cause an error in the next release of modular. Have you installed your dependencies?`,
     ),
   );
 

--- a/packages/modular-scripts/src/utils/getPackageDependencies.ts
+++ b/packages/modular-scripts/src/utils/getPackageDependencies.ts
@@ -82,7 +82,9 @@ export async function getPackageDependencies(
   ).reduce<{ manifest: DependencyManifest; resolutions: DependencyManifest }>(
     (acc, depName) => {
       const depManifestVersion = deps[depName];
-      if (!depManifestVersion) {
+      if (depManifestVersion) {
+        acc.manifest[depName] = depManifestVersion;
+      } else {
         logger.error(
           `Package ${depName} imported in ${target} source but not found in package dependencies or hoisted dependencies - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular`,
         );
@@ -90,14 +92,12 @@ export async function getPackageDependencies(
       // Resolve either from lockfile or from workspace info. Precedence is given to lockfile.
       const resolutionVersion =
         lockDeps[depName] ?? workspaceInfo[depName]?.version;
-      if (!resolutionVersion) {
+      if (resolutionVersion) {
+        acc.resolutions[depName] = resolutionVersion;
+      } else {
         logger.error(
           `Package ${depName} imported in ${target} source but not found in lockfile - this will prevent you from successfully build, start or move esm-views and will cause an error in the next release of modular. Have you installed your dependencies?`,
         );
-      }
-      acc.manifest[depName] = depManifestVersion;
-      if (resolutionVersion) {
-        acc.resolutions[depName] = resolutionVersion;
       }
       return acc;
     },

--- a/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
+++ b/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
@@ -12,6 +12,7 @@ export interface WorkSpaceRecord {
   mismatchedWorkspaceDependencies: string[];
   type: ModularType;
   public: boolean;
+  version?: string;
 }
 
 type WorkspaceInfo = Record<string, WorkSpaceRecord>;
@@ -32,6 +33,7 @@ export async function getWorkspaceInfo(): Promise<WorkspaceInfo> {
       ...packageInfo,
       type,
       public: !packageJson.private,
+      version: packageJson.version,
     };
 
     res[packageName] = modularPackageInfo;

--- a/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
+++ b/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
@@ -15,7 +15,7 @@ export interface WorkSpaceRecord {
   version?: string;
 }
 
-type WorkspaceInfo = Record<string, WorkSpaceRecord>;
+export type WorkspaceInfo = Record<string, WorkSpaceRecord>;
 
 export async function getWorkspaceInfo(): Promise<WorkspaceInfo> {
   const workspaces = await getAllWorkspaces();


### PR DESCRIPTION
- `modular analyze` will show workspace dependencies with their correct resolutions (before it didn't)
- `modular build` and `modular start` will build (and bundle / not rewrite by default) the workspace dependencies the target package depends on (before those commands were breaking because `getDependenciesInfo` didn't find the resolutions in `yarn.lock`)
- Debug logging is more thorough and comprehensible
- Conditional yarnv1 / yarnv3 lockfile parsing error reporting works better (before, _any_ exception in the v1 parsing block would trigger a v3 parse, with consequent confusing "parse error" message - now it reports the correct error)
- Support `workspace:` deps
- Tests added
- Docs updated with mention of how we bundle workspace dependencies by default