### PR TITLE
CMRA: use modular lint instead of eslint directly

### DIFF
--- a/.changeset/quick-eggs-bow.md
+++ b/.changeset/quick-eggs-bow.md
@@ -1,0 +1,5 @@
+---
+'create-modular-react-app': patch
+---
+
+Use modular lint for linting by default

--- a/packages/create-modular-react-app/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/create-modular-react-app/src/__tests__/__snapshots__/index.test.ts.snap
@@ -72,7 +72,7 @@ exports[`create-modular-react-app WHEN it sets up a project with prefer Offline 
           "private": true,
           "scripts": Object {
             "build": "modular build",
-            "lint": "eslint . --ext .js,.ts,.tsx",
+            "lint": "modular lint",
             "prettier": "prettier --write .",
             "start": "modular start",
             "test": "modular test",
@@ -132,7 +132,7 @@ Object {
   "private": true,
   "scripts": Object {
     "build": "modular build",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write .",
     "start": "modular start",
     "test": "modular test",
@@ -296,7 +296,7 @@ exports[`create-modular-react-app WHEN setting a project with defaults Sets up t
             "private": true,
             "scripts": Object {
               "build": "modular build",
-              "lint": "eslint . --ext .js,.ts,.tsx",
+              "lint": "modular lint",
               "prettier": "prettier --write .",
               "start": "modular start",
               "test": "modular test",
@@ -356,7 +356,7 @@ Object {
   "private": true,
   "scripts": Object {
     "build": "modular build",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write .",
     "start": "modular start",
     "test": "modular test",

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -158,7 +158,7 @@ describe('create-modular-react-app', () => {
             "private": true,
             "scripts": Object {
               "build": "modular build",
-              "lint": "eslint . --ext .js,.ts,.tsx",
+              "lint": "modular lint",
               "prettier": "prettier --write .",
               "start": "modular start",
               "test": "modular test",
@@ -295,7 +295,7 @@ describe('create-modular-react-app', () => {
           "private": true,
           "scripts": Object {
             "build": "modular build",
-            "lint": "eslint . --ext .js,.ts,.tsx",
+            "lint": "modular lint",
             "prettier": "prettier --write .",
             "start": "modular start",
             "test": "modular test",

--- a/packages/create-modular-react-app/src/index.ts
+++ b/packages/create-modular-react-app/src/index.ts
@@ -100,7 +100,7 @@ export default async function createModularApp(argv: {
       start: 'modular start',
       build: 'modular build',
       test: 'modular test',
-      lint: 'eslint . --ext .js,.ts,.tsx',
+      lint: 'modular lint',
       prettier: 'prettier --write .',
     },
     eslintConfig: {


### PR DESCRIPTION
Use `modular lint` instead of a direct `eslint` call for the `lint` script in the create-modular-react-app template