### PR TITLE
Remove requirement for Apps to be private in modular check

### DIFF
--- a/.changeset/purple-numbers-camp.md
+++ b/.changeset/purple-numbers-camp.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+App type modular packages are no longer required to be private

--- a/packages/modular-scripts/src/check/verifyWorkspaceDependencies.ts
+++ b/packages/modular-scripts/src/check/verifyWorkspaceDependencies.ts
@@ -37,13 +37,6 @@ export async function check(target?: string): Promise<boolean> {
       valid = false;
     }
 
-    if (packageInfo.type === 'app' && packageInfo.public) {
-      logger.error(
-        `${packageName} is marked as "public" - Modular apps should be marked as private.`,
-      );
-      valid = false;
-    }
-
     logger.debug(`${packageName} is valid.`);
   }
 


### PR DESCRIPTION
Although we believe that Modular packages of type `App` should not be published to NPM, we don't want to prevent users from changing it should they so choose.
The default will still be `"private": true` on new packages of type `App` 