### PR TITLE
Integrate workspace resolver into modular-scripts

### DIFF
--- a/.changeset/sour-windows-laugh.md
+++ b/.changeset/sour-windows-laugh.md
@@ -1,0 +1,7 @@
+---
+'modular-scripts': minor
+'@modular-scripts/modular-types': minor
+'@modular-scripts/workspace-resolver': minor
+---
+
+Integrate new yarn-agnostic workspace resolver

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,5 +34,7 @@ jobs:
 
       - name: 'Install Dependencies'
         run: yarn --frozen-lockfile
+      - name: 'Build internal prerequisites'
+        run: yarn workspace @modular-scripts/workspace-resolver build
       - name: ${{ matrix.name }}
         run: yarn ${{ matrix.command }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -31,5 +31,7 @@ jobs:
           cache: 'yarn'
       - name: Install Dependencies
         run: yarn --frozen-lockfile
+      - name: 'Build internal prerequisites'
+        run: yarn workspace @modular-scripts/workspace-resolver build
       - name: Run Windows tests
         run: yarn test esmView.test.ts workspace-resolver

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
           cache: 'yarn'
       - name: Install Dependencies
         run: yarn --frozen-lockfile
+      - name: 'Build internal prerequisites'
+        run: yarn workspace @modular-scripts/workspace-resolver build
       - name: Run Tests
         run: yarn test --coverage
       - name: Coveralls Parallel

--- a/packages/modular-scripts/src/__tests__/convert.test.ts
+++ b/packages/modular-scripts/src/__tests__/convert.test.ts
@@ -37,7 +37,7 @@ describe('Converting a react app to modular app', () => {
   beforeAll(async () => {
     tmpFolder = tmp.dirSync({ unsafeCleanup: true });
     tmpFolderPath = path.join(tmpFolder.name, tmpProjectName);
-    await fs.mkdir(tmpFolderPath);
+    await fs.mkdirp(tmpFolderPath);
     mockedModularRoot.mockImplementation(() => tmpFolderPath);
     const starterFolder = ['src', 'public'];
     starterFolder.forEach((dir) => {
@@ -154,6 +154,7 @@ describe('Converting a react app to modular app', () => {
       ),
     ).toBe(false);
   });
+
   it('should remove react-scripts from the dependencies', () => {
     const updatedPackageJson = fs.readJsonSync(
       path.join(tmpFolderPath, 'package.json'),

--- a/packages/modular-scripts/src/__tests__/init.test.tsx
+++ b/packages/modular-scripts/src/__tests__/init.test.tsx
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as tmp from 'tmp';
 import * as fs from 'fs-extra';
 import { promisify } from 'util';
-import { getWorkspaceInfo } from '../utils/getAllWorkspaces';
+import { getWorkspacePackages } from '../utils/getAllWorkspaces';
 
 import type { ModularPackageJson } from '@modular-scripts/modular-types';
 
@@ -47,7 +47,7 @@ describe('Creating a new modular folder', () => {
   });
 
   it('should not have any workspace info', async () => {
-    const workspace = await getWorkspaceInfo(folder);
+    const workspace = await getWorkspacePackages(folder);
     expect(workspace).toEqual({});
   });
 });

--- a/packages/modular-scripts/src/__tests__/init.test.tsx
+++ b/packages/modular-scripts/src/__tests__/init.test.tsx
@@ -51,9 +51,12 @@ describe('Creating a new modular folder', () => {
 
     // 1 item in the workspace output (the root package)
     expect(workspace[0].size).toEqual(1);
-    const item = Array.from(workspace[0])[0][1];
-    expect(item.version).toEqual('1.0.0');
-    expect(item.workspace).toEqual(true);
+    const workspaceMap = workspace[0];
+    expect(workspaceMap).toEqual(expect.any(Map));
+    const [, workspaceContent] = Array.from(workspaceMap)[0];
+    expect(workspaceContent).toEqual(
+      expect.objectContaining({ version: '1.0.0', workspace: true }),
+    );
 
     // Empty dependency analysis
     expect(workspace[1]).toEqual({});

--- a/packages/modular-scripts/src/__tests__/init.test.tsx
+++ b/packages/modular-scripts/src/__tests__/init.test.tsx
@@ -46,8 +46,16 @@ describe('Creating a new modular folder', () => {
     expect(String(lockfile)).toMatchSnapshot();
   });
 
-  it('should not have any workspace info', async () => {
-    const workspace = await getWorkspacePackages(folder);
-    expect(workspace).toEqual({});
+  it('should contain 1 workspace (the root) and an empty dependency analysis', async () => {
+    const workspace = await getWorkspacePackages(folder, folder);
+
+    // 1 item in the workspace output (the root package)
+    expect(workspace[0].size).toEqual(1);
+    const item = Array.from(workspace[0])[0][1];
+    expect(item.version).toEqual('1.0.0');
+    expect(item.workspace).toEqual(true);
+
+    // Empty dependency analysis
+    expect(workspace[1]).toEqual({});
   });
 });

--- a/packages/modular-scripts/src/__tests__/init.test.tsx
+++ b/packages/modular-scripts/src/__tests__/init.test.tsx
@@ -47,7 +47,7 @@ describe('Creating a new modular folder', () => {
   });
 
   it('should not have any workspace info', async () => {
-    const workspace = await getWorkspaceInfo(folder, 'yarn');
+    const workspace = await getWorkspaceInfo(folder);
     expect(workspace).toEqual({});
   });
 });

--- a/packages/modular-scripts/src/__tests__/port.test.ts
+++ b/packages/modular-scripts/src/__tests__/port.test.ts
@@ -183,6 +183,7 @@ describe('Porting a react app into a modular project', () => {
       );
     });
   });
+
   describe('when modular root has the targeted app dependency', () => {
     it('should not add it to the new app package.json', async () => {
       fs.writeJsonSync(
@@ -216,6 +217,7 @@ describe('Porting a react app into a modular project', () => {
       );
     });
   });
+
   describe('when modular root has the targeted app dev dependency', () => {
     it('should not add it to the new app package.json', async () => {
       fs.writeJsonSync(

--- a/packages/modular-scripts/src/build/buildPackage/getPackageEntryPoints.ts
+++ b/packages/modular-scripts/src/build/buildPackage/getPackageEntryPoints.ts
@@ -1,14 +1,15 @@
-import type { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
 import * as path from 'path';
 import * as fse from 'fs-extra';
 
 import getModularRoot from '../../utils/getModularRoot';
 import getPackageMetadata from '../../utils/getPackageMetadata';
 
+import type { ModularPackageJson } from '@modular-scripts/modular-types';
+
 export function getMain(
   packagePath: string,
   includePrivate: boolean,
-  packageJson: JSONSchemaForNPMPackageJsonFiles | undefined,
+  packageJson: ModularPackageJson | undefined,
 ): string {
   let main: string | undefined;
 

--- a/packages/modular-scripts/src/check/index.ts
+++ b/packages/modular-scripts/src/check/index.ts
@@ -19,7 +19,10 @@ interface Verification {
   fix?(): Promise<void>;
 }
 
-export async function check({ fix = false, target }: Check): Promise<void> {
+export async function check({
+  fix = false,
+  target = process.cwd(),
+}: Check): Promise<void> {
   let failed = false;
 
   for (const checkName of CHECKS) {
@@ -32,7 +35,7 @@ export async function check({ fix = false, target }: Check): Promise<void> {
     }
 
     // if the check returns false then we fail and show the error.
-    if (await checkCls.check(target || process.cwd())) {
+    if (await checkCls.check(target)) {
       continue;
     } else {
       failed = true;

--- a/packages/modular-scripts/src/check/index.ts
+++ b/packages/modular-scripts/src/check/index.ts
@@ -10,17 +10,22 @@ const CHECKS = [
 ];
 
 interface Check {
-  check(target?: string): Promise<boolean>;
-  fix?(this: void): Promise<void>;
+  fix: boolean;
+  target?: string;
 }
 
-export async function check(fix = false, target?: string): Promise<void> {
+interface Verification {
+  check(target?: string): Promise<boolean>;
+  fix?(): Promise<void>;
+}
+
+export async function check({ fix = false, target }: Check): Promise<void> {
   let failed = false;
 
   for (const checkName of CHECKS) {
     logger.debug('');
     logger.debug(`===== Running ${checkName} =====`);
-    const checkCls = (await import(`./${checkName}`)) as Check;
+    const checkCls = (await import(`./${checkName}`)) as Verification;
 
     if (fix && checkCls.fix) {
       await checkCls.fix();

--- a/packages/modular-scripts/src/check/index.ts
+++ b/packages/modular-scripts/src/check/index.ts
@@ -10,11 +10,11 @@ const CHECKS = [
 ];
 
 interface Check {
-  check(this: void): Promise<boolean>;
+  check(target?: string): Promise<boolean>;
   fix?(this: void): Promise<void>;
 }
 
-export async function check(fix = false): Promise<void> {
+export async function check(fix = false, target?: string): Promise<void> {
   let failed = false;
 
   for (const checkName of CHECKS) {
@@ -27,7 +27,7 @@ export async function check(fix = false): Promise<void> {
     }
 
     // if the check returns false then we fail and show the error.
-    if (await checkCls.check()) {
+    if (await checkCls.check(target || process.cwd())) {
       continue;
     } else {
       failed = true;

--- a/packages/modular-scripts/src/check/verifyBrowserslist.ts
+++ b/packages/modular-scripts/src/check/verifyBrowserslist.ts
@@ -11,14 +11,14 @@ import { defaultBrowsers } from '../utils/checkBrowsers';
 
 import type { ModularPackageJson } from '@modular-scripts/modular-types';
 
-export async function check(): Promise<boolean> {
+export async function check(target?: string): Promise<boolean> {
   let valid = true;
 
   browserslist.clearCaches();
 
   const modularRoot = getModularRoot();
 
-  const workspace = await getWorkspaceInfo();
+  const workspace = await getWorkspaceInfo(target);
 
   for (const [packageName, worktree] of Object.entries(workspace)) {
     if (worktree.type === 'app') {

--- a/packages/modular-scripts/src/check/verifyWorkspaceDependencies.ts
+++ b/packages/modular-scripts/src/check/verifyWorkspaceDependencies.ts
@@ -4,7 +4,7 @@ import getWorkspaceInfo from '../utils/getWorkspaceInfo';
 import { getModularType, isValidModularType } from '../utils/isModularType';
 import * as logger from '../utils/logger';
 
-export async function check(): Promise<boolean> {
+export async function check(target?: string): Promise<boolean> {
   let valid = true;
 
   const modularRoot = getModularRoot();
@@ -13,7 +13,7 @@ export async function check(): Promise<boolean> {
   // init is a special case where we don't already need to be in a modular repository
   // in this case there's no use checking the workspaces yet because we're setting
   // up a new folder
-  const workspace = await getWorkspaceInfo();
+  const workspace = await getWorkspaceInfo(target);
 
   /**
    * Validate the structure of the workspace to ensure there's no mismatched dependencies and that

--- a/packages/modular-scripts/src/check/verifyWorkspaceStructure.ts
+++ b/packages/modular-scripts/src/check/verifyWorkspaceStructure.ts
@@ -4,9 +4,9 @@ import getModularRoot from '../utils/getModularRoot';
 import getWorkspaceInfo from '../utils/getWorkspaceInfo';
 import * as logger from '../utils/logger';
 
-export async function check(): Promise<boolean> {
+export async function check(target?: string): Promise<boolean> {
   let valid = true;
-  const workspace = await getWorkspaceInfo();
+  const workspace = await getWorkspaceInfo(target);
   const modularRoot = getModularRoot();
 
   /**

--- a/packages/modular-scripts/src/convert.ts
+++ b/packages/modular-scripts/src/convert.ts
@@ -164,7 +164,7 @@ export async function convert(cwd: string = process.cwd()): Promise<void> {
     });
 
     logger.log('Validating your modular project...');
-    await check(false, cwd);
+    await check({ fix: false, target: cwd });
   } catch (err) {
     logger.error(err as string);
     stashChanges();

--- a/packages/modular-scripts/src/convert.ts
+++ b/packages/modular-scripts/src/convert.ts
@@ -164,7 +164,7 @@ export async function convert(cwd: string = process.cwd()): Promise<void> {
     });
 
     logger.log('Validating your modular project...');
-    await check();
+    await check(false, cwd);
   } catch (err) {
     logger.error(err as string);
     stashChanges();

--- a/packages/modular-scripts/src/port.ts
+++ b/packages/modular-scripts/src/port.ts
@@ -199,7 +199,7 @@ export async function port(relativePath: string): Promise<void> {
       devDependencies: targetDevDeps = {},
     } = targetedAppPackageJson;
 
-    const workspaces = await getWorkspaceInfo();
+    const workspaces = await getWorkspaceInfo(modularRoot);
 
     const publicPackages = Object.keys(workspaces).filter(
       (name) => workspaces[name].public,
@@ -309,7 +309,7 @@ export async function port(relativePath: string): Promise<void> {
 
     logger.log('Validating your modular project...');
 
-    await check();
+    await check(false, modularRoot);
 
     logger.log('Successfully ported your app over!');
 

--- a/packages/modular-scripts/src/port.ts
+++ b/packages/modular-scripts/src/port.ts
@@ -309,7 +309,7 @@ export async function port(relativePath: string): Promise<void> {
 
     logger.log('Validating your modular project...');
 
-    await check(false, modularRoot);
+    await check({ fix: false, target: modularRoot });
 
     logger.log('Successfully ported your app over!');
 

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -218,7 +218,7 @@ program
   .option('--verbose', 'Run yarn commands with --verbose set')
   .action(async ({ fix }: { fix: boolean }) => {
     const { check } = await import('./check');
-    await check(fix);
+    await check({ fix });
     logger.log(chalk.green('Success!'));
   });
 

--- a/packages/modular-scripts/src/utils/actionPreflightCheck.ts
+++ b/packages/modular-scripts/src/utils/actionPreflightCheck.ts
@@ -10,7 +10,7 @@ function actionPreflightCheck(fn: ModularAction): ModularAction {
     getModularRoot();
     if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
       const { check } = await import('../check');
-      await check();
+      await check({ fix: false });
     } else {
       logger.warn(
         'Preflight check is skipped. Modular repository may be invalid.',

--- a/packages/modular-scripts/src/utils/getAllWorkspaces.ts
+++ b/packages/modular-scripts/src/utils/getAllWorkspaces.ts
@@ -21,10 +21,7 @@ export async function getWorkspacePackages(
   modularRoot: string,
   target?: string,
 ): Promise<WorkspaceContent> {
-  const [allPackages] = await resolveWorkspace({
-    root: modularRoot,
-    workingDir: target,
-  });
+  const [allPackages] = await resolveWorkspace(modularRoot, target);
 
   return [allPackages, analyzeWorkspaceDependencies(allPackages)];
 }

--- a/packages/modular-scripts/src/utils/getAllWorkspaces.ts
+++ b/packages/modular-scripts/src/utils/getAllWorkspaces.ts
@@ -17,7 +17,7 @@ export interface PackageManagerInfo {
   formatWorkspaceCommandOutput: (stdout: string) => WorkspaceMap;
 }
 
-export async function getWorkspaceInfo(
+export async function getWorkspacePackages(
   modularRoot: string,
 ): Promise<WorkspaceContent> {
   const [allPackages] = await resolveWorkspace(modularRoot);
@@ -28,7 +28,7 @@ export async function getWorkspaceInfo(
 function _getAllWorkspaces(): Promise<WorkspaceContent> {
   const modularRoot = getModularRoot();
 
-  return getWorkspaceInfo(modularRoot);
+  return getWorkspacePackages(modularRoot);
 }
 
 export const getAllWorkspaces = memoize(_getAllWorkspaces);

--- a/packages/modular-scripts/src/utils/getAllWorkspaces.ts
+++ b/packages/modular-scripts/src/utils/getAllWorkspaces.ts
@@ -19,7 +19,7 @@ export interface PackageManagerInfo {
 
 export async function getWorkspacePackages(
   modularRoot: string,
-  target?: string,
+  target: string = modularRoot,
 ): Promise<WorkspaceContent> {
   const [allPackages] = await resolveWorkspace(modularRoot, target);
 

--- a/packages/modular-scripts/src/utils/getAllWorkspaces.ts
+++ b/packages/modular-scripts/src/utils/getAllWorkspaces.ts
@@ -19,16 +19,20 @@ export interface PackageManagerInfo {
 
 export async function getWorkspacePackages(
   modularRoot: string,
+  target?: string,
 ): Promise<WorkspaceContent> {
-  const [allPackages] = await resolveWorkspace(modularRoot);
+  const [allPackages] = await resolveWorkspace({
+    root: modularRoot,
+    workingDir: target,
+  });
 
   return [allPackages, analyzeWorkspaceDependencies(allPackages)];
 }
 
-function _getAllWorkspaces(): Promise<WorkspaceContent> {
+function _getAllWorkspaces(target?: string): Promise<WorkspaceContent> {
   const modularRoot = getModularRoot();
 
-  return getWorkspacePackages(modularRoot);
+  return getWorkspacePackages(modularRoot, target);
 }
 
 export const getAllWorkspaces = memoize(_getAllWorkspaces);

--- a/packages/modular-scripts/src/utils/getPackageMetadata.ts
+++ b/packages/modular-scripts/src/utils/getPackageMetadata.ts
@@ -32,39 +32,19 @@ async function getPackageMetadata() {
     ).dependencies || {};
 
   // let's populate the above three
-  const [workspaces, workspacesMap] = await getAllWorkspaces();
+  const [workspaces] = await getAllWorkspaces();
 
   // an array of all the package names
   const packageNames = Array.from(workspaces.keys());
 
   // a map of all package.json contents, indexed by package name
-  const pkgByName: PackageByPath = {};
-  const packageJsons = Array.from(workspaces).reduce(
-    (byName, [packageName, workspace]) => {
-      byName[packageName] = workspace.rawPackageJson;
-      return byName;
-    },
-    pkgByName,
-  );
+  const packageJsons: PackageByPath = {};
+  const packageJsonsByPackagePath: PackageByPath = {};
 
-  // a map of all package.json contents, indexed by directory name
-  const pkgByPath: PackageByPath = {};
-  const packageJsonsByPackagePath = Object.entries(workspacesMap).reduce(
-    (byPath, [packageName, { location }]) => {
-      const workspace = workspaces.get(packageName);
-      // @modular-scripts/workspace-resolver should guarantee a 1:1 relationship of items in workspaces and workspacesMap
-      if (!workspace) {
-        throw new Error(
-          'Modular was not able to understand your workspaces configuration',
-        );
-      }
-      const { rawPackageJson } = workspace;
-      byPath[location] = rawPackageJson;
-
-      return byPath;
-    },
-    pkgByPath,
-  );
+  Array.from(workspaces).forEach(([packageName, workspace]) => {
+    packageJsons[packageName] = workspace.rawPackageJson;
+    packageJsonsByPackagePath[workspace.location] = workspace.rawPackageJson;
+  });
 
   // TODO: do a quick check to make sure workspaces aren't
   // explicitly included in dependencies

--- a/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
+++ b/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
@@ -21,11 +21,11 @@ export interface WorkSpaceRecord {
 export type WorkspaceInfo = Record<string, WorkSpaceRecord>;
 
 export async function getWorkspaceInfo(): Promise<WorkspaceInfo> {
-  const workspaces = await getAllWorkspaces();
+  const [, workspacesMap] = await getAllWorkspaces();
   const workspaceRoot = getModularRoot();
 
   const res: WorkspaceInfo = {};
-  for (const [packageName, packageInfo] of Object.entries(workspaces)) {
+  for (const [packageName, packageInfo] of Object.entries(workspacesMap)) {
     const packageJson = (await fs.readJSON(
       path.join(workspaceRoot, packageInfo.location, 'package.json'),
     )) as ModularPackageJson;

--- a/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
+++ b/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
@@ -14,8 +14,10 @@ export interface WorkSpaceRecord {
 
 export type WorkspaceInfo = Record<string, WorkSpaceRecord>;
 
-export async function getWorkspaceInfo(): Promise<WorkspaceInfo> {
-  const [workspaces, workspacesMap] = await getAllWorkspaces();
+export async function getWorkspaceInfo(
+  target?: string,
+): Promise<WorkspaceInfo> {
+  const [workspaces, workspacesMap] = await getAllWorkspaces(target);
   const workspaceInfo: WorkspaceInfo = {};
 
   return Object.entries(workspacesMap).reduce(

--- a/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
+++ b/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
@@ -1,13 +1,7 @@
-import * as fs from 'fs-extra';
-import * as path from 'path';
-
-import type {
-  ModularType,
-  ModularPackageJson,
-} from '@modular-scripts/modular-types';
 import { getAllWorkspaces } from './getAllWorkspaces';
-import getModularRoot from './getModularRoot';
 import memoize from './memoize';
+
+import type { ModularType } from '@modular-scripts/modular-types';
 
 export interface WorkSpaceRecord {
   location: string;
@@ -21,28 +15,32 @@ export interface WorkSpaceRecord {
 export type WorkspaceInfo = Record<string, WorkSpaceRecord>;
 
 export async function getWorkspaceInfo(): Promise<WorkspaceInfo> {
-  const [, workspacesMap] = await getAllWorkspaces();
-  const workspaceRoot = getModularRoot();
+  const [workspaces, workspacesMap] = await getAllWorkspaces();
+  const workspaceInfo: WorkspaceInfo = {};
 
-  const res: WorkspaceInfo = {};
-  for (const [packageName, packageInfo] of Object.entries(workspacesMap)) {
-    const packageJson = (await fs.readJSON(
-      path.join(workspaceRoot, packageInfo.location, 'package.json'),
-    )) as ModularPackageJson;
+  return Object.entries(workspacesMap).reduce(
+    (byPath, [packageName, packageInfo]) => {
+      const workspace = workspaces.get(packageName);
+      // @modular-scripts/workspace-resolver should guarantee a 1:1 relationship of items in workspaces and workspacesMap
+      if (!workspace) {
+        throw new Error(
+          'Modular was not able to understand your workspaces configuration',
+        );
+      }
+      const { rawPackageJson } = workspace;
 
-    const type = packageJson.modular?.type || ('package' as ModularType);
+      const type = rawPackageJson.modular?.type || ('package' as ModularType);
+      workspaceInfo[packageName] = {
+        ...packageInfo,
+        type,
+        public: !rawPackageJson.private,
+        version: rawPackageJson.version,
+      };
 
-    const modularPackageInfo = {
-      ...packageInfo,
-      type,
-      public: !packageJson.private,
-      version: packageJson.version,
-    };
-
-    res[packageName] = modularPackageInfo;
-  }
-
-  return res;
+      return byPath;
+    },
+    workspaceInfo,
+  );
 }
 
 export default memoize(getWorkspaceInfo);

--- a/packages/modular-scripts/src/utils/gitActions.ts
+++ b/packages/modular-scripts/src/utils/gitActions.ts
@@ -15,7 +15,7 @@ export function cleanGit(cwd: string): boolean {
 }
 
 export function stashChanges(): void {
-  execa.sync('git', ['stash', '-u']);
+  // execa.sync('git', ['stash', '-u']);
   throw new Error('Failed to perform action cleanly. Stashing git changes...');
 }
 

--- a/packages/modular-scripts/src/utils/gitActions.ts
+++ b/packages/modular-scripts/src/utils/gitActions.ts
@@ -15,7 +15,7 @@ export function cleanGit(cwd: string): boolean {
 }
 
 export function stashChanges(): void {
-  // execa.sync('git', ['stash', '-u']);
+  execa.sync('git', ['stash', '-u']);
   throw new Error('Failed to perform action cleanly. Stashing git changes...');
 }
 

--- a/packages/modular-types/src/types.ts
+++ b/packages/modular-types/src/types.ts
@@ -16,7 +16,7 @@ export type ModularWorkspacePackage = {
     type: ModularType;
   };
   children: ModularWorkspacePackage[];
-  parent: ModularWorkspacePackage | null;
+  parent?: ModularWorkspacePackage;
   dependencies: Record<string, string> | undefined;
   rawPackageJson: ModularPackageJson;
 };

--- a/packages/modular-types/src/types.ts
+++ b/packages/modular-types/src/types.ts
@@ -8,6 +8,7 @@ export type ModularType = PackageType | UnknownType | 'root';
 
 export type ModularWorkspacePackage = {
   path: string;
+  location: string;
   name: string;
   version: string;
   workspace: boolean;

--- a/packages/modular-types/src/types.ts
+++ b/packages/modular-types/src/types.ts
@@ -17,6 +17,7 @@ export type ModularWorkspacePackage = {
   children: ModularWorkspacePackage[];
   parent: ModularWorkspacePackage | null;
   dependencies: Record<string, string> | undefined;
+  rawPackageJson: ModularPackageJson;
 };
 
 export interface WorkspaceObj {

--- a/packages/modular-types/src/types.ts
+++ b/packages/modular-types/src/types.ts
@@ -16,7 +16,7 @@ export type ModularWorkspacePackage = {
     type: ModularType;
   };
   children: ModularWorkspacePackage[];
-  parent?: ModularWorkspacePackage;
+  parent: ModularWorkspacePackage | null;
   dependencies: Record<string, string> | undefined;
   rawPackageJson: ModularPackageJson;
 };

--- a/packages/workspace-resolver/README.md
+++ b/packages/workspace-resolver/README.md
@@ -3,7 +3,11 @@
 This package encapsulates two functions:
 
 1. `resolveWorkspace` - Searches the filesystem (at a given modular root) for
-   workspace packages, returning a flat map of all packages found
+   workspace packages, returning a flat map of all packages found. An optional
+   2nd argument of `target` can be passed, which sets the working directory that
+   workspaces should be resolved from. This can be useful when the modular root
+   needs to be different to the current working directory, such as when modular
+   `convert` or `port` happens.
 2. `analyzeWorkspaceDependencies` - Analyzes `package.json` files for a set of
    workspace packages, returning a flat object for each package, listing out
    workspace inter-dependencies plus and mismatched dependencies. The

--- a/packages/workspace-resolver/src/__tests__/resolve-workspace.test.ts
+++ b/packages/workspace-resolver/src/__tests__/resolve-workspace.test.ts
@@ -18,10 +18,7 @@ describe('@modular-scripts/workspace-resolver', () => {
   describe('resolveWorkspace', () => {
     it('resolves a clean workspace, detecting modular packages as appropriate', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-1`;
-      const [allPackages] = await resolveWorkspace({
-        root: projectRoot,
-        workingDir: projectRoot,
-      });
+      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
       expect(allPackages.has('clean-workspace-1')).toEqual(true);
       expect(allPackages.has('app-one')).toEqual(true);
       expect(allPackages.has('package-one')).toEqual(true);
@@ -32,10 +29,7 @@ describe('@modular-scripts/workspace-resolver', () => {
     // See https://classic.yarnpkg.com/blog/2018/02/15/nohoist/
     it('resolves a clean workspace (using object workspaces syntax)', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-2`;
-      const [allPackages] = await resolveWorkspace({
-        root: projectRoot,
-        workingDir: projectRoot,
-      });
+      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
       expect(allPackages.has('clean-workspace-2')).toEqual(true);
       expect(allPackages.has('app-one')).toEqual(true);
       expect(allPackages.has('package-one')).toEqual(true);
@@ -44,10 +38,7 @@ describe('@modular-scripts/workspace-resolver', () => {
 
     it('resolves a clean workspace (using workspace ranges)', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-3`;
-      const [allPackages] = await resolveWorkspace({
-        root: projectRoot,
-        workingDir: projectRoot,
-      });
+      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
       expect(allPackages.has('clean-workspace-3')).toEqual(true);
       expect(allPackages.has('app-one')).toEqual(true);
       expect(allPackages.has('package-one')).toEqual(true);
@@ -62,7 +53,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
+        await resolveWorkspace(projectRoot, projectRoot);
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -82,7 +73,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
+        await resolveWorkspace(projectRoot, projectRoot);
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -102,7 +93,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
+        await resolveWorkspace(projectRoot, projectRoot);
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -122,7 +113,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
+        await resolveWorkspace(projectRoot, projectRoot);
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -142,7 +133,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
+        await resolveWorkspace(projectRoot, projectRoot);
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -160,10 +151,7 @@ describe('@modular-scripts/workspace-resolver', () => {
   describe('analyzeWorkspaceDependencies', () => {
     it('correctly identifies workspace dependencies for a clean workspace', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-1`;
-      const [allPackages] = await resolveWorkspace({
-        root: projectRoot,
-        workingDir: projectRoot,
-      });
+      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
 
       const result = analyzeWorkspaceDependencies(allPackages);
       const expected = {
@@ -188,10 +176,7 @@ describe('@modular-scripts/workspace-resolver', () => {
 
     it('correctly identifies mismatched dependencies', async () => {
       const projectRoot = `${fixturesPath}mismatched-dependency`;
-      const [allPackages] = await resolveWorkspace({
-        root: projectRoot,
-        workingDir: projectRoot,
-      });
+      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
 
       const result = analyzeWorkspaceDependencies(allPackages);
       const expected = {
@@ -216,10 +201,7 @@ describe('@modular-scripts/workspace-resolver', () => {
 
     it('correctly identifies dependencies (workspace range)', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-3`;
-      const [allPackages] = await resolveWorkspace({
-        root: projectRoot,
-        workingDir: projectRoot,
-      });
+      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
 
       // Matches explanation (version 1.0.0):
       // Range of '*': matches

--- a/packages/workspace-resolver/src/__tests__/resolve-workspace.test.ts
+++ b/packages/workspace-resolver/src/__tests__/resolve-workspace.test.ts
@@ -18,7 +18,10 @@ describe('@modular-scripts/workspace-resolver', () => {
   describe('resolveWorkspace', () => {
     it('resolves a clean workspace, detecting modular packages as appropriate', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-1`;
-      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
+      const [allPackages] = await resolveWorkspace({
+        root: projectRoot,
+        workingDir: projectRoot,
+      });
       expect(allPackages.has('clean-workspace-1')).toEqual(true);
       expect(allPackages.has('app-one')).toEqual(true);
       expect(allPackages.has('package-one')).toEqual(true);
@@ -29,7 +32,10 @@ describe('@modular-scripts/workspace-resolver', () => {
     // See https://classic.yarnpkg.com/blog/2018/02/15/nohoist/
     it('resolves a clean workspace (using object workspaces syntax)', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-2`;
-      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
+      const [allPackages] = await resolveWorkspace({
+        root: projectRoot,
+        workingDir: projectRoot,
+      });
       expect(allPackages.has('clean-workspace-2')).toEqual(true);
       expect(allPackages.has('app-one')).toEqual(true);
       expect(allPackages.has('package-one')).toEqual(true);
@@ -38,7 +44,10 @@ describe('@modular-scripts/workspace-resolver', () => {
 
     it('resolves a clean workspace (using workspace ranges)', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-3`;
-      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
+      const [allPackages] = await resolveWorkspace({
+        root: projectRoot,
+        workingDir: projectRoot,
+      });
       expect(allPackages.has('clean-workspace-3')).toEqual(true);
       expect(allPackages.has('app-one')).toEqual(true);
       expect(allPackages.has('package-one')).toEqual(true);
@@ -53,7 +62,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace(projectRoot, projectRoot);
+        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -73,7 +82,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace(projectRoot, projectRoot);
+        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -93,7 +102,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace(projectRoot, projectRoot);
+        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -113,7 +122,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace(projectRoot, projectRoot);
+        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -133,7 +142,7 @@ describe('@modular-scripts/workspace-resolver', () => {
       let message = '';
 
       try {
-        await resolveWorkspace(projectRoot, projectRoot);
+        await resolveWorkspace({ root: projectRoot, workingDir: projectRoot });
       } catch (err) {
         thrown = true;
         if (err instanceof Error) {
@@ -151,7 +160,10 @@ describe('@modular-scripts/workspace-resolver', () => {
   describe('analyzeWorkspaceDependencies', () => {
     it('correctly identifies workspace dependencies for a clean workspace', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-1`;
-      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
+      const [allPackages] = await resolveWorkspace({
+        root: projectRoot,
+        workingDir: projectRoot,
+      });
 
       const result = analyzeWorkspaceDependencies(allPackages);
       const expected = {
@@ -176,7 +188,10 @@ describe('@modular-scripts/workspace-resolver', () => {
 
     it('correctly identifies mismatched dependencies', async () => {
       const projectRoot = `${fixturesPath}mismatched-dependency`;
-      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
+      const [allPackages] = await resolveWorkspace({
+        root: projectRoot,
+        workingDir: projectRoot,
+      });
 
       const result = analyzeWorkspaceDependencies(allPackages);
       const expected = {
@@ -201,7 +216,10 @@ describe('@modular-scripts/workspace-resolver', () => {
 
     it('correctly identifies dependencies (workspace range)', async () => {
       const projectRoot = `${fixturesPath}clean-workspace-3`;
-      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
+      const [allPackages] = await resolveWorkspace({
+        root: projectRoot,
+        workingDir: projectRoot,
+      });
 
       // Matches explanation (version 1.0.0):
       // Range of '*': matches

--- a/packages/workspace-resolver/src/resolve-workspace.ts
+++ b/packages/workspace-resolver/src/resolve-workspace.ts
@@ -97,6 +97,9 @@ export async function resolveWorkspace(
       ...json.devDependencies,
       ...json.dependencies,
     },
+    // Various parts of modular reach into package.json
+    // It's helpful to keep a full copy of this to avoid duplicate IO later on
+    rawPackageJson: json,
   };
   collector.set(json.name, pkg);
 

--- a/packages/workspace-resolver/src/resolve-workspace.ts
+++ b/packages/workspace-resolver/src/resolve-workspace.ts
@@ -52,24 +52,14 @@ function readPackageJson(
   return readJson(jsonPath) as Promise<ModularPackageJson>;
 }
 
-interface ResolveWorkspaceArgs {
-  root: string;
-  workingDir?: string;
-  parent?: ModularWorkspacePackage;
-  collector?: Map<string, ModularWorkspacePackage>;
-}
-
 export async function resolveWorkspace(
-  args: ResolveWorkspaceArgs,
+  root: string,
+  workingDir: string | null = null,
+  parent: ModularWorkspacePackage | null = null,
+  collector = new Map<string, ModularWorkspacePackage>(),
 ): Promise<
   [Map<string, ModularWorkspacePackage>, ModularWorkspacePackage | null]
 > {
-  const {
-    root,
-    workingDir,
-    parent,
-    collector = new Map<string, ModularWorkspacePackage>(),
-  } = args;
   const workingDirToUse = workingDir ?? process.cwd();
   const isRoot = workingDirToUse === root;
   const pkgPath = packageJsonPath(root);
@@ -141,12 +131,12 @@ export async function resolveWorkspace(
   }
 
   for (const link of resolveWorkspacesDefinition(root, json.workspaces)) {
-    const [, child] = await resolveWorkspace({
-      root: link,
-      workingDir: workingDirToUse,
-      parent: pkg,
+    const [, child] = await resolveWorkspace(
+      link,
+      workingDirToUse,
+      pkg,
       collector,
-    });
+    );
     child && pkg.children.push(child);
   }
 

--- a/packages/workspace-resolver/src/resolve-workspace.ts
+++ b/packages/workspace-resolver/src/resolve-workspace.ts
@@ -62,13 +62,13 @@ export async function resolveWorkspace(
 > {
   const workingDirToUse = workingDir ?? process.cwd();
   const isRoot = workingDirToUse === root;
-  const path = packageJsonPath(root);
-  const json = await readPackageJson(isRoot, workingDirToUse, path);
+  const pkgPath = packageJsonPath(root);
+  const json = await readPackageJson(isRoot, workingDirToUse, pkgPath);
   const isModularRoot = json.modular?.type === 'root';
 
   if (!json.name) {
     throw new Error(
-      `The package at ${path} does not have a valid name. Modular requires workspace packages to have a name.`,
+      `The package at ${pkgPath} does not have a valid name. Modular requires workspace packages to have a name.`,
     );
   }
 
@@ -81,7 +81,8 @@ export async function resolveWorkspace(
   }
 
   const pkg: ModularWorkspacePackage = {
-    path,
+    path: pkgPath,
+    location: path.dirname(pkgPath),
     name: json.name,
     version: versionToUse,
     workspace: !!json.workspaces,


### PR DESCRIPTION
### Backwards-compatible implementation swap for `getAllWorkspaces()`

- Implemented `@modular-scripts/workspace-resolver` in `getAllWorkspaces`. Also removed the old implementation.
- Updated the interface of `getAllWorkspaces` to accept an optional `target` string, which can be thought of as a working directory. It is required when the modular root based off `process.cwd()` is not the same as the directory we want to parse workspaces from. This allows the new implementation to work with operations such as `convert` and `port` without any breakages.
- Updated the interface of `Check` so that `check()` has an optional `target?: string` argument
- Changed `getWorkspaceInfo` to work with the new implementation *and* perform less filesystem IO
  - Since we are already reading `package.json` files in the workspace-resolver, reading them again would be duplicate filesystem IO work
  - By adding the `location` and `rawPackageJson` fields to `ModularWorkspacePackage` in `@modular-scripts/workspace-resolver`, we save all this extra IO
  - The approach with `rawPackageJson` can be considered "lazy": the alternatives as I see it are to either (a) keep the duplicate IO or (b) reduce it to _what we need_ - but this would require significant refactoring, as the whole content is currently exposed by `getPackageMetadata` & various commands depend on that function
- Changed `getPackageMetadata` to work with the new structures returned by `@modular-scripts/workspace-resolver`
- Also made `getPackageMetadata` use the more accurate `@modular-scripts/workspace-resolver` `ModularPackageJson` type instead of `JSONSchemaForNPMPackageJsonFiles`
- Renamed `getWorkspaceInfo` in `utils/getAllWorkspaces` to become `getWorkspacePackages`. This is because `getWorkspaceInfo` was conflicting with a function of the same name in `utils/getWorkspaceInfo`. It was quite confusing before.
- Updated CI so that `@modular-scripts/workspace-resolver` is built as a prerequisite step - this is needed because we're now using it directly in `modular-scripts`
