### PR TITLE
Allow workspaces outside the packages/ directory

### DIFF
--- a/.changeset/spicy-hotels-cross.md
+++ b/.changeset/spicy-hotels-cross.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": minor
+---
+
+Allow workspaces outside the `packages` directory

--- a/__fixtures__/verifiable-project/packages/app-one/package.json
+++ b/__fixtures__/verifiable-project/packages/app-one/package.json
@@ -6,9 +6,9 @@
   },
   "dependencies": {
     "package-one": "workspace:*",
-    "package-two": "workspace:^",
-    "package-three": "workspace:~",
-    "package-four": "workspace:^1.0.0"
+    "package-two": "workspace:*",
+    "package-three": "workspace:*",
+    "package-four": "workspace:*"
   },
   "version": "1.0.0"
 }

--- a/packages/modular-scripts/src/__tests__/check/verifyWorkspaceDependencies.test.ts
+++ b/packages/modular-scripts/src/__tests__/check/verifyWorkspaceDependencies.test.ts
@@ -22,16 +22,12 @@ describe('verifyWorkspaceDependencies', () => {
     expect(error).not.toHaveBeenCalled();
   });
 
-  it('rejects packages not in the "packages" directory', async () => {
+  it('doesn\'t reject packages not in the "packages" directory', async () => {
     mock(getModularRoot).mockReturnValue('__fixtures__/verifiable-project');
 
     const checked = await check('__fixtures__/verifiable-project');
-    expect(checked).toBe(false);
-    expect(error).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `package-four is not located within the "/packages" directory`,
-      ),
-    );
+    expect(checked).toBe(true);
+    expect(error).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/modular-scripts/src/check/verifyWorkspaceDependencies.ts
+++ b/packages/modular-scripts/src/check/verifyWorkspaceDependencies.ts
@@ -29,13 +29,6 @@ export async function check(target?: string): Promise<boolean> {
       valid = false;
     }
 
-    if (!packageInfo.location.startsWith('packages')) {
-      logger.error(
-        `${packageName} is not located within the "/packages" directory in the repository, instead found "${packageInfo.location}"`,
-      );
-      valid = false;
-    }
-
     if (!isValidModularType(path.join(modularRoot, packageInfo.location))) {
       logger.error(
         `${packageName} at ${


### PR DESCRIPTION
The verifyWorkspaceDependencies check should not reject modular packages found outside of the packages directory.

Consider the file system:

```
- package.json
- apps
  |- some-app-not-in-packages
- packages
  |- package-a
  |- package-b (not a modular package)
  ```
When the modular check runs as part of pre-flight, the some-app-not-in-packages package will cause the check to fail because it is outside the packages directory.

Given that it was found by the workspace-resolver, the check should not fail.