### PR TITLE
Selective test on workspace name with the --package option

### DIFF
--- a/.changeset/friendly-dancers-fix.md
+++ b/.changeset/friendly-dancers-fix.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": minor
+---
+
+Selective test on workspace name with the --package option

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -64,7 +64,7 @@ Specify the comparison branch used to determine which files have changed when
 using the `changed` option. If this option is used without `changed`, the
 command will fail.
 
-#### collectCoverageFrom
+### collectCoverageFrom
 
 [_Documentation_](https://jestjs.io/docs/configuration#collectcoveragefrom-array)
 
@@ -88,7 +88,7 @@ Example:
 }
 ```
 
-#### coveragePathIgnorePatterns
+### coveragePathIgnorePatterns
 
 [_Documentation_](https://jestjs.io/docs/configuration#coveragepathignorepatterns-arraystring)
 
@@ -98,7 +98,7 @@ An array of regexp pattern strings that are matched against all file paths
 before executing the test. If the file path matches any of the patterns,
 coverage information will be skipped.
 
-#### coverageThreshold
+### coverageThreshold
 
 [_Documentation_](https://jestjs.io/docs/configuration#coveragethreshold-object)
 
@@ -111,7 +111,7 @@ positive number are taken to be the minimum percentage required. Thresholds
 specified as a negative number represent the maximum number of uncovered
 entities allowed.
 
-#### moduleNameMapper
+### moduleNameMapper
 
 [_Documentation_](https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring)
 
@@ -131,7 +131,7 @@ The moduleNameMapper is merged with the `modular` defaults to provide common use
 cases for static assets, like static assets including images, CSS and
 CSS-modules.
 
-#### modulePathIgnorePatterns
+### modulePathIgnorePatterns
 
 [_Documentation_](https://jestjs.io/docs/configuration#modulepathignorepatterns-arraystring)
 
@@ -142,7 +142,16 @@ before those paths are to be considered 'visible' to the module loader. If a
 given module's path matches any of the patterns, it will not be `require()`-able
 in the test environment.
 
-#### testPathIgnorePatterns
+### package
+
+Default: `undefined`
+
+Run all the test for the workspace with the specified package name. Can be
+repeated to select more than one workspace. Can be combined with the
+`--ancestors` option to test the specified workspace(s) plus all the workspaces
+that, directly or indirectly, depend on them. Conflicts with `--changed`.
+
+### testPathIgnorePatterns
 
 [_Documentation_](https://jestjs.io/docs/configuration#testpathignorepatterns-arraystring)
 
@@ -152,7 +161,7 @@ An array of regexp pattern strings that are matched against all test paths
 before executing the test. If the test path matches any of the patterns, it will
 be skipped.
 
-#### testRunner
+### testRunner
 
 [_Documentation_](https://jestjs.io/docs/configuration#testrunner-string)
 
@@ -166,7 +175,7 @@ This can be used to revert to the previous `jest` default testRunner
 (`jest-jasmine2`) in cases where `circus` is not yet compatible with an older
 codebase.
 
-#### transformIgnorePatterns
+### transformIgnorePatterns
 
 [_Documentation_](https://jestjs.io/docs/configuration#transformignorepatterns-arraystring)
 

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -146,7 +146,7 @@ in the test environment.
 
 Default: `undefined`
 
-Run all the test for the workspace with the specified package name. Can be
+Run all the tests for the workspace with the specified package name. Can be
 repeated to select more than one workspace. Can be combined with the
 `--ancestors` option to test the specified workspace(s) plus all the workspaces
 that, directly or indirectly, depend on them. Conflicts with `--changed`.

--- a/packages/modular-scripts/src/__tests__/test.test.ts
+++ b/packages/modular-scripts/src/__tests__/test.test.ts
@@ -194,6 +194,81 @@ describe('Modular test command', () => {
       );
     });
   });
+
+  describe('test command can successfully do selective tests based on selected packages', () => {
+    const fixturesFolder = path.join(
+      __dirname,
+      Array.from({ length: 4 }).reduce<string>(
+        (acc) => `${acc}..${path.sep}`,
+        '',
+      ),
+      '__fixtures__',
+      'ghost-testing',
+    );
+
+    const currentModularFolder = getModularRoot();
+    let randomOutputFolder: string;
+
+    beforeEach(() => {
+      // Create random dir
+      randomOutputFolder = tmp.dirSync({ unsafeCleanup: true }).name;
+      fs.copySync(fixturesFolder, randomOutputFolder);
+      execa.sync('yarn', {
+        cwd: randomOutputFolder,
+      });
+    });
+
+    // Run in a single test, serially for performance reasons (the setup time is quite long)
+    it('finds --package after specifying a valid workspaces / finds ancestors using --ancestors', () => {
+      const resultPackages = runRemoteModularTest(
+        currentModularFolder,
+        randomOutputFolder,
+        ['test', '--package', 'b', '--package', 'c'],
+      );
+      expect(resultPackages.stderr).toContain(
+        'packages/c/src/__tests__/utils/c-nested.test.ts',
+      );
+      expect(resultPackages.stderr).toContain(
+        'packages/c/src/__tests__/c.test.ts',
+      );
+      expect(resultPackages.stderr).toContain(
+        'packages/b/src/__tests__/utils/b-nested.test.ts',
+      );
+      expect(resultPackages.stderr).toContain(
+        'packages/b/src/__tests__/b.test.ts',
+      );
+
+      const resultPackagesWithAncestors = runRemoteModularTest(
+        currentModularFolder,
+        randomOutputFolder,
+        ['test', '--ancestors', '--package', 'b', '--package', 'c'],
+      );
+      expect(resultPackagesWithAncestors.stderr).toContain(
+        'packages/c/src/__tests__/utils/c-nested.test.ts',
+      );
+      expect(resultPackagesWithAncestors.stderr).toContain(
+        'packages/c/src/__tests__/c.test.ts',
+      );
+      expect(resultPackagesWithAncestors.stderr).toContain(
+        'packages/b/src/__tests__/utils/b-nested.test.ts',
+      );
+      expect(resultPackagesWithAncestors.stderr).toContain(
+        'packages/b/src/__tests__/b.test.ts',
+      );
+      expect(resultPackagesWithAncestors.stderr).toContain(
+        'packages/a/src/__tests__/utils/a-nested.test.ts',
+      );
+      expect(resultPackagesWithAncestors.stderr).toContain(
+        'packages/a/src/__tests__/a.test.ts',
+      );
+      expect(resultPackagesWithAncestors.stderr).toContain(
+        'packages/e/src/__tests__/utils/e-nested.test.ts',
+      );
+      expect(resultPackagesWithAncestors.stderr).toContain(
+        'packages/e/src/__tests__/e.test.ts',
+      );
+    });
+  });
 });
 
 function runRemoteModularTest(

--- a/packages/modular-scripts/src/__tests__/test.test.ts
+++ b/packages/modular-scripts/src/__tests__/test.test.ts
@@ -269,6 +269,134 @@ describe('Modular test command', () => {
       );
     });
   });
+
+  describe('test command has error states', () => {
+    // Run in a single test, serially for performance reasons (the setup time is quite long)
+    it('errors when specifying --package with --changed', async () => {
+      let errorNumber;
+      try {
+        await execa(
+          'yarnpkg',
+          ['modular', 'test', '--changed', '--package', 'modular-scripts'],
+          {
+            all: true,
+            cleanup: true,
+          },
+        );
+      } catch (error) {
+        errorNumber = (error as ExecaError).exitCode;
+      }
+      expect(errorNumber).toEqual(1);
+    });
+
+    it('errors when specifying --package with a non-existing workspace', async () => {
+      let capturedError;
+      try {
+        await execa(
+          'yarnpkg',
+          ['modular', 'test', '--package', 'non-existing'],
+          {
+            all: true,
+            cleanup: true,
+          },
+        );
+      } catch (error) {
+        capturedError = error as ExecaError;
+      }
+      expect(capturedError?.exitCode).toEqual(1);
+      expect(capturedError?.stderr).toContain(
+        `Package non-existing was specified, but Modular couldn't find it`,
+      );
+    });
+
+    it('errors when specifying a regex with --packages', async () => {
+      let capturedError;
+      try {
+        await execa(
+          'yarnpkg',
+          [
+            'modular',
+            'test',
+            'memoize.test.ts',
+            '--package',
+            'modular-scripts',
+          ],
+          {
+            all: true,
+            cleanup: true,
+          },
+        );
+      } catch (error) {
+        capturedError = error as ExecaError;
+      }
+      expect(capturedError?.exitCode).toEqual(1);
+      expect(capturedError?.stderr).toContain(
+        `Option --package conflicts with supplied test regex`,
+      );
+    });
+
+    it('errors when specifying a regex with --package', async () => {
+      let capturedError;
+      try {
+        await execa(
+          'yarnpkg',
+          [
+            'modular',
+            'test',
+            'memoize.test.ts',
+            '--package',
+            'modular-scripts',
+          ],
+          {
+            all: true,
+            cleanup: true,
+          },
+        );
+      } catch (error) {
+        capturedError = error as ExecaError;
+      }
+      expect(capturedError?.exitCode).toEqual(1);
+      expect(capturedError?.stderr).toContain(
+        `Option --package conflicts with supplied test regex`,
+      );
+    });
+
+    it('errors when specifying a regex with --changed', async () => {
+      let capturedError;
+      try {
+        await execa(
+          'yarnpkg',
+          ['modular', 'test', 'memoize.test.ts', '--changed'],
+          {
+            all: true,
+            cleanup: true,
+          },
+        );
+      } catch (error) {
+        capturedError = error as ExecaError;
+      }
+      expect(capturedError?.exitCode).toEqual(1);
+      expect(capturedError?.stderr).toContain(
+        `Option --changed conflicts with supplied test regex`,
+      );
+    });
+
+    it('errors when specifying --compareBranch without --changed', async () => {
+      let capturedError;
+      try {
+        await execa('yarnpkg', ['modular', 'test', '--compareBranch', 'main'], {
+          all: true,
+          cleanup: true,
+        });
+      } catch (error) {
+        capturedError = error as ExecaError;
+      }
+      expect(capturedError?.exitCode).toEqual(1);
+      expect(capturedError?.stderr).toContain(
+        `Option --compareBranch doesn't make sense without option --changed`,
+      );
+    });
+  });
 });
 
 function runRemoteModularTest(

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -142,6 +142,7 @@ program
     '--compareBranch <branch>',
     "Specifies the branch to use with the --changed flag. If not specified, Modular will use the repo's default branch",
   )
+  .option('--package <packages...>', 'Specifies one or more packages to test')
   .option('--coverage', testOptions.coverage.description)
   .option('--forceExit', testOptions.forceExit.description)
   .option('--env <env>', testOptions.env.description, 'jsdom')
@@ -168,10 +169,14 @@ program
   .allowUnknownOption()
   .description('Run tests over the codebase')
   .action(async (regexes: string[], options: CLITestOptions) => {
-    if (options.ancestors && !options.changed) {
+    if (options.ancestors && !options.changed && !options.package) {
       process.stderr.write(
-        "Option --ancestors doesn't make sense without option --changed",
+        "Option --ancestors doesn't make sense without option --changed or option --package",
       );
+      process.exit(1);
+    }
+    if (options.package && options.changed) {
+      process.stderr.write('Option --package conflicts with option --changed');
       process.exit(1);
     }
     if (options.compareBranch && !options.changed) {
@@ -183,6 +188,12 @@ program
     if (options.changed && regexes.length) {
       process.stderr.write(
         'Option --changed conflicts with supplied test regex',
+      );
+      process.exit(1);
+    }
+    if (options.package && regexes.length) {
+      process.stderr.write(
+        'Option --package conflicts with supplied test regex',
       );
       process.exit(1);
     }

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -171,29 +171,31 @@ program
   .action(async (regexes: string[], options: CLITestOptions) => {
     if (options.ancestors && !options.changed && !options.package) {
       process.stderr.write(
-        "Option --ancestors doesn't make sense without option --changed or option --package",
+        "Option --ancestors doesn't make sense without option --changed or option --package\n",
       );
       process.exit(1);
     }
     if (options.package && options.changed) {
-      process.stderr.write('Option --package conflicts with option --changed');
+      process.stderr.write(
+        'Option --package conflicts with option --changed\n',
+      );
       process.exit(1);
     }
     if (options.compareBranch && !options.changed) {
       process.stderr.write(
-        "Option --compareBranch doesn't make sense without option --changed",
+        "Option --compareBranch doesn't make sense without option --changed\n",
       );
       process.exit(1);
     }
     if (options.changed && regexes.length) {
       process.stderr.write(
-        'Option --changed conflicts with supplied test regex',
+        'Option --changed conflicts with supplied test regex\n',
       );
       process.exit(1);
     }
     if (options.package && regexes.length) {
       process.stderr.write(
-        'Option --package conflicts with supplied test regex',
+        'Option --package conflicts with supplied test regex\n',
       );
       process.exit(1);
     }

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -122,16 +122,26 @@ async function test(
   const cleanRegexes: string[] = [];
 
   // There are two ways of discovering the test regexes we need: either they're specified by the user as CLI arguments
-  // or they have to be calculated from selective options (--changed and --package) and optionally agumented with --ancestors.
-  const regexes =
-    changed || packages?.length
-      ? await computeSelectiveRegexes({
-          changed,
-          compareBranch,
-          packages,
-          ancestors,
-        })
-      : userRegexes;
+  // or they have to be calculated from selective options (--changed and --package) and optionally agumented with --ancestors
+  const isSelective = changed || packages?.length;
+  const regexes = isSelective
+    ? await computeSelectiveRegexes({
+        changed,
+        compareBranch,
+        packages,
+        ancestors,
+      })
+    : userRegexes;
+
+  // If test is selective (user set --changed or --package) and we computed no regexes, then bail out
+  if (!regexes?.length && isSelective) {
+    process.stdout.write(
+      changed
+        ? 'No changed workspaces found'
+        : 'No workspaces found in selection',
+    );
+    process.exit(0);
+  }
 
   if (regexes?.length) {
     regexes.forEach((reg) => {

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -137,8 +137,8 @@ async function test(
   if (!regexes?.length && isSelective) {
     process.stdout.write(
       changed
-        ? 'No changed workspaces found'
-        : 'No workspaces found in selection',
+        ? 'No changed workspaces found\n'
+        : 'No workspaces found in selection\n',
     );
     process.exit(0);
   }

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -286,7 +286,7 @@ async function getSinglePackagesContent(singlePackages: string[]) {
     const packageContent = sourcePackageContent.get(pkgName);
     if (!sourcePackageMap[pkgName] || !packageContent) {
       throw new Error(
-        `Package ${pkgName} was specified, but Modular couldn't find it in the workspaces.`,
+        `Package ${pkgName} was specified, but Modular couldn't find it`,
       );
     }
     targetPackageContent.set(pkgName, packageContent);

--- a/packages/modular-scripts/src/utils/gitActions.ts
+++ b/packages/modular-scripts/src/utils/gitActions.ts
@@ -1,6 +1,7 @@
 import stripAnsi from 'strip-ansi';
 import execa from 'execa';
 import getModularRoot from './getModularRoot';
+import * as logger from './logger';
 
 export function cleanGit(cwd: string): boolean {
   const trackedChanged = stripAnsi(
@@ -36,10 +37,20 @@ function getGitDefaultBranch(): string {
       'symbolic-ref',
       'refs/remotes/origin/HEAD',
     ]);
-    return `origin/${stripAnsi(result.stdout).split('/').pop() as string}`;
+    const defaultBranch = `origin/${
+      stripAnsi(result.stdout).split('/').pop() as string
+    }`;
+    logger.debug(
+      `Git default branch calculated from remote origin: ${defaultBranch}`,
+    );
+    return defaultBranch;
   } catch (err) {
     // no remote origin, look into git config for init.defaultBranch setting
-    return getGitLocalDefaultBranch();
+    const defaultBranch = getGitLocalDefaultBranch();
+    logger.debug(
+      `Git default branch calculated from local git config: ${defaultBranch}`,
+    );
+    return defaultBranch;
   }
 }
 


### PR DESCRIPTION
Enhance `modular test` with the following behaviour:
```
$ modular test --package PACKAGE_NAME
# Run all tests for PACKAGE_NAME

$ modular test --package PACKAGE_NAME_1 --package PACKAGE_NAME_2
# Run all tests for PACKAGE_NAME_1 and PACKAGE_NAME_2

$ modular test --package PACKAGE_NAME --ancestors
# Run all tests for PACKAGE_NAME and all other workspaces that, directly or indirectly, depend on it

$ modular test --package PACKAGE_NAME --changed
# Options are not compatible: exit with error

modular test SOME_REGEX --package PACKAGE_NAME
# Options are not compatible: exit with error
```