### PR TITLE
Remove @types/semver-regex

### DIFF
--- a/.changeset/heavy-mangos-count.md
+++ b/.changeset/heavy-mangos-count.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": patch
+---
+
+Remove @types/semver-regex

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/recursive-readdir": "^2.2.1",
     "@types/rimraf": "3.0.2",
     "@types/semver": "7.3.9",
-    "@types/semver-regex": "^3.1.0",
     "@types/tmp": "0.2.3",
     "@types/update-notifier": "5.1.0",
     "@yarnpkg/lockfile": "^1.1.0",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -31,7 +31,6 @@
     "@svgr/core": "6.2.1",
     "@svgr/webpack": "6.2.1",
     "@types/micromatch": "4.0.2",
-    "@types/semver-regex": "3.1.0",
     "@types/yarnpkg__lockfile": "^1.1.5",
     "@yarnpkg/lockfile": "^1.1.0",
     "address": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,13 +2944,6 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/semver-regex@3.1.0", "@types/semver-regex@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/semver-regex/-/semver-regex-3.1.0.tgz#76a753b94318df340e9468b0644a387cefcbb8a9"
-  integrity sha512-dF4bvVQjiCd/No7udT/BfOTfBksT1HCUwIpthCjS4kQYTzeZNVx2EKRzk+sIP4OW4ShKVsMDL3V6RX+c7GKmEA==
-  dependencies:
-    semver-regex "*"
-
 "@types/semver@7.3.9":
   version "7.3.9"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
@@ -11043,11 +11036,6 @@ semver-diff@^3.1.1:
   integrity sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==
   dependencies:
     semver "^6.3.0"
-
-semver-regex@*:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-4.0.2.tgz#fd3124efe81647b33eb90a9de07cb72992424a02"
-  integrity sha512-xyuBZk1XYqQkB687hMQqrCP+J9bdJSjPpZwdmmNjyxKW1K3LDXxqxw91Egaqkh/yheBIVtKPt4/1eybKVdCx3g==
 
 semver-regex@3.1.4:
   version "3.1.4"


### PR DESCRIPTION
@types/semver-regex is a stub package so it's not needed and is only available on the [yarn registry ](https://yarnpkg.com/package/@types/semver-regex)

It also is including semver-regex@4.0.2 which is a [vulnerable dependency](https://github.com/advisories/GHSA-4x5v-gmq8-25ch) . #2135 moves modular to semver-regex@3.1.4 which helps fix this but @types/semver-regex still needs to be removed to fix it.