### PR TITLE
Fix: running an esm-view with modular start renders in quirksmode

### DIFF
--- a/.changeset/silver-spies-listen.md
+++ b/.changeset/silver-spies-listen.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': patch
+---
+
+Set a doctype for the template used when starting an ESM view

--- a/packages/modular-scripts/react-scripts/config/parts/esmViewConfig.js
+++ b/packages/modular-scripts/react-scripts/config/parts/esmViewConfig.js
@@ -27,6 +27,7 @@ function createPluginConfig({ isEnvProduction }) {
             {
               inject: true,
               templateContent: `
+                <!DOCTYPE html>
                 <html>
                   <body>
                     <div id="root"></div>


### PR DESCRIPTION
Include the html DOCTYPE to the template used by `modular` when starting an `esm-view` to prevent the browser from switching to legacy quirks-mode rendering.

Thanks @ararus for pointing out the issue.