### PR TITLE
Support for non-modular packages in tests and workspace resolver

### DIFF
--- a/.changeset/thirty-crews-buy.md
+++ b/.changeset/thirty-crews-buy.md
@@ -1,0 +1,7 @@
+---
+'modular-scripts': minor
+'@modular-scripts/workspace-resolver': minor
+'@modular-scripts/modular-types': minor
+---
+
+Support for non-modular packages in test runner and workspace resolver

--- a/__fixtures__/extraneous-packages/.gitignore
+++ b/__fixtures__/extraneous-packages/.gitignore
@@ -1,0 +1,22 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+/dist

--- a/__fixtures__/extraneous-packages/.yarnrc
+++ b/__fixtures__/extraneous-packages/.yarnrc
@@ -1,0 +1,1 @@
+disable-self-update-check true

--- a/__fixtures__/extraneous-packages/README.md
+++ b/__fixtures__/extraneous-packages/README.md
@@ -1,0 +1,11 @@
+This monorepository has inter-workspace dependencies:
+
+```mermaid
+graph TD;
+    app-->a;
+    a-->b;
+    a-->c;
+    b-->c;
+    c-->d;
+    e-->a;
+```

--- a/__fixtures__/extraneous-packages/modular/setupEnvironment.ts
+++ b/__fixtures__/extraneous-packages/modular/setupEnvironment.ts
@@ -1,0 +1,2 @@
+// Allows for adding setup configuration to Jest
+export {};

--- a/__fixtures__/extraneous-packages/modular/setupTests.ts
+++ b/__fixtures__/extraneous-packages/modular/setupTests.ts
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom/extend-expect';

--- a/__fixtures__/extraneous-packages/package.json
+++ b/__fixtures__/extraneous-packages/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "ghost-tests-monorepo",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "Cristiano Belloni <cristiano.belloni@jpmorgan.com>",
+  "license": "MIT",
+  "private": true,
+  "workspaces": [
+    "packages/**"
+  ],
+  "modular": {
+    "type": "root"
+  },
+  "scripts": {
+    "start": "modular start",
+    "build": "modular build",
+    "test": "modular test",
+    "lint": "eslint . --ext .js,.ts,.tsx",
+    "prettier": "prettier --write ."
+  },
+  "eslintConfig": {
+    "extends": "modular-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all",
+    "printWidth": 80,
+    "proseWrap": "always"
+  },
+  "dependencies": {
+    "@testing-library/dom": "^8.16.1",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.3.0",
+    "@testing-library/user-event": "^7.2.1",
+    "@types/jest": "^28.1.6",
+    "@types/node": "^18.7.2",
+    "@types/react": "^18.0.17",
+    "@types/react-dom": "^18.0.6",
+    "eslint-config-modular-app": "^3.0.1",
+    "modular-scripts": "^3.3.1",
+    "modular-template-app": "^1.1.0",
+    "modular-template-package": "^1.1.0",
+    "prettier": "^2.7.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": ">=4.2.1 <4.5.0"
+  }
+}

--- a/__fixtures__/extraneous-packages/packages/README.md
+++ b/__fixtures__/extraneous-packages/packages/README.md
@@ -1,0 +1,1 @@
+This will be the readme inside /packages

--- a/__fixtures__/extraneous-packages/packages/a/package.json
+++ b/__fixtures__/extraneous-packages/packages/a/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "a",
+  "private": false,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "failing-extraneous-test": "1.0.0"
+  }
+}

--- a/__fixtures__/extraneous-packages/packages/a/src/__tests__/index.test.ts
+++ b/__fixtures__/extraneous-packages/packages/a/src/__tests__/index.test.ts
@@ -1,0 +1,6 @@
+import add from '../index';
+
+test('it should add two numbers', () => {
+  console.log('testing a:index.test.ts');
+  expect(add(0.1, 0.2)).toEqual(0.30000000000000004);
+});

--- a/__fixtures__/extraneous-packages/packages/a/src/__tests__/utils/utils.test.ts
+++ b/__fixtures__/extraneous-packages/packages/a/src/__tests__/utils/utils.test.ts
@@ -1,0 +1,6 @@
+import add from '../../index';
+
+test('it should add two numbers', () => {
+  console.log('testing a:/utils/utils.test.ts');
+  expect(add(0.1, 0.2)).toEqual(0.30000000000000004);
+});

--- a/__fixtures__/extraneous-packages/packages/a/src/dummy.ts
+++ b/__fixtures__/extraneous-packages/packages/a/src/dummy.ts
@@ -1,0 +1,2 @@
+console.log('DUMMY a:dummy.ts - SHOULD NOT EXECUTE!');
+export {};

--- a/__fixtures__/extraneous-packages/packages/a/src/index.ts
+++ b/__fixtures__/extraneous-packages/packages/a/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/__fixtures__/extraneous-packages/packages/b/package.json
+++ b/__fixtures__/extraneous-packages/packages/b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "b",
+  "private": false,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "successful-extraneous-test": "1.0.0"
+  }
+}

--- a/__fixtures__/extraneous-packages/packages/b/src/__tests__/index.test.ts
+++ b/__fixtures__/extraneous-packages/packages/b/src/__tests__/index.test.ts
@@ -1,0 +1,6 @@
+import multiply from '../index';
+
+test('it should multiply two numbers', () => {
+  console.log('testing b:index.test.ts');
+  expect(multiply(4, 5)).toEqual(20);
+});

--- a/__fixtures__/extraneous-packages/packages/b/src/__tests__/utils/utils.test.ts
+++ b/__fixtures__/extraneous-packages/packages/b/src/__tests__/utils/utils.test.ts
@@ -1,0 +1,6 @@
+import multiply from '../../index';
+
+test('it should multiply two numbers', () => {
+  console.log('testing b:/utils/utils.test.ts');
+  expect(multiply(2, 4)).toEqual(8);
+});

--- a/__fixtures__/extraneous-packages/packages/b/src/index.ts
+++ b/__fixtures__/extraneous-packages/packages/b/src/index.ts
@@ -1,0 +1,3 @@
+export default function multiply(...operands: number[]): number {
+  return operands.reduce((a, o) => a * o);
+}

--- a/__fixtures__/extraneous-packages/packages/c/package.json
+++ b/__fixtures__/extraneous-packages/packages/c/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "c",
+  "private": false,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "no-extraneous-test": "1.0.0"
+  }
+}

--- a/__fixtures__/extraneous-packages/packages/c/src/__tests__/index.test.ts
+++ b/__fixtures__/extraneous-packages/packages/c/src/__tests__/index.test.ts
@@ -1,0 +1,6 @@
+import add from '../index';
+
+test('it should add two numbers', () => {
+  console.log('testing c:index.test.ts');
+  expect(add(0.1, 0.2)).toEqual(0.30000000000000004);
+});

--- a/__fixtures__/extraneous-packages/packages/c/src/__tests__/utils/utils.test.ts
+++ b/__fixtures__/extraneous-packages/packages/c/src/__tests__/utils/utils.test.ts
@@ -1,0 +1,6 @@
+import add from '../../index';
+
+test('it should add two numbers', () => {
+  console.log('testing c:/utils/utils.test.ts');
+  expect(add(0.1, 0.2)).toEqual(0.30000000000000004);
+});

--- a/__fixtures__/extraneous-packages/packages/c/src/index.ts
+++ b/__fixtures__/extraneous-packages/packages/c/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/__fixtures__/extraneous-packages/packages/failing-extraneous-test/package.json
+++ b/__fixtures__/extraneous-packages/packages/failing-extraneous-test/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "failing-extraneous-test",
+  "private": false,
+  "main": "./src/index.ts",
+  "scripts": {
+    "test": "echo 'this is the test for failing-extraneous-test'  && exit -1"
+  },
+  "version": "1.0.0"
+}

--- a/__fixtures__/extraneous-packages/packages/failing-extraneous-test/src/__tests__/index.test.ts
+++ b/__fixtures__/extraneous-packages/packages/failing-extraneous-test/src/__tests__/index.test.ts
@@ -1,0 +1,5 @@
+import add from '../index';
+
+test('it should add two numbers', () => {
+  expect(add(0.1, 0.2)).toEqual(0.30000000000000004);
+});

--- a/__fixtures__/extraneous-packages/packages/failing-extraneous-test/src/index.ts
+++ b/__fixtures__/extraneous-packages/packages/failing-extraneous-test/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/__fixtures__/extraneous-packages/packages/no-extraneous-test/package.json
+++ b/__fixtures__/extraneous-packages/packages/no-extraneous-test/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "no-extraneous-test",
+  "private": false,
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/extraneous-packages/packages/no-extraneous-test/src/__tests__/index.test.ts
+++ b/__fixtures__/extraneous-packages/packages/no-extraneous-test/src/__tests__/index.test.ts
@@ -1,0 +1,5 @@
+import add from '../index';
+
+test('it should add two numbers', () => {
+  expect(add(0.1, 0.2)).toEqual(0.30000000000000004);
+});

--- a/__fixtures__/extraneous-packages/packages/no-extraneous-test/src/index.ts
+++ b/__fixtures__/extraneous-packages/packages/no-extraneous-test/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/__fixtures__/extraneous-packages/packages/successful-extraneous-test/package.json
+++ b/__fixtures__/extraneous-packages/packages/successful-extraneous-test/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "successful-extraneous-test",
+  "private": false,
+  "main": "./src/index.ts",
+  "scripts": {
+    "test": "echo 'this is the test for successful-extraneous-test'"
+  },
+  "version": "1.0.0"
+}

--- a/__fixtures__/extraneous-packages/packages/successful-extraneous-test/src/__tests__/index.test.ts
+++ b/__fixtures__/extraneous-packages/packages/successful-extraneous-test/src/__tests__/index.test.ts
@@ -1,0 +1,5 @@
+import add from '../index';
+
+test('it should add two numbers', () => {
+  expect(add(0.1, 0.2)).toEqual(0.30000000000000004);
+});

--- a/__fixtures__/extraneous-packages/packages/successful-extraneous-test/src/index.ts
+++ b/__fixtures__/extraneous-packages/packages/successful-extraneous-test/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/__fixtures__/extraneous-packages/tsconfig.json
+++ b/__fixtures__/extraneous-packages/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "modular-scripts/tsconfig.json",
+  "include": ["modular", "packages/**/src"]
+}

--- a/__fixtures__/resolve-workspace/non-modular-workspace-1/package.json
+++ b/__fixtures__/resolve-workspace/non-modular-workspace-1/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "non-modular-workspace-1",
+  "version": "1.0.0",
+  "author": "App Frameworks team",
+  "license": "MIT",
+  "private": true,
+  "workspaces": [
+    "packages/**"
+  ],
+  "modular": {
+    "type": "root"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}

--- a/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/app-one/package.json
+++ b/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/app-one/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app-one",
+  "private": true,
+  "modular": {
+    "type": "app"
+  },
+  "dependencies": {
+    "package-one": "1.0.0",
+    "package-two": "1.0.0"
+  },
+  "version": "1.0.0"
+}

--- a/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/package-extraneous-1/package.json
+++ b/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/package-extraneous-1/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "package-extraneous-1",
+  "private": true,
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/package-extraneous-2/package.json
+++ b/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/package-extraneous-2/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-extraneous-2",
+  "private": true,
+  "modular": {
+    "anotherProperty": "value"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/package-extraneous-3/package.json
+++ b/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/package-extraneous-3/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-extraneous-3",
+  "private": true,
+  "modular": {
+    "type": ""
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/package-one/package.json
+++ b/__fixtures__/resolve-workspace/non-modular-workspace-1/packages/package-one/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-one",
+  "private": true,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/packages/modular-scripts/src/__tests__/utils/getChangedWorkspaces.test.ts
+++ b/packages/modular-scripts/src/__tests__/utils/getChangedWorkspaces.test.ts
@@ -15,6 +15,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'package',
             },
+            type: 'package',
             children: [],
             parent: null,
             dependencies: undefined,
@@ -29,6 +30,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'package',
             },
+            type: 'package',
             children: [],
             parent: null,
             dependencies: undefined,
@@ -43,6 +45,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'package',
             },
+            type: 'package',
             children: [],
             parent: null,
             dependencies: undefined,
@@ -90,6 +93,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'package',
             },
+            type: 'package',
             children: [],
             parent: null,
             dependencies: undefined,
@@ -104,6 +108,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'package',
             },
+            type: 'package',
             children: [],
             parent: null,
             dependencies: undefined,
@@ -139,6 +144,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'package',
             },
+            type: 'package',
             children: [],
             parent: null,
             dependencies: undefined,
@@ -153,6 +159,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'package',
             },
+            type: 'package',
             children: [],
             parent: null,
             dependencies: undefined,
@@ -167,6 +174,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'package',
             },
+            type: 'package',
             children: [],
             parent: null,
             dependencies: undefined,
@@ -215,6 +223,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'root',
             },
+            type: 'root',
             children: [],
             parent: null,
             dependencies: undefined,
@@ -229,6 +238,7 @@ describe('matchWorkspaces', () => {
             modular: {
               type: 'package',
             },
+            type: 'package',
             children: [],
             parent: null,
             dependencies: undefined,

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -132,12 +132,12 @@ async function test(
         packages,
         ancestors,
       })
-    : { regexes: userRegexes, extraneous: [] };
+    : { regexes: userRegexes, extraneous: undefined };
 
-  const [extraneousWorkspaces] = extraneous;
+  const [extraneousWorkspaces] = extraneous ?? [];
 
   // If test is selective (user set --changed or --package) and we computed no regexes or extraneous packages involved, then bail out
-  if (!regexes?.length && !extraneousWorkspaces.size && isSelective) {
+  if (!regexes?.length && !extraneousWorkspaces?.size && isSelective) {
     process.stdout.write(
       changed
         ? 'No changed workspaces found\n'
@@ -205,7 +205,7 @@ async function test(
 
   console.log(
     'Running tests for the extraneous dependencies',
-    extraneousWorkspaces.keys(),
+    extraneousWorkspaces?.keys(),
   );
 }
 

--- a/packages/modular-types/src/types.ts
+++ b/packages/modular-types/src/types.ts
@@ -12,9 +12,10 @@ export type ModularWorkspacePackage = {
   name: string;
   version: string;
   workspace: boolean;
-  modular: {
-    type: ModularType;
+  modular?: {
+    type: ModularType | undefined;
   };
+  type: ModularType | undefined;
   children: ModularWorkspacePackage[];
   parent: ModularWorkspacePackage | null;
   dependencies: Record<string, string> | undefined;

--- a/packages/workspace-resolver/src/__tests__/resolve-dependencies.test.ts
+++ b/packages/workspace-resolver/src/__tests__/resolve-dependencies.test.ts
@@ -28,6 +28,7 @@ describe('resolve-dependencies', () => {
           modular: {
             type: 'package',
           },
+          type: 'package',
           children: [],
           parent: null,
           dependencies: undefined,

--- a/packages/workspace-resolver/src/__tests__/resolve-workspace.test.ts
+++ b/packages/workspace-resolver/src/__tests__/resolve-workspace.test.ts
@@ -151,6 +151,35 @@ describe('@modular-scripts/workspace-resolver', () => {
         'The package "app-one" has an invalid version. Modular requires workspace packages to have a version.',
       );
     });
+
+    it('supports type property', async () => {
+      const projectRoot = path.join(fixturesPath, 'non-modular-workspace-1');
+      const [allPackages] = await resolveWorkspace(projectRoot, projectRoot);
+      expect(allPackages.has('non-modular-workspace-1')).toEqual(true);
+      expect(allPackages.has('app-one')).toEqual(true);
+      expect(allPackages.get('app-one')?.modular).toEqual({
+        type: 'app',
+      });
+      expect(allPackages.get('app-one')?.type).toBe('app');
+      expect(allPackages.has('package-one')).toEqual(true);
+      expect(allPackages.get('package-one')?.modular).toEqual({
+        type: 'package',
+      });
+      expect(allPackages.get('package-one')?.type).toBe('package');
+      expect(allPackages.has('package-extraneous-1')).toEqual(true);
+      expect(allPackages.get('package-extraneous-1')?.modular).toBeUndefined();
+      expect(allPackages.get('package-extraneous-1')?.type).toBeUndefined();
+      expect(allPackages.has('package-extraneous-2')).toEqual(true);
+      expect(allPackages.get('package-extraneous-2')?.modular).toEqual({
+        anotherProperty: 'value',
+      });
+      expect(allPackages.get('package-extraneous-2')?.type).toBeUndefined();
+      expect(allPackages.has('package-extraneous-3')).toEqual(true);
+      expect(allPackages.get('package-extraneous-3')?.modular).toEqual({
+        type: '',
+      });
+      expect(allPackages.get('package-extraneous-3')?.type).toBeUndefined();
+    });
   });
 
   describe('analyzeWorkspaceDependencies', () => {

--- a/packages/workspace-resolver/src/resolve-workspace.ts
+++ b/packages/workspace-resolver/src/resolve-workspace.ts
@@ -65,7 +65,8 @@ export async function resolveWorkspace(
   const pkgPath = packageJsonPath(root);
 
   const json = await readPackageJson(isRoot, workingDirToUse, pkgPath);
-  const isModularRoot = json.modular?.type === 'root';
+  const type = json.modular?.type || undefined;
+  const isModularRoot = type === 'root';
 
   if (!json.name) {
     throw new Error(
@@ -89,10 +90,8 @@ export async function resolveWorkspace(
     workspace: !!json.workspaces,
     children: [],
     parent,
-    modular: {
-      type: 'unknown',
-      ...json.modular,
-    },
+    modular: json.modular,
+    type,
     // Like yarn classic `workspaces info`, we include all except peerDependencies
     dependencies: {
       ...json.optionalDependencies,
@@ -153,7 +152,7 @@ export function analyzeWorkspaceDependencies(
   // Exclude the root when analyzing package inter-dependencies
   const packagesWithoutRoot = Array.from(workspacePackages.entries()).filter(
     ([, pkg]) => {
-      return pkg.modular.type !== 'root';
+      return pkg.modular?.type !== 'root';
     },
   );
 


### PR DESCRIPTION
This PR stems from the discussion here: https://github.com/jpmorganchase/modular/discussions/2168 and from the necessity of either:
a) not list non-modular workspaces in workspace-resolver or 
b) list them, but clarifying that they are non-modular.

Since we don't want to impact how `mismatchedWorkspaceDependencies` works and we like the idea of executing workspace commands on non-modular workspaces, this PR modifies the output of workspace-resolver, adding a `type` field, and adds support for non-modular (from now: extraneous) workspaces in `modular test`. In particular, `modular test` will:

- identify the eventual extraneous packages with selective options (`--package`, `--changed`, `--ancestors`), in addition to the usual modular packages
- try to run `yarn workspace <extraneous-workspace-name> test` for each one of them, **after** running the regular jest tests
- emit a warning for all the selected extraneous packages that don't have a test script
- fail the test command if one of them fails
- succeed normally if all of them succeed

I also refactored the `test` command to factor out utilities and tasks.

Note: The PR seems huge, but most of the content are new test fixtures to simulate a monorepo with examples of failing, successful and non-existent test scripts in extraneous workspaces, with regular Modular workspace ancestors.

TASKS

- [x] `type` is first-class
- [x] Run package.json `test` script for non-modular workspaces or warn