### PR TITLE
Add --staged to modular lint

### DIFF
--- a/.changeset/silly-hairs-sip.md
+++ b/.changeset/silly-hairs-sip.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+Add --staged flag to modular lint

--- a/packages/modular-scripts/src/lint.ts
+++ b/packages/modular-scripts/src/lint.ts
@@ -6,28 +6,29 @@ import actionPreflightCheck from './utils/actionPreflightCheck';
 import { resolveAsBin } from './utils/resolveAsBin';
 import getModularRoot from './utils/getModularRoot';
 import execAsync from './utils/execAsync';
-import { getDiffedFiles } from './utils/gitActions';
+import { addFiles, getDiffedFiles, getStagedFiles } from './utils/gitActions';
 import * as logger from './utils/logger';
 
 export interface LintOptions {
   all: boolean;
   fix: boolean;
+  staged: boolean;
 }
 
 async function lint(
   options: LintOptions,
   regexes: string[] = [],
 ): Promise<void> {
-  const { all = false, fix = false } = options;
+  const { all = false, fix = false, staged = false } = options;
   const modularRoot = getModularRoot();
   const lintExtensions = ['.ts', '.tsx', '.js', '.jsx'];
   let targetedFiles = ['<rootDir>/**/src/**/*.{js,jsx,ts,tsx}'];
 
   if (!all && !isCI && regexes.length === 0) {
-    const diffedFiles = getDiffedFiles();
+    const diffedFiles = staged ? getStagedFiles() : getDiffedFiles();
     if (diffedFiles.length === 0) {
       logger.log(
-        'No diffed files detected. Add the `--all` option to lint the entire codebase',
+        'No diffed files detected. Use the `--all` option to lint the entire codebase',
       );
       return;
     }
@@ -71,6 +72,11 @@ async function lint(
         MODULAR_LINT_FIX: String(fix),
       },
     });
+
+    if (staged && fix) {
+      targetedFiles = targetedFiles.map((p) => p.replace('<rootDir>/', ''));
+      addFiles(targetedFiles);
+    }
   } catch (err) {
     logger.debug((err as ExecaError).message);
     // ✕ Modular lint did not pass

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -3,7 +3,7 @@
 import * as fs from 'fs-extra';
 import isCI from 'is-ci';
 import chalk from 'chalk';
-import commander from 'commander';
+import commander, { Option } from 'commander';
 import type { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 import type { TestOptions } from './test';
 import type { LintOptions } from './lint';
@@ -245,13 +245,23 @@ program
     await port(relativePath);
   });
 
+const lintStagedFlag = '--staged';
 program
   .command('lint [regexes...]')
   .option(
     '--all',
     'Only lint diffed files from your remote origin default branch (e.g. main or master)',
   )
-  .option('--fix', 'Fix the lint errors wherever possible')
+  .option(
+    '--fix',
+    `Fix the lint errors wherever possible, restages changes if run with ${lintStagedFlag}`,
+  )
+  .addOption(
+    new Option(
+      lintStagedFlag,
+      'Only lint files that have been staged to be committed',
+    ).conflicts('all'),
+  )
   .description('Lints the codebase')
   .action(async (regexes: string[], options: LintOptions) => {
     const { default: lint } = await import('./lint');


### PR DESCRIPTION
Adds support for a `--staged` flag to modular lint.

This flag conflicts with `--all` and only lint checks files that have been staged with git.

If the `--fix` flag is provided, it will run lint fix on only the staged files and then re-stage changes on **only** the previously staged files.

This makes `modular lint --fix --staged` a good pre-commit hook, especially when paired with `eslint-plugin-prettier`.

Tested `--staged` with no changes, non-staged changes, partially staged changes, and fully staged changes on a repository with and without the `--fix` flag to ensure it functions correctly. I didn't see any place for unit tests for `gitActions.ts` so I didn't write any. The `lint.ts` tests also didn't test any lint flags so I also didn't test `--staged` there.