### PR TITLE
Fix `lint --staged --fix` falsely failing when a deleted file is in the staged files

### DIFF
--- a/.changeset/itchy-clouds-exist.md
+++ b/.changeset/itchy-clouds-exist.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Fix bug in lint --staged --fix where deleted files would fail the lint.

--- a/.changeset/silver-houses-count.md
+++ b/.changeset/silver-houses-count.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": patch
+---
+
+Fix `lint --staged --fix` falsely failing when a deleted file is in the staged files

--- a/packages/modular-scripts/src/lint.ts
+++ b/packages/modular-scripts/src/lint.ts
@@ -24,7 +24,7 @@ async function lint(
   const lintExtensions = ['.ts', '.tsx', '.js', '.jsx'];
   let targetedFiles = ['<rootDir>/**/src/**/*.{js,jsx,ts,tsx}'];
 
-  if (!all && !isCI && regexes.length === 0) {
+  if (!all && (!isCI || staged) && regexes.length === 0) {
     const diffedFiles = staged ? getStagedFiles() : getDiffedFiles();
     if (diffedFiles.length === 0) {
       logger.log(


### PR DESCRIPTION
This fixes a bug where if a file was deleted and `modular lint --staged --fix` was run on a CI environment, it would fail because it would try and git add a non-existent file.