### PR TITLE
Create test for current state of the `verifyWorkspaceDependencies` check

### DIFF
--- a/__fixtures__/verify-workspace/other-packages/package-four/package.json
+++ b/__fixtures__/verify-workspace/other-packages/package-four/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-four",
+  "private": true,
+  "modular": {
+    "type": "esm-view"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/verify-workspace/package.json
+++ b/__fixtures__/verify-workspace/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "clean-workspace-3",
+  "version": "1.0.0",
+  "author": "App Frameworks team",
+  "license": "MIT",
+  "private": true,
+  "workspaces": [
+    "packages/**",
+    "other-packages/**"
+  ],
+  "modular": {
+    "type": "root"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}

--- a/__fixtures__/verify-workspace/packages/app-one/package.json
+++ b/__fixtures__/verify-workspace/packages/app-one/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "app-one",
+  "private": true,
+  "modular": {
+    "type": "app"
+  },
+  "dependencies": {
+    "package-one": "workspace:*",
+    "package-two": "workspace:^",
+    "package-three": "workspace:~",
+    "package-four": "workspace:^1.0.0"
+  },
+  "version": "1.0.0"
+}

--- a/__fixtures__/verify-workspace/packages/package-one/package.json
+++ b/__fixtures__/verify-workspace/packages/package-one/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-one",
+  "private": true,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/verify-workspace/packages/package-three/package.json
+++ b/__fixtures__/verify-workspace/packages/package-three/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "package-three",
+  "private": true,
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/verify-workspace/packages/package-two/package.json
+++ b/__fixtures__/verify-workspace/packages/package-two/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-two",
+  "private": true,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/packages/modular-scripts/src/__tests__/check/verifyWorkspaceDependencies.test.ts
+++ b/packages/modular-scripts/src/__tests__/check/verifyWorkspaceDependencies.test.ts
@@ -1,0 +1,40 @@
+import { check } from '../../check/verifyWorkspaceDependencies';
+import getModularRoot from '../../utils/getModularRoot';
+import { error } from '../../utils/logger';
+
+jest.mock('../../utils/getModularRoot', () => jest.fn());
+jest.mock('../../utils/logger', () => ({
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+describe('verifyWorkspaceDependencies', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('checks a valid workspace', async () => {
+    mock(getModularRoot).mockReturnValue(
+      '__fixtures__/resolve-workspace/clean-workspace-1',
+    );
+
+    expect(await check()).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('rejects packages not in the "packages" directory', async () => {
+    mock(getModularRoot).mockReturnValue('__fixtures__/verify-workspace');
+
+    const checked = await check('__fixtures__/verify-workspace');
+    expect(checked).toBe(false);
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `package-four is not located within the "/packages" directory`,
+      ),
+    );
+  });
+});
+
+function mock(input: unknown) {
+  return input as jest.Mock;
+}


### PR DESCRIPTION
Codifies some of the current behaviour of the `verifyWorkspaceDependencies` check to simplify making changes to it in the future.