### PR TITLE
Add support for extendedPublishConfig, apply to workspace resolver

### DIFF
--- a/.changeset/cool-rice-grin.md
+++ b/.changeset/cool-rice-grin.md
@@ -1,0 +1,5 @@
+---
+'@modular-scripts/workspace-resolver': patch
+---
+
+Remove requirement to build the package in local dev

--- a/packages/workspace-resolver/package.json
+++ b/packages/workspace-resolver/package.json
@@ -2,7 +2,7 @@
   "name": "@modular-scripts/workspace-resolver",
   "version": "1.1.0",
   "license": "Apache-2.0",
-  "main": "dist-cjs/index.js",
+  "main": "src/index.ts",
   "dependencies": {
     "fs-extra": "^10.1.0",
     "globby": "11.0.4",
@@ -14,13 +14,18 @@
   },
   "scripts": {
     "build": "tsc && babel --source-maps --root-mode upward src --out-dir dist-cjs --extensions .ts --ignore **/__tests__",
-    "clean": "rimraf dist-cjs"
+    "clean": "rimraf dist-cjs",
+    "prepublishOnly": "node ../../scripts/extend-publish-config.js"
   },
   "files": [
     "dist-cjs"
   ],
-  "types": "dist-cjs/index.d.ts",
+  "types": "src/index.ts",
   "publishConfig": {
     "access": "public"
+  },
+  "extendedPublishConfig": {
+    "main": "dist-cjs/index.js",
+    "types": "dist-cjs/index.d.ts"
   }
 }

--- a/scripts/extend-publish-config.js
+++ b/scripts/extend-publish-config.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { writeFileSync } = require('fs');
+const { resolve } = require('path');
+
+// This script applies the contents of any `extendedPublishConfig` blocks
+// to the root package.json of affected packages in PACKAGES_TO_EXTEND.
+//
+// It also removes `scripts` on the assumption none are needed when installing npm libraries.
+
+const PACKAGES_TO_EXTEND = ['workspace-resolver'];
+
+function writeNewPackageJson(src, content) {
+  writeFileSync(src, JSON.stringify(content, null, 2));
+}
+
+function updatePackageJson(src) {
+  const { extendedPublishConfig, scripts, ...pkg } = require(src);
+
+  return {
+    ...pkg,
+    ...extendedPublishConfig,
+  };
+}
+
+PACKAGES_TO_EXTEND.forEach((dirName) => {
+  const src = resolve(__dirname, `../packages/${dirName}`, 'package.json');
+  const content = updatePackageJson(src);
+  writeNewPackageJson(src, content);
+});


### PR DESCRIPTION
Thanks @steveukx for providing prior art in [git-js](https://github.com/steveukx/git-js/blob/main/simple-git/scripts/package-json.js)! My implementation is very similar, but I've come up with some alternative naming, let me know what you think.

- Adds a script to the root which enables a `extendedPublishConfig` block in the `package.json` of any packages in the project. The idea is that we can make changes to the project before publishing, very similar to the native [publishConfig](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#publishconfig) option, however, is not restricted to what fields we can change.
- All items in `extendedPublishConfig` will override fields of the same name at publish time
- We also remove `scripts`, since they are useless in published packages. This isn't required to achieve the desired result here, but could help avoid confusion should a user attempt to use scripts in the wrong way
- Applied `extendedPublishConfig` to the workspace resolver package. In this case, we have made the `main` and `types` fields change to the built versions at publish time.

The end result is that developers no longer need to build the workspace resolver package in local dev - the dependency can be imported right away, and the types just work.