### PR TITLE
Bump the versions that weren't bumped when releasing 3.3.0

### DIFF
--- a/.changeset/good-otters-work.md
+++ b/.changeset/good-otters-work.md
@@ -1,0 +1,7 @@
+---
+'@modular-scripts/workspace-resolver': minor
+'modular-scripts': patch
+'@modular-scripts/modular-types': patch
+---
+
+Export computeAncestorWorkspaces


### PR DESCRIPTION
When merging https://github.com/jpmorganchase/modular/pull/2027, the Github changesets bot didn't recognise all the changed packages automatically and we erroneously bumped only "modular-scripts" to minor (3.3.0).
The result is that we now are dependent from "@modular-scripts/workspace-resolver@1.0.0" (the old version) in modular-scripts@3.3.0 and modular fails when we try to use `modular test --changed` because it needs the newer version of workspace-resolver that was never published (`[modular] (0 , _workspaceResolver.computeAncestorWorkspaces) is not a function`).

This PR bumps the packages that weren't bumped before.