### PR TITLE
Normalize globby paths

### DIFF
--- a/.changeset/young-socks-learn.md
+++ b/.changeset/young-socks-learn.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": patch
+---
+
+Fix files not added when using a template with `modular add` on Windows

--- a/packages/modular-scripts/src/addPackage.ts
+++ b/packages/modular-scripts/src/addPackage.ts
@@ -216,13 +216,13 @@ async function addPackage({
   const packageFilePaths = getAllFiles(packagePath);
 
   // If we get our package locally we need to whitelist files like yarn publish does
-  const packageWhitelist = globby.sync(
-    modularTemplatePackageJson.files || ['*'],
-    {
+  const packageWhitelist = globby
+    .sync(modularTemplatePackageJson.files || ['*'], {
       cwd: packagePath,
       absolute: true,
-    },
-  );
+    })
+    .map((filePath) => path.normalize(filePath));
+
   for (const packageFilePath of packageFilePaths) {
     if (!packageWhitelist.includes(packageFilePath)) {
       fs.removeSync(packageFilePath);


### PR DESCRIPTION
Problem: Globby correctly globs the paths, but it formats them according to the platform filesystem's separator, which means quoted backslashes on Windows. Since we compare them with `.includes` (string equality) to decide if we want to remove them, we actually end up blocklisting them all on Windows.

Fix: Normalising paths as soon as we get them from Globby fixes the issue.