### PR TITLE
Splitting up large processes

### DIFF
--- a/packages/modular-scripts/src/build/createBuilderContext.ts
+++ b/packages/modular-scripts/src/build/createBuilderContext.ts
@@ -1,0 +1,76 @@
+import { debug, log } from '../utils/logger';
+import type { Paths } from '../utils/createPaths';
+import createPaths from '../utils/createPaths';
+import type { DependencyManifest } from './dependencyManifest';
+import type { Asset } from './fileSizeReporter';
+import type { ModularType } from '../utils/isModularType';
+import getLocation from '../utils/getLocation';
+import getModularRoot from '../utils/getModularRoot';
+import { paramCase as toParamCase } from 'param-case';
+import createEsbuildBrowserslistTarget from '../utils/createEsbuildBrowserslistTarget';
+import { AsyncEventHandler } from '../utils/asyncEventEmitter';
+
+export interface StandAloneBuilderContext {
+  log(...args: unknown[]): void;
+
+  debug(...args: unknown[]): void;
+
+  assets: Asset[];
+  jsEntryPoint?: string;
+  cssEntryPoint?: string;
+
+  browserTarget: string[];
+  dependencies?: DependencyManifest;
+  modularRoot: string;
+  paths: Paths;
+  previousFileSizes: Record<string, number>;
+  targetDirectory: string;
+  targetName: string;
+  tool: BuildTool;
+  type: ModularType;
+}
+
+export type StandAloneBuilderHandler =
+  AsyncEventHandler<StandAloneBuilderContext>;
+
+export type BuildTool = 'webpack' | 'esbuild';
+export type StandAlonePackages = Extract<ModularType, 'app' | 'esm-view'>;
+
+export async function createBuilderContext(
+  target: string,
+  tool: BuildTool,
+  type: ModularType,
+): Promise<StandAloneBuilderContext> {
+  const targetDirectory = await getLocation(target);
+  return {
+    log(...args) {
+      log(...(args as string[]));
+    },
+    debug(...args) {
+      debug(...(args as string[]));
+    },
+    assets: [],
+    paths: await createPaths(target),
+    modularRoot: getModularRoot(),
+    targetDirectory,
+    targetName: toParamCase(target),
+    tool,
+    type,
+    browserTarget: createEsbuildBrowserslistTarget(targetDirectory),
+    previousFileSizes: {},
+  };
+}
+
+export function filterTool(
+  tool: BuildTool,
+  handler: StandAloneBuilderHandler,
+): StandAloneBuilderHandler {
+  return (context) => context.tool === tool && handler(context);
+}
+
+export function filterType(
+  type: ModularType,
+  handler: StandAloneBuilderHandler,
+): StandAloneBuilderHandler {
+  return (context) => context.type === type && handler(context);
+}

--- a/packages/modular-scripts/src/build/dependencyManifest.ts
+++ b/packages/modular-scripts/src/build/dependencyManifest.ts
@@ -1,0 +1,72 @@
+import type { Dependency } from '@schemastore/package';
+import getWorkspaceInfo from '../utils/getWorkspaceInfo';
+import { getPackageDependencies } from '../utils/getPackageDependencies';
+import { filterDependencies } from '../utils/filterDependencies';
+import { StandAloneBuilderContext } from './createBuilderContext';
+
+export interface DependencyManifest {
+  externalDependencies: Dependency;
+  packageDependencies: Dependency;
+  bundledResolutions: Dependency;
+  bundledDependencies: Dependency;
+  externalResolutions: Dependency;
+}
+
+export async function builderLifecycleExtractDependencies(
+  context: StandAloneBuilderContext,
+) {
+  const dependencies = (context.dependencies = await extractDependencies(
+    context.targetDirectory,
+    context.type === 'app',
+  ));
+
+  context.debug(
+    `These are the external dependencies and their resolutions: ${JSON.stringify(
+      {
+        externalDependencies: dependencies.externalDependencies,
+        externalResolutions: dependencies.externalResolutions,
+      },
+    )}`,
+  );
+
+  context.debug(
+    `These are the bundled dependencies and their resolutions: ${JSON.stringify(
+      {
+        bundledDependencies: dependencies.bundledDependencies,
+        bundledResolutions: dependencies.bundledResolutions,
+      },
+    )}`,
+  );
+}
+
+async function extractDependencies(
+  target: string,
+  isApp: boolean,
+): Promise<DependencyManifest> {
+  // Get workspace info to automatically bundle workspace dependencies
+  const workspaceInfo = await getWorkspaceInfo();
+
+  const { manifest, resolutions } = await getPackageDependencies(target);
+
+  // Split dependencies between external and bundled
+  const { external: externalDependencies, bundled: bundledDependencies } =
+    filterDependencies({
+      dependencies: manifest,
+      isApp,
+      workspaceInfo,
+    });
+  const { external: externalResolutions, bundled: bundledResolutions } =
+    filterDependencies({
+      dependencies: resolutions,
+      isApp,
+      workspaceInfo,
+    });
+
+  return {
+    packageDependencies: manifest,
+    externalDependencies,
+    bundledDependencies,
+    externalResolutions,
+    bundledResolutions,
+  };
+}

--- a/packages/modular-scripts/src/build/fileSizeReporter.ts
+++ b/packages/modular-scripts/src/build/fileSizeReporter.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import filesize from 'filesize';
 import stripAnsi from 'strip-ansi';
 import * as logger from '../utils/logger';
+import { StandAloneBuilderContext } from './createBuilderContext';
 
 export interface Asset {
   folder: string;
@@ -25,14 +26,12 @@ const WARN_AFTER_CHUNK_GZIP_SIZE = 1024 * 1024;
 const FIFTY_KILOBYTES = 1024 * 50;
 
 // Prints a detailed summary of build files.
-export function printFileSizesAfterBuild(
-  assets: Asset[],
-  previousSizeMap: Record<string, number | undefined>,
-) {
+export function printFileSizesAfterBuild(context: StandAloneBuilderContext) {
+  const { assets, previousFileSizes } = context;
   const sizedAssets = assets
     .sort((a, b) => b.size - a.size)
     .map<LabelledAsset>((asset) => {
-      const previousSize = previousSizeMap[asset.normalizedName];
+      const previousSize = previousFileSizes[asset.normalizedName];
       const differenceLabel = getDifferenceLabel(asset.size, previousSize);
       return {
         ...asset,

--- a/packages/modular-scripts/src/build/generateAssetsEsBuild.ts
+++ b/packages/modular-scripts/src/build/generateAssetsEsBuild.ts
@@ -1,0 +1,34 @@
+import { getEntryPoint } from '../esbuild-scripts/api';
+import { createEsbuildAssets } from './esbuildFileSizeReporter';
+import { StandAloneBuilderContext } from './createBuilderContext';
+
+export async function generateAssetsWithEsbuild(
+  context: StandAloneBuilderContext,
+) {
+  const { dependencies, modularRoot, paths, targetDirectory, type } = context;
+
+  if (!dependencies) {
+    throw new Error(
+      `generateAssetsWithEsbuild: cannot run without a dependencies map`,
+    );
+  }
+
+  if (type !== 'app' && type !== 'esm-view') {
+    throw new Error(
+      `generateAssetsWithEsbuild: cannot process package type "${type}"`,
+    );
+  }
+
+  const { default: buildEsbuildApp } = await import('../esbuild-scripts/build');
+  const result = await buildEsbuildApp(
+    targetDirectory,
+    paths,
+    dependencies.externalDependencies,
+    dependencies.externalResolutions,
+    type,
+  );
+
+  context.jsEntryPoint = getEntryPoint(paths, result, '.js');
+  context.cssEntryPoint = getEntryPoint(paths, result, '.css');
+  context.assets = createEsbuildAssets(paths, result, modularRoot);
+}

--- a/packages/modular-scripts/src/build/generateAssetsWebpack.ts
+++ b/packages/modular-scripts/src/build/generateAssetsWebpack.ts
@@ -1,0 +1,81 @@
+import * as fs from 'fs-extra';
+import chalk from 'chalk';
+import path from 'path';
+import { StatsCompilation } from 'webpack';
+import execAsync from '../utils/execAsync';
+import * as logger from '../utils/logger';
+import { createWebpackAssets } from './webpackFileSizeReporter';
+import { StandAloneBuilderContext } from './createBuilderContext';
+
+export async function generateAssetsWebpack(context: StandAloneBuilderContext) {
+  const {
+    paths,
+    dependencies,
+    type,
+    targetDirectory,
+    browserTarget,
+    modularRoot,
+    targetName,
+  } = context;
+
+  if (!dependencies) {
+    throw new Error(
+      `generateWebpackAssets: cannot run without a dependencies map`,
+    );
+  }
+
+  const isApp = type === 'app';
+  const buildScript = require.resolve(
+    'modular-scripts/react-scripts/scripts/build.js',
+  );
+
+  await execAsync('node', [buildScript], {
+    cwd: targetDirectory,
+    log: false,
+    // @ts-ignore
+    env: {
+      ESBUILD_TARGET_FACTORY: JSON.stringify(browserTarget),
+      MODULAR_ROOT: modularRoot,
+      MODULAR_PACKAGE: targetDirectory,
+      MODULAR_PACKAGE_NAME: targetName,
+      MODULAR_IS_APP: JSON.stringify(isApp),
+      MODULAR_PACKAGE_DEPS: JSON.stringify({
+        externalDependencies: dependencies.externalDependencies,
+        bundledDependencies: dependencies.bundledDependencies,
+      }),
+      MODULAR_PACKAGE_RESOLUTIONS: JSON.stringify({
+        externalResolutions: dependencies.externalResolutions,
+        bundledResolutions: dependencies.bundledResolutions,
+      }),
+    },
+  });
+
+  const statsFilePath = path.join(paths.appBuild, 'bundle-stats.json');
+
+  try {
+    const stats: StatsCompilation = await fs.readJson(statsFilePath);
+
+    const mainEntrypoint = stats?.assetsByChunkName?.main;
+    context.jsEntryPoint = mainEntrypoint?.find((entryPoint) =>
+      entryPoint.endsWith('.js'),
+    );
+    context.cssEntryPoint = mainEntrypoint?.find((entryPoint) =>
+      entryPoint.endsWith('.css'),
+    );
+
+    if (stats?.warnings?.length) {
+      logger.log(chalk.yellow('Compiled with warnings.\n'));
+      logger.log(stats.warnings.join('\n\n'));
+      logger.log(
+        '\nSearch for the ' +
+          chalk.underline(chalk.yellow('keywords')) +
+          ' to learn more about each warning.',
+      );
+    } else {
+      logger.log(chalk.green('Compiled successfully.\n'));
+    }
+    context.assets.push(...createWebpackAssets(paths, stats));
+  } finally {
+    await fs.remove(statsFilePath);
+  }
+}

--- a/packages/modular-scripts/src/build/generateEsmViewTrampoline.ts
+++ b/packages/modular-scripts/src/build/generateEsmViewTrampoline.ts
@@ -1,0 +1,61 @@
+import path from 'path';
+import * as fs from 'fs-extra';
+import * as minimize from 'html-minifier-terser';
+import getClientEnvironment from '../esbuild-scripts/config/getClientEnvironment';
+import {
+  createSyntheticIndex,
+  createViewTrampoline,
+} from '../esbuild-scripts/api';
+import { StandAloneBuilderContext } from './createBuilderContext';
+
+export async function generateEsmViewTrampoline(
+  context: StandAloneBuilderContext,
+) {
+  const { jsEntryPoint, paths, cssEntryPoint, dependencies, browserTarget } =
+    context;
+
+  if (!dependencies) {
+    throw new Error(
+      `generateEsmViewTrampoline: cannot run without a dependencies map`,
+    );
+  }
+
+  if (!jsEntryPoint) {
+    throw new Error(
+      `generateEsmViewTrampoline: unable to process view, jsEntryPoint not found`,
+    );
+  }
+
+  // Create synthetic index
+  const env = getClientEnvironment(paths.publicUrlOrPath.slice(0, -1));
+  const html = createSyntheticIndex({ cssEntryPoint, replacements: env.raw });
+  await fs.writeFile(
+    path.join(paths.appBuild, 'index.html'),
+    await minimize.minify(html, {
+      html5: true,
+      collapseBooleanAttributes: true,
+      collapseWhitespace: true,
+      collapseInlineTagWhitespace: true,
+      decodeEntities: true,
+      minifyCSS: true,
+      minifyJS: true,
+      removeAttributeQuotes: false,
+      removeComments: true,
+      removeTagWhitespace: true,
+    }),
+  );
+
+  // Create and write trampoline file
+  const trampolineBuildResult = await createViewTrampoline(
+    path.basename(jsEntryPoint),
+    paths.appSrc,
+    dependencies.externalDependencies,
+    dependencies.externalResolutions,
+    browserTarget,
+  );
+  const trampolinePath = `${paths.appBuild}/static/js/_trampoline.js`;
+  await fs.writeFile(
+    trampolinePath,
+    trampolineBuildResult.outputFiles[0].contents,
+  );
+}

--- a/packages/modular-scripts/src/build/generateTargetPackageJson.ts
+++ b/packages/modular-scripts/src/build/generateTargetPackageJson.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs-extra';
+import path from 'path';
+import { CoreProperties } from '@schemastore/package';
+import { StandAloneBuilderContext } from './createBuilderContext';
+
+export async function generateTargetPackageJson(
+  context: StandAloneBuilderContext,
+) {
+  const { jsEntryPoint, paths, cssEntryPoint, targetDirectory, dependencies } =
+    context;
+
+  if (!dependencies) {
+    throw new Error(
+      `generateAssetsWithEsbuild: cannot run without a dependencies map`,
+    );
+  }
+
+  const input = (await fs.readJSON(
+    path.join(targetDirectory, 'package.json'),
+  )) as CoreProperties;
+  input.dependencies = dependencies.packageDependencies;
+  input.bundledDependencies = Object.keys(dependencies.bundledDependencies);
+
+  const output = {
+    name: input.name,
+    version: input.version,
+    license: input.license,
+    modular: input.modular,
+    dependencies: input.dependencies,
+    bundledDependencies: input.bundledDependencies,
+    module: jsEntryPoint ? paths.publicUrlOrPath + jsEntryPoint : undefined,
+    style: cssEntryPoint ? paths.publicUrlOrPath + cssEntryPoint : undefined,
+  };
+
+  await fs.writeJSON(path.join(paths.appBuild, 'package.json'), output, {
+    spaces: 2,
+  });
+}

--- a/packages/modular-scripts/src/build/index.ts
+++ b/packages/modular-scripts/src/build/index.ts
@@ -1,287 +1,18 @@
-import { paramCase as toParamCase } from 'change-case';
-import chalk from 'chalk';
-import * as fs from 'fs-extra';
-import * as path from 'path';
-import * as logger from '../utils/logger';
-import * as minimize from 'html-minifier-terser';
-import getModularRoot from '../utils/getModularRoot';
 import actionPreflightCheck from '../utils/actionPreflightCheck';
-import { getModularType } from '../utils/isModularType';
-import { filterDependencies } from '../utils/filterDependencies';
-import getWorkspaceInfo from '../utils/getWorkspaceInfo';
-import type { ModularType } from '../utils/isModularType';
-import execAsync from '../utils/execAsync';
+import { getModularType, ModularType } from '../utils/isModularType';
 import getLocation from '../utils/getLocation';
 import { setupEnvForDirectory } from '../utils/setupEnv';
-import createPaths from '../utils/createPaths';
-import printHostingInstructions from './printHostingInstructions';
-import { Asset, printFileSizesAfterBuild } from './fileSizeReporter';
-import type { StatsCompilation } from 'webpack';
-import { checkBrowsers } from '../utils/checkBrowsers';
-import checkRequiredFiles from '../utils/checkRequiredFiles';
-import createEsbuildBrowserslistTarget from '../utils/createEsbuildBrowserslistTarget';
-import getClientEnvironment from '../esbuild-scripts/config/getClientEnvironment';
-import {
-  createSyntheticIndex,
-  getEntryPoint,
-  createViewTrampoline,
-} from '../esbuild-scripts/api';
-import {
-  webpackMeasureFileSizesBeforeBuild,
-  createWebpackAssets,
-} from './webpackFileSizeReporter';
-import {
-  createEsbuildAssets,
-  esbuildMeasureFileSizesBeforeBuild,
-} from './esbuildFileSizeReporter';
-import { getPackageDependencies } from '../utils/getPackageDependencies';
-import type { CoreProperties } from '@schemastore/package';
+import { createBuilderContext } from './createBuilderContext';
+import { getBuildTool, getStandAloneLifecycle } from './standAloneBuilder';
+
+// Add dependencies from source and bundled dependencies to target package.json
 
 async function buildStandalone(
   target: string,
   type: Extract<ModularType, 'app' | 'esm-view'>,
 ) {
-  // True if there's no preference set - or the preference is for webpack.
-  const useWebpack =
-    !process.env.USE_MODULAR_WEBPACK ||
-    process.env.USE_MODULAR_WEBPACK === 'true';
-
-  // True if the preferene IS set and the preference is esbuid.
-  const useEsbuild =
-    process.env.USE_MODULAR_ESBUILD &&
-    process.env.USE_MODULAR_ESBUILD === 'true';
-
-  // If you want to use webpack then we'll always use webpack. But if you've indicated
-  // you want esbuild - then we'll switch you to the new fancy world.
-  const isEsbuild = !useWebpack || useEsbuild;
-
-  // Setup Paths
-  const modularRoot = getModularRoot();
-  const targetDirectory = await getLocation(target);
-  const targetName = toParamCase(target);
-
-  const paths = await createPaths(target);
-  const isApp = type === 'app';
-
-  await checkBrowsers(targetDirectory);
-
-  let previousFileSizes: Record<string, number>;
-  if (isEsbuild) {
-    previousFileSizes = await esbuildMeasureFileSizesBeforeBuild(
-      paths.appBuild,
-    );
-  } else {
-    previousFileSizes = await webpackMeasureFileSizesBeforeBuild(
-      paths.appBuild,
-    );
-  }
-
-  // Warn and crash if required files are missing
-  isApp
-    ? await checkRequiredFiles([paths.appHtml, paths.appIndexJs])
-    : await checkRequiredFiles([paths.appIndexJs]);
-
-  logger.log('Creating an optimized production build...');
-
-  await fs.emptyDir(paths.appBuild);
-
-  if (isApp) {
-    await fs.copy(paths.appPublic, paths.appBuild, {
-      dereference: true,
-      filter: (file) => file !== paths.appHtml,
-      overwrite: true,
-    });
-  }
-
-  let assets: Asset[];
-  logger.debug('Extracting dependencies from source code...');
-  // Retrieve dependencies for target to inform the build process
-  const { manifest: packageDependencies, resolutions: packageResolutions } =
-    await getPackageDependencies(target);
-  // Get workspace info to automatically bundle workspace dependencies
-  const workspaceInfo = await getWorkspaceInfo();
-  // Split dependencies between external and bundled
-  const { external: externalDependencies, bundled: bundledDependencies } =
-    filterDependencies({
-      dependencies: packageDependencies,
-      isApp,
-      workspaceInfo,
-    });
-  const { external: externalResolutions, bundled: bundledResolutions } =
-    filterDependencies({
-      dependencies: packageResolutions,
-      isApp,
-      workspaceInfo,
-    });
-
-  logger.debug(
-    `These are the external dependencies and their resolutions: ${JSON.stringify(
-      {
-        externalDependencies,
-        externalResolutions,
-      },
-    )}`,
-  );
-  logger.debug(
-    `These are the bundled dependencies and their resolutions: ${JSON.stringify(
-      {
-        bundledDependencies,
-        bundledResolutions,
-      },
-    )}`,
-  );
-
-  const browserTarget = createEsbuildBrowserslistTarget(targetDirectory);
-
-  let jsEntryPoint: string | undefined;
-  let cssEntryPoint: string | undefined;
-
-  if (isEsbuild) {
-    const { default: buildEsbuildApp } = await import(
-      '../esbuild-scripts/build'
-    );
-    const result = await buildEsbuildApp(
-      target,
-      paths,
-      externalDependencies,
-      externalResolutions,
-      type,
-    );
-    jsEntryPoint = getEntryPoint(paths, result, '.js');
-    cssEntryPoint = getEntryPoint(paths, result, '.css');
-    assets = createEsbuildAssets(paths, result);
-  } else {
-    // create-react-app doesn't support plain module outputs yet,
-    // so --preserve-modules has no effect here
-
-    const buildScript = require.resolve(
-      'modular-scripts/react-scripts/scripts/build.js',
-    );
-
-    // TODO: this shouldn't be sync
-    await execAsync('node', [buildScript], {
-      cwd: targetDirectory,
-      log: false,
-      // @ts-ignore
-      env: {
-        ESBUILD_TARGET_FACTORY: JSON.stringify(browserTarget),
-        MODULAR_ROOT: modularRoot,
-        MODULAR_PACKAGE: target,
-        MODULAR_PACKAGE_NAME: targetName,
-        MODULAR_IS_APP: JSON.stringify(isApp),
-        MODULAR_PACKAGE_DEPS: JSON.stringify({
-          externalDependencies,
-          bundledDependencies,
-        }),
-        MODULAR_PACKAGE_RESOLUTIONS: JSON.stringify({
-          externalResolutions,
-          bundledResolutions,
-        }),
-      },
-    });
-
-    const statsFilePath = path.join(paths.appBuild, 'bundle-stats.json');
-
-    try {
-      const stats: StatsCompilation = await fs.readJson(statsFilePath);
-
-      const mainEntrypoint = stats?.assetsByChunkName?.main;
-      jsEntryPoint = mainEntrypoint?.find((entryPoint) =>
-        entryPoint.endsWith('.js'),
-      );
-      cssEntryPoint = mainEntrypoint?.find((entryPoint) =>
-        entryPoint.endsWith('.css'),
-      );
-
-      if (stats?.warnings?.length) {
-        logger.log(chalk.yellow('Compiled with warnings.\n'));
-        logger.log(stats.warnings.join('\n\n'));
-        logger.log(
-          '\nSearch for the ' +
-            chalk.underline(chalk.yellow('keywords')) +
-            ' to learn more about each warning.',
-        );
-      } else {
-        logger.log(chalk.green('Compiled successfully.\n'));
-      }
-
-      assets = createWebpackAssets(paths, stats);
-    } finally {
-      await fs.remove(statsFilePath);
-    }
-  }
-
-  // If view, write the synthetic index.html and create a trampoline file pointing to the main entrypoint
-  // This is for both esbuild and webpack so it lives here. If app, instead, the public/index.html file is generated specifical in different ways.
-  if (!isApp) {
-    if (!jsEntryPoint) {
-      throw new Error("Can't find main entrypoint after building");
-    }
-    // Create synthetic index
-    const env = getClientEnvironment(paths.publicUrlOrPath.slice(0, -1));
-    const html = createSyntheticIndex({ cssEntryPoint, replacements: env.raw });
-    await fs.writeFile(
-      path.join(paths.appBuild, 'index.html'),
-      await minimize.minify(html, {
-        html5: true,
-        collapseBooleanAttributes: true,
-        collapseWhitespace: true,
-        collapseInlineTagWhitespace: true,
-        decodeEntities: true,
-        minifyCSS: true,
-        minifyJS: true,
-        removeAttributeQuotes: false,
-        removeComments: true,
-        removeTagWhitespace: true,
-      }),
-    );
-
-    // Create and write trampoline file
-    const trampolineBuildResult = await createViewTrampoline(
-      path.basename(jsEntryPoint),
-      paths.appSrc,
-      externalDependencies,
-      externalResolutions,
-      browserTarget,
-    );
-    const trampolinePath = `${paths.appBuild}/static/js/_trampoline.js`;
-    await fs.writeFile(
-      trampolinePath,
-      trampolineBuildResult.outputFiles[0].contents,
-    );
-  }
-
-  // Add dependencies from source and bundled dependencies to target package.json
-  const targetPackageJson = (await fs.readJSON(
-    path.join(targetDirectory, 'package.json'),
-  )) as CoreProperties;
-  targetPackageJson.dependencies = packageDependencies;
-  targetPackageJson.bundledDependencies = Object.keys(bundledDependencies);
-
-  // Copy selected fields of package.json over
-  await fs.writeJSON(
-    path.join(paths.appBuild, 'package.json'),
-    {
-      name: targetPackageJson.name,
-      version: targetPackageJson.version,
-      license: targetPackageJson.license,
-      modular: targetPackageJson.modular,
-      dependencies: targetPackageJson.dependencies,
-      bundledDependencies: targetPackageJson.bundledDependencies,
-      module: jsEntryPoint ? paths.publicUrlOrPath + jsEntryPoint : undefined,
-      style: cssEntryPoint ? paths.publicUrlOrPath + cssEntryPoint : undefined,
-    },
-    { spaces: 2 },
-  );
-
-  printFileSizesAfterBuild(assets, previousFileSizes);
-
-  printHostingInstructions(
-    target,
-    paths.publicUrlOrPath,
-    paths.publicUrlOrPath,
-    paths.appBuild,
-  );
+  const lifecycle = await getStandAloneLifecycle();
+  await lifecycle.run(await createBuilderContext(target, getBuildTool(), type));
 }
 
 async function build(
@@ -291,18 +22,17 @@ async function build(
 ): Promise<void> {
   const targetDirectory = await getLocation(target);
 
-  await setupEnvForDirectory(targetDirectory);
+  setupEnvForDirectory(targetDirectory);
 
   const targetType = getModularType(targetDirectory);
   if (targetType === 'app' || targetType === 'esm-view') {
-    await buildStandalone(target, targetType);
-  } else {
-    const { buildPackage } = await import('./buildPackage');
-    // ^ we do a dynamic import here to defer the module's initial side effects
-    // till when it's actually needed (i.e. now)
-
-    await buildPackage(target, preserveModules, includePrivate);
+    return buildStandalone(target, targetType);
   }
+
+  // ^ we do a dynamic import here to defer the module's initial side effects
+  // till when it's actually needed (i.e. now)
+  const { buildPackage } = await import('./buildPackage');
+  await buildPackage(target, preserveModules, includePrivate);
 }
 
 export default actionPreflightCheck(build);

--- a/packages/modular-scripts/src/build/printHostingInstructions.ts
+++ b/packages/modular-scripts/src/build/printHostingInstructions.ts
@@ -1,26 +1,29 @@
 import chalk from 'chalk';
 
 import * as logger from '../utils/logger';
+import { StandAloneBuilderContext } from './createBuilderContext';
 
-function printHostingInstructions(
-  target: string,
-  publicUrl: string,
-  publicPath: string,
-  buildFolder: string,
+export function printHostingInstructions(
+  context: StandAloneBuilderContext,
 ): void {
-  if (publicUrl && publicUrl.includes('.github.io/')) {
+  const {
+    targetDirectory,
+    paths: { publicUrlOrPath, appBuild },
+  } = context;
+
+  if (publicUrlOrPath && publicUrlOrPath.includes('.github.io/')) {
     // "homepage": "http://user.github.io/project"
-    const publicPathname = new URL(publicPath).pathname;
-    printBaseMessage(buildFolder, publicPathname);
-  } else if (publicPath !== '/') {
+    const publicPathname = new URL(publicUrlOrPath).pathname;
+    printBaseMessage(appBuild, publicPathname);
+  } else if (publicUrlOrPath !== '/') {
     // "homepage": "http://mywebsite.com/project"
-    printBaseMessage(buildFolder, publicPath);
+    printBaseMessage(appBuild, publicUrlOrPath);
   } else {
     // "homepage": "http://mywebsite.com"
     //   or no homepage
-    printBaseMessage(buildFolder, publicUrl);
+    printBaseMessage(appBuild, publicUrlOrPath);
 
-    printStaticServerInstructions(target);
+    printStaticServerInstructions(targetDirectory);
   }
   logger.log();
   logger.log('Find out more about deployment here:');
@@ -29,7 +32,7 @@ function printHostingInstructions(
   logger.log();
 }
 
-function printBaseMessage(buildFolder: string, hostingLocation: string) {
+function printBaseMessage(appBuild: string, hostingLocation: string) {
   logger.log(
     `The project was built assuming it is hosted at ${chalk.green(
       hostingLocation || 'the server root',
@@ -52,7 +55,7 @@ function printBaseMessage(buildFolder: string, hostingLocation: string) {
     );
   }
   logger.log();
-  logger.log(`The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`);
+  logger.log(`The ${chalk.cyan(appBuild)} folder is ready to be deployed.`);
 }
 
 function printStaticServerInstructions(target: string) {
@@ -61,5 +64,3 @@ function printStaticServerInstructions(target: string) {
 
   logger.log(`  ${chalk.cyan('modular serve')} ${target}`);
 }
-
-export default printHostingInstructions;

--- a/packages/modular-scripts/src/build/standAloneBuilder.ts
+++ b/packages/modular-scripts/src/build/standAloneBuilder.ts
@@ -1,0 +1,77 @@
+import * as fs from 'fs-extra';
+import checkRequiredFiles from '../utils/checkRequiredFiles';
+import { envBool } from '../utils/env';
+import { esbuildMeasureFileSizesBeforeBuild } from './esbuildFileSizeReporter';
+import { webpackMeasureFileSizesBeforeBuild } from './webpackFileSizeReporter';
+import {
+  BuildTool,
+  filterTool,
+  filterType,
+  StandAloneBuilderContext,
+} from './createBuilderContext';
+import { generateAssetsWithEsbuild } from './generateAssetsEsBuild';
+import { generateAssetsWebpack } from './generateAssetsWebpack';
+import { printFileSizesAfterBuild } from './fileSizeReporter';
+import { printHostingInstructions } from './printHostingInstructions';
+import { builderLifecycleExtractDependencies } from './dependencyManifest';
+import { generateEsmViewTrampoline } from './generateEsmViewTrampoline';
+import { generateTargetPackageJson } from './generateTargetPackageJson';
+import { createLifecycle, TaskLifecycle } from '../utils/lifecycle';
+
+export async function getStandAloneLifecycle(): Promise<
+  TaskLifecycle<StandAloneBuilderContext>
+> {
+  const lifeCycle = createLifecycle<StandAloneBuilderContext>();
+
+  lifeCycle.initialize(
+    filterTool('esbuild', esbuildMeasureFileSizesBeforeBuild),
+  );
+  lifeCycle.initialize(
+    filterTool('webpack', webpackMeasureFileSizesBeforeBuild),
+  );
+
+  lifeCycle.initialize(ensureRequiredFilesExist);
+  lifeCycle.initialize(prepareBuildDir);
+  lifeCycle.initialize(filterType('app', prepareAppPublicContent));
+
+  lifeCycle.beforeGenerate(builderLifecycleExtractDependencies);
+
+  lifeCycle.generate(filterTool('esbuild', generateAssetsWithEsbuild));
+  lifeCycle.generate(filterTool('webpack', generateAssetsWebpack));
+
+  lifeCycle.afterGenerate(filterType('esm-view', generateEsmViewTrampoline));
+  lifeCycle.afterGenerate(generateTargetPackageJson);
+
+  lifeCycle.finalize(printFileSizesAfterBuild);
+  lifeCycle.finalize(printHostingInstructions);
+
+  return lifeCycle;
+}
+
+export function getBuildTool(): BuildTool {
+  const useWebpack = envBool(process.env.USE_MODULAR_WEBPACK, true);
+  const useEsbuild = envBool(process.env.USE_MODULAR_ESBUILD, false);
+
+  // If you want to use webpack then we'll always use webpack. But if you've indicated
+  // you want esbuild - then we'll switch you to the new fancy world.
+  return !useWebpack || useEsbuild ? 'esbuild' : 'webpack';
+}
+
+async function prepareBuildDir(context: StandAloneBuilderContext) {
+  await fs.emptyDir(context.paths.appBuild);
+}
+
+async function ensureRequiredFilesExist(context: StandAloneBuilderContext) {
+  await checkRequiredFiles([context.paths.appIndexJs]);
+  if (context.type === 'app') {
+    await checkRequiredFiles([context.paths.appHtml]);
+  }
+}
+
+async function prepareAppPublicContent(context: StandAloneBuilderContext) {
+  await fs.copy(context.paths.appPublic, context.paths.appBuild, {
+    dereference: true,
+    filter: (file) => file !== context.paths.appHtml,
+    overwrite: true,
+  });
+}

--- a/packages/modular-scripts/src/cli.ts
+++ b/packages/modular-scripts/src/cli.ts
@@ -16,7 +16,7 @@ process.on('unhandledRejection', (err) => {
 });
 
 async function startUp(env: typeof process.env.NODE_ENV) {
-  await setupEnv(env);
+  setupEnv(env);
 
   await startupCheck();
 }

--- a/packages/modular-scripts/src/start.ts
+++ b/packages/modular-scripts/src/start.ts
@@ -38,7 +38,7 @@ async function start(packageName: string): Promise<void> {
 
   let targetPath = await getLocation(target);
 
-  await setupEnvForDirectory(targetPath);
+  setupEnvForDirectory(targetPath);
 
   if (isModularType(targetPath, 'package')) {
     throw new Error(

--- a/packages/modular-scripts/src/utils/asyncEventEmitter.ts
+++ b/packages/modular-scripts/src/utils/asyncEventEmitter.ts
@@ -1,0 +1,35 @@
+export type AsyncEventHandler<T extends unknown> = (
+  arg: T,
+) => unknown | Promise<unknown>;
+
+export class AsyncEventEmitter<T extends unknown> {
+  #handlers: Set<AsyncEventHandler<T>> = new Set();
+
+  off(handler?: AsyncEventHandler<T>): void {
+    handler ? this.#handlers.delete(handler) : this.#handlers.clear();
+  }
+
+  on(handler: AsyncEventHandler<T>): () => boolean {
+    this.#handlers.add(handler);
+
+    return () => this.#handlers.delete(handler);
+  }
+
+  async emit(arg: T): Promise<void> {
+    for (const handler of this.#handlers) {
+      await handler(arg);
+    }
+  }
+}
+
+export type AsyncEvent<T extends unknown> = AsyncEventEmitter<T>['on'] & {
+  emit: AsyncEventEmitter<T>['emit'];
+};
+
+export function asyncEvent<T extends unknown>(): AsyncEvent<T> {
+  const emitter = new AsyncEventEmitter<T>();
+
+  return Object.assign(emitter.on.bind(emitter), {
+    emit: emitter.emit.bind(emitter),
+  });
+}

--- a/packages/modular-scripts/src/utils/env.ts
+++ b/packages/modular-scripts/src/utils/env.ts
@@ -1,0 +1,3 @@
+export function envBool(input: string | undefined, def = true): boolean {
+  return (def && !input) || input === 'true';
+}

--- a/packages/modular-scripts/src/utils/lifecycle.ts
+++ b/packages/modular-scripts/src/utils/lifecycle.ts
@@ -1,0 +1,51 @@
+import { AsyncEvent, asyncEvent, AsyncEventHandler } from './asyncEventEmitter';
+
+export interface TaskLifecycle<Context> {
+  initialize: AsyncEvent<Context>;
+  beforeGenerate: AsyncEvent<Context>;
+  generate: AsyncEvent<Context>;
+  afterGenerate: AsyncEvent<Context>;
+  finalize: AsyncEvent<Context>;
+
+  run(context: Context): Promise<void>;
+}
+
+class Lifecycle<Context> implements TaskLifecycle<Context> {
+  public readonly initialize = asyncEvent<Context>();
+  public readonly beforeGenerate = asyncEvent<Context>();
+  public readonly generate = asyncEvent<Context>();
+  public readonly afterGenerate = asyncEvent<Context>();
+  public readonly finalize = asyncEvent<Context>();
+
+  public async run(context: Context) {
+    await [
+      this.initialize,
+      this.beforeGenerate,
+      this.generate,
+      this.afterGenerate,
+      this.finalize,
+    ].reduce(
+      async (chain, emitter) => await emitter.emit(context),
+      Promise.resolve(),
+    );
+  }
+}
+
+export function createLifecycle<Context>(): TaskLifecycle<Context> {
+  return new Lifecycle<Context>();
+}
+
+export function requireInContext<Context>(
+  key: keyof Context,
+  handler: AsyncEventHandler<Context>,
+): AsyncEventHandler<Context> {
+  return (context) => {
+    if (!context[key]) {
+      throw new Error(
+        `requireInContext: cannot run without first setting "${String(key)}"`,
+      );
+    }
+
+    return handler(context);
+  };
+}


### PR DESCRIPTION
Split the main `modular build` handler into a lifecycle style runner,
 each step of the process can be handled by one or more async functions
 run in series, sharing build state with a `StandAloneBuilderContext`.

Configuring the steps and running the build is now split into separate
 concerns, which should help run builds concurrently as their state
 isn't shared.