### PR TITLE
Docs housekeeping + fix ESM Views visibility

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -4,9 +4,3 @@ nav_order: 250
 ---
 
 # Concepts
-
-- [Linting](./linting.md)
-- [Micro Frontends](./microfrontends.md)
-- [Philosophy](./philosophy.md)
-- [Versioning](./versioning.md)
-- [Views](./views.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ nav_order: 10
 
 # Configuration
 
-Modular has minimal configuration because of it's philosophy. However there is a
+Modular has minimal configuration because of its philosophy. However there is a
 set of minimum configuration required.
 
 ## `package.json#modular`
@@ -39,6 +39,11 @@ generated view map with `modular-views.macro`. Read more about Views in
 ### `"app"`
 
 This type identifies a standalone application that can be started or built.
+
+### `"esm-view"`
+
+This type identifies an ESM view that can be started in standalone mode, built
+and imported dynamically by an host application.
 
 ### `"package"`
 

--- a/docs/esm-views/index.md
+++ b/docs/esm-views/index.md
@@ -1,7 +1,7 @@
 ---
 has_children: true
 title: ESM Views
-nav_order: 750
+nav_order: 700
 ---
 
 # ESM Views

--- a/docs/esm-views/index.md
+++ b/docs/esm-views/index.md
@@ -1,7 +1,10 @@
 ---
 has_children: true
+title: ESM Views
 nav_order: 750
 ---
+
+# ESM Views
 
 Modular builds packages of `"type": "esm-view"` as
 [ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules),
@@ -13,10 +16,3 @@ that can be
 [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports)ed
 at runtime by a host application, or loaded stand-alone thanks to the automatic
 generation of the `index.html` and trampoline file.
-
-- [How to build ESM Views](./how-to-build.md)
-- [ESM CDN](./esm-cdn.md)
-- [Customize bundling strategy](./customize-bundle-strategy.md)
-- [Output package manifest](./output-package-manifest.md)
-- [External CSS imports](./external-css-imports.md)
-- [Known limitations](./known-limitations.md)

--- a/docs/esm-views/known-limitations.md
+++ b/docs/esm-views/known-limitations.md
@@ -1,7 +1,7 @@
 ---
 parent: ESM Views
 nav_order: 100
-title: Known limitations of ESM Views
+title: Known limitations
 ---
 
 # Known limitations of ESM Views

--- a/docs/esm-views/known-limitations.md
+++ b/docs/esm-views/known-limitations.md
@@ -1,6 +1,6 @@
 ---
 parent: ESM Views
-nav_order: 250
+nav_order: 100
 title: Known limitations of ESM Views
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ It supports three flags:
 - [`port`](./commands/port.md)
 - [`typecheck`](./commands/typecheck.md)
 - [`lint`](./commands/lint.md)
+- [`rename`](./commands/rename.md)
 
 ## Concepts
 

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,5 +1,5 @@
 ---
 has_children: true
-nav_order: 700
+nav_order: 750
 title: Release Notes
 ---

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,5 +1,5 @@
 ---
 has_children: true
-nav_order: 750
+nav_order: 700
 title: Release Notes
 ---


### PR DESCRIPTION
- The esm-view section was invisible because of `nav_order` overlap. Fixed.
- Redundant indices removed from index pages
- Title updated to not wrap around in left side column
- Typo fixed