### PR TITLE
Unify modular test command interface

### DIFF
--- a/.changeset/green-shrimps-build.md
+++ b/.changeset/green-shrimps-build.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": major
+---
+
+Fully selective `modular test` command interface, compatible with `modular build`.

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -34,4 +34,6 @@ jobs:
       - name: 'Build internal prerequisites'
         run: yarn workspace @modular-scripts/workspace-resolver build
       - name: Run Windows tests
-        run: yarn test esmView.test.ts workspace-resolver addPackage.test.ts
+        run:
+          yarn test --regex esmView.test.ts workspace-resolver
+          addPackage.test.ts

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -13,6 +13,13 @@ The output directory for built artifacts is `dist/`, which has a flat structure
 of modular package names. Each built app/view/package is added to the `dist/` as
 its own folder.
 
+When `packages` is empty and no selective options have been specified (for
+example when running `yarn modular build`), all packages in the monorepo will be
+built. When `packages` contains one or more non-existing package name, the
+non-existing packages will be ignored without an error. If any package or
+selective option have been defined but the final set of regular expressions is
+empty, Modular will write a message to `stdout` and exit with code `0`.
+
 For views and packages, package names are transformed to `Param case` (e.g.
 this-is-param-case) in `dist/`
 

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -25,7 +25,7 @@ this-is-param-case) in `dist/`
 
 `--preserve-modules`: Preserve module structure in generated modules.
 
-`--changed`: Build only packages whose workspaces contain files that have
+`--changed`: Build only the packages whose workspaces contain files that have
 changed. Files that have changed are calculated comparing the current state of
 the repository with the branch specified by `compareBranch` or, if
 `compareBranch` is not set, with the default git branch.

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -36,9 +36,9 @@ identified test files will be run in non-predictable order. When `packages` is
 empty and no selective options have been specified (for example when running
 `yarn modular test`), all tests in the monorepo will be executed. When
 `packages` contains one or more non-existing package name, the non-existing
-packages will be ignored without an error. If any package or selective options
-has been defined but the final set of regular expressions is empty, Modular will
-write a message to `stdout` and exit with code `0`.
+packages will be ignored without an error. If any package or selective option
+have been defined but the final set of regular expressions is empty, Modular
+will write a message to `stdout` and exit with code `0`.
 
 ### Modular-specific options
 

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -26,14 +26,14 @@ This contains the setup for tests corresponding to
 ### Arguments
 
 `[packages ...]`: Packages is a list of packages that the user wants to run a
-test on. The specified set of oackages can be agumented by the selective test
-options (`--ancestors`, `--descendants` and `--changed`). Modular will take all
-the selected packages, generate regular expressions based on their location on
-disk and finally merge those regular expressions to the ones optionally
-specified by the user with the `--regex` option. The resulting set of regular
-expressions will be passed to the underlying Jest process and the identified
-test files will be run in non-predictable order. When `packages` is empty and no
-selective options have been specified (for example when running
+test on. The specified set of packages can be further agumented by the selective
+test options (`--ancestors`, `--descendants` and `--changed`). Modular will take
+all the selected packages, generate a list of regular expressions based on their
+location on disk and finally merge those regular expressions to the ones
+optionally specified by the user with the `--regex` option. The resulting set of
+regular expressions will be passed to the underlying Jest process and the
+identified test files will be run in non-predictable order. When `packages` is
+empty and no selective options have been specified (for example when running
 `yarn modular test`), all tests in the monorepo will be executed. When
 `packages` contains one or more non-existing package name, the non-existing
 packages will be ignored without an error. If any package or selective options
@@ -42,18 +42,19 @@ write a message to `stdout` and exit with code `0`.
 
 ### Modular-specific options
 
-`--ancestors`: Test the packages specified by the `[packages...]` argument
-and/or the `--changed` option and additionally build all their ancestors (i.e.
-the packages that have a direct or indirect dependency on them).
+`--ancestors`: Take the packages specified by the user via arguments or options
+and add their ancestors (i.e. the packages that have a direct or indirect
+dependency on them) to the test list.
 
-`--descendants`: Test the packages specified by the `[packages...]` argument
-and/or the `--changed` option and additionally test all their descendants (i.e.
-the packages they directly or indirectly depend on).
+`--descendants`: Take the packages specified by the user via arguments or
+options and add their descendants (i.e. the packages they directly or indirectly
+depend on) to the test list.
 
-`--changed`: Test only packages whose workspaces contain the files that have
-changed. Files that have changed are calculated comparing the current state of
-the repository with the branch specified by `compareBranch` or, if
-`compareBranch` is not set, with the default git branch.
+`--changed`: Take the packages specified by the user via arguments or options
+and add all the packages whose workspaces contain files that have changed,
+calculated comparing the current state of the git repository with the branch
+specified by `compareBranch` or, if `compareBranch` is not set, with the default
+branch.
 
 `--debug`: Add the `--inspect-brk` option to the Node.js process executing Jest
 to allow a debugger to be attached to the running process. For more information,
@@ -63,9 +64,8 @@ to allow a debugger to be attached to the running process. For more information,
 which files have changed when using the `changed` option. If this option is used
 without `changed`, the command will fail.
 
-`--regex <regexes...>`: Run all the tests for all the test files matching the
-specified regular expressions. Can be repeated to select more than one
-workspace. Can be combined with all the other selective options.
+`--regex <regexes...>`: Select all the test files matching the specified regular
+expressions. Can be combined with all the other selective options.
 
 `--verbose`: Activate debug logging. Useful to see which packages have been
 selected and which regular expression and arguments have been passed to the

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -25,20 +25,16 @@ This contains the setup for tests corresponding to
 
 ### Arguments
 
-`[packages ...]`: Packages is a list of packages that the user wants to run a
-test on. The specified set of packages can be further agumented by the selective
-test options (`--ancestors`, `--descendants` and `--changed`). Modular will take
-all the selected packages, generate a list of regular expressions based on their
-location on disk and finally merge those regular expressions to the ones
-optionally specified by the user with the `--regex` option. The resulting set of
-regular expressions will be passed to the underlying Jest process and the
-identified test files will be run in non-predictable order. When `packages` is
-empty and no selective options have been specified (for example when running
-`yarn modular test`), all tests in the monorepo will be executed. When
-`packages` contains one or more non-existing package name, the non-existing
-packages will be ignored without an error. If any package or selective option
-have been defined but the final set of regular expressions is empty, Modular
-will write a message to `stdout` and exit with code `0`.
+`[packages ...]`: List of packages to test. Can be combined with multiple
+selective options (`--ancestors`, `--descendants`, `--changed` and `--regex`).
+Modular will generate a list of regular expressions that satisfies all options
+passed which are then passed to Jest. The tests will run in non-predictable
+order. When `packages` is empty and no selective options have been specified
+(for example when running `yarn modular test`), all tests in the monorepo will
+be executed. When `packages` contains one or more non-existing package name, the
+non-existing packages will be ignored without an error. If any package or
+selective option have been defined but the final set of regular expressions is
+empty, Modular will write a message to `stdout` and exit with code `0`.
 
 ### Modular-specific options
 

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -3,7 +3,7 @@ parent: Commands
 title: modular test
 ---
 
-# `modular test [options] [regexes...]`
+# `modular test [options] [packages...]`
 
 `test` is an opinionated wrapper around [`jest`](https://jestjs.io/) which runs
 tests against the entire `modular` project. It comes with out-of-the-box
@@ -21,51 +21,55 @@ This contains the setup for tests corresponding to
 This contains the setup for tests corresponding to
 [`jest.config.js#setupFilesAfterEnv`](https://jestjs.io/docs/en/configuration#setupfilesafterenv-array).
 
-## Command line options
+## Command line options and arguments
+
+### Arguments
+
+`[packages ...]`: Packages is a list of packages that the user wants to run a
+test on. The specified set of oackages can be agumented by the selective test
+options (`--ancestors`, `--descendants` and `--changed`). Modular will take all
+the selected packages, generate regular expressions based on their location on
+disk and finally merge those regular expressions to the ones optionally
+specified by the user with the `--regex` option. The resulting set of regular
+expressions will be passed to the underlying Jest process and the identified
+test files will be run in non-predictable order. When `packages` is empty and no
+selective options have been specified (for example when running
+`yarn modular test`), all tests in the monorepo will be executed. When
+`packages` contains one or more non-existing package name, the non-existing
+packages will be ignored without an error. If any package or selective options
+has been defined but the final set of regular expressions is empty, Modular will
+write a message to `stdout` and exit with code `0`.
 
 ### Modular-specific options
 
-#### ancestors
+`--ancestors`: Test the packages specified by the `[packages...]` argument
+and/or the `--changed` option and additionally build all their ancestors (i.e.
+the packages that have a direct or indirect dependency on them).
 
-Default: `false`
+`--descendants`: Test the packages specified by the `[packages...]` argument
+and/or the `--changed` option and additionally test all their descendants (i.e.
+the packages they directly or indirectly depend on).
 
-Can be used only in combination with `changed` or the command will fail. If set,
-it will additionally execute tests for all the workspaces that (directly or
-indirectly) depend on the workspaces selected by `changed`.
+`--changed`: Test only packages whose workspaces contain the files that have
+changed. Files that have changed are calculated comparing the current state of
+the repository with the branch specified by `compareBranch` or, if
+`compareBranch` is not set, with the default git branch.
 
-#### changed
-
-Default: `false`
-
-Execute tests only for the workspaces that contain files that have changed.
-Files that have changed are calculated comparing the current state of the
-repository with the branch specified by `compareBranch` or, if `compareBranch`
-is not set, with the default git branch.
-
-#### debug
-
-Default: `false`
-
-Add the `--inspect-brk` option to the Node.js process executing Jest to allow a
-debugger to be attached to the running process. For more information,
+`--debug`: Add the `--inspect-brk` option to the Node.js process executing Jest
+to allow a debugger to be attached to the running process. For more information,
 [see the Node.js debugging guide](https://nodejs.org/en/docs/guides/debugging-getting-started/).
 
-#### compareBranch
+`--compareBranch <branch>`: Specify the comparison branch used to determine
+which files have changed when using the `changed` option. If this option is used
+without `changed`, the command will fail.
 
-Default: `undefined`
+`--regex <regexes...>`: Run all the tests for all the test files matching the
+specified regular expressions. Can be repeated to select more than one
+workspace. Can be combined with all the other selective options.
 
-Specify the comparison branch used to determine which files have changed when
-using the `changed` option. If this option is used without `changed`, the
-command will fail.
-
-#### package
-
-Default: `undefined`
-
-Run all the tests for the workspace with the specified package name. Can be
-repeated to select more than one workspace. Can be combined with the
-`--ancestors` option to test the specified workspace(s) plus all the workspaces
-that, directly or indirectly, depend on them. Conflicts with `--changed`.
+`--verbose`: Activate debug logging. Useful to see which packages have been
+selected and which regular expression and arguments have been passed to the
+underlying Jest process.
 
 ### Jest CLI Options
 

--- a/packages/modular-scripts/src/__tests__/selectiveBuild.test.ts
+++ b/packages/modular-scripts/src/__tests__/selectiveBuild.test.ts
@@ -139,6 +139,13 @@ describe('--changed builds all the changed packages in order', () => {
     expect(result.stderr).toBeFalsy();
     expect(getBuildOrder(result.stdout)).toEqual(['c', 'b', 'a', 'e']);
   });
+
+  it('builds all packages if invoked without arguments / selective options', () => {
+    const result = runModularPipeLogs(tempModularRepo, 'build');
+
+    expect(result.stderr).toBeFalsy();
+    expect(getBuildOrder(result.stdout)).toEqual(['d', 'c', 'b', 'a', 'e']);
+  });
 });
 
 function getBuildOrder(output: string) {

--- a/packages/modular-scripts/src/__tests__/test.test.ts
+++ b/packages/modular-scripts/src/__tests__/test.test.ts
@@ -41,7 +41,7 @@ describe('Modular test command', () => {
         try {
           await runYarnModular(
             tempModularRepo,
-            'test test/InvalidTest.test.ts --watchAll=false',
+            'test --regex test/InvalidTest.test.ts --watchAll=false',
           );
         } catch (error) {
           errorNumber = (error as ExecaError).exitCode;
@@ -56,7 +56,7 @@ describe('Modular test command', () => {
         try {
           await runYarnModular(
             tempModularRepo,
-            'test test/ValidTest.test.ts --watchAll=false',
+            'test --regex test/ValidTest.test.ts --watchAll=false',
           );
         } catch (error) {
           errorNumber = (error as ExecaError).exitCode;
@@ -203,10 +203,10 @@ describe('Modular test command', () => {
     });
 
     // Run in a single test, serially for performance reasons (the setup time is quite long)
-    it('finds --package after specifying a valid workspaces / finds ancestors using --ancestors', () => {
+    it('finds test after specifying a valid package / finds ancestors using --ancestors', () => {
       const resultPackages = runModularPipeLogs(
         randomOutputFolder,
-        'test --package b --package c',
+        'test b c',
         'true',
       );
       expect(resultPackages.stderr).toContain(
@@ -224,7 +224,7 @@ describe('Modular test command', () => {
 
       const resultPackagesWithAncestors = runModularPipeLogs(
         randomOutputFolder,
-        'test --ancestors --package b --package c',
+        'test b c  --ancestors',
         'true',
       );
       expect(resultPackagesWithAncestors.stderr).toContain(
@@ -256,74 +256,17 @@ describe('Modular test command', () => {
 
   describe('test command has error states', () => {
     // Run in a single test, serially for performance reasons (the setup time is quite long)
-    it('errors when specifying --package with --changed', async () => {
-      let errorNumber;
-      try {
-        await runYarnModular(
-          modularRoot,
-          'test --changed --package modular-scripts',
-        );
-      } catch (error) {
-        errorNumber = (error as ExecaError).exitCode;
-      }
-      expect(errorNumber).toBe(1);
-    });
 
-    it('errors when specifying --package with a non-existing workspace', async () => {
+    it('errors when specifying a non-existing workspace', async () => {
       let capturedError;
       try {
-        await runYarnModular(modularRoot, 'test --package non-existing');
+        await runYarnModular(modularRoot, 'test non-existing');
       } catch (error) {
         capturedError = error as ExecaError;
       }
       expect(capturedError?.exitCode).toBe(1);
       expect(capturedError?.stderr).toContain(
         `Package non-existing was specified, but Modular couldn't find it`,
-      );
-    });
-
-    it('errors when specifying a regex with --packages', async () => {
-      let capturedError;
-      try {
-        await runYarnModular(
-          modularRoot,
-          'test memoize.test.ts --package modular-scripts',
-        );
-      } catch (error) {
-        capturedError = error as ExecaError;
-      }
-      expect(capturedError?.exitCode).toBe(1);
-      expect(capturedError?.stderr).toContain(
-        `Option --package conflicts with supplied test regex`,
-      );
-    });
-
-    it('errors when specifying a regex with --package', async () => {
-      let capturedError;
-      try {
-        await runYarnModular(
-          modularRoot,
-          'test memoize.test.ts --package modular-scripts',
-        );
-      } catch (error) {
-        capturedError = error as ExecaError;
-      }
-      expect(capturedError?.exitCode).toBe(1);
-      expect(capturedError?.stderr).toContain(
-        `Option --package conflicts with supplied test regex`,
-      );
-    });
-
-    it('errors when specifying a regex with --changed', async () => {
-      let capturedError;
-      try {
-        await runYarnModular(modularRoot, 'test memoize.test.ts --changed');
-      } catch (error) {
-        capturedError = error as ExecaError;
-      }
-      expect(capturedError?.exitCode).toBe(1);
-      expect(capturedError?.stderr).toContain(
-        `Option --changed conflicts with supplied test regex`,
       );
     });
 

--- a/packages/modular-scripts/src/__tests__/test.test.ts
+++ b/packages/modular-scripts/src/__tests__/test.test.ts
@@ -224,7 +224,7 @@ describe('Modular test command', () => {
 
       const resultPackagesWithAncestors = runModularPipeLogs(
         randomOutputFolder,
-        'test b c  --ancestors',
+        'test b c --ancestors',
         'true',
       );
       expect(resultPackagesWithAncestors.stderr).toContain(

--- a/packages/modular-scripts/src/__tests__/test.test.ts
+++ b/packages/modular-scripts/src/__tests__/test.test.ts
@@ -120,7 +120,9 @@ describe('Modular test command', () => {
         'test --changed',
         'true',
       );
-      expect(resultUnchanged.stdout).toContain('No changed workspaces found');
+      expect(resultUnchanged.stdout).toContain(
+        'No workspaces found in selection',
+      );
 
       fs.appendFileSync(
         path.join(randomOutputFolder, '/packages/b/src/index.ts'),
@@ -136,47 +138,23 @@ describe('Modular test command', () => {
         'test --changed',
         'true',
       );
-      expect(resultChanged.stderr).toContain(
-        'packages/c/src/__tests__/utils/c-nested.test.ts',
-      );
-      expect(resultChanged.stderr).toContain(
-        'packages/c/src/__tests__/c.test.ts',
-      );
-      expect(resultChanged.stderr).toContain(
-        'packages/b/src/__tests__/utils/b-nested.test.ts',
-      );
-      expect(resultChanged.stderr).toContain(
-        'packages/b/src/__tests__/b.test.ts',
-      );
+      expect(resultChanged.stderr).toContain('c-nested.test.ts');
+      expect(resultChanged.stderr).toContain('c.test.ts');
+      expect(resultChanged.stderr).toContain('b-nested.test.ts');
+      expect(resultChanged.stderr).toContain('b.test.ts');
 
       const resultChangedWithAncestors = runModularPipeLogs(
         randomOutputFolder,
         'test --changed --ancestors',
       );
-      expect(resultChangedWithAncestors.stderr).toContain(
-        'packages/c/src/__tests__/utils/c-nested.test.ts',
-      );
-      expect(resultChangedWithAncestors.stderr).toContain(
-        'packages/c/src/__tests__/c.test.ts',
-      );
-      expect(resultChangedWithAncestors.stderr).toContain(
-        'packages/b/src/__tests__/utils/b-nested.test.ts',
-      );
-      expect(resultChangedWithAncestors.stderr).toContain(
-        'packages/b/src/__tests__/b.test.ts',
-      );
-      expect(resultChangedWithAncestors.stderr).toContain(
-        'packages/a/src/__tests__/utils/a-nested.test.ts',
-      );
-      expect(resultChangedWithAncestors.stderr).toContain(
-        'packages/a/src/__tests__/a.test.ts',
-      );
-      expect(resultChangedWithAncestors.stderr).toContain(
-        'packages/e/src/__tests__/utils/e-nested.test.ts',
-      );
-      expect(resultChangedWithAncestors.stderr).toContain(
-        'packages/e/src/__tests__/e.test.ts',
-      );
+      expect(resultChangedWithAncestors.stderr).toContain('c-nested.test.ts');
+      expect(resultChangedWithAncestors.stderr).toContain('c.test.ts');
+      expect(resultChangedWithAncestors.stderr).toContain('b-nested.test.ts');
+      expect(resultChangedWithAncestors.stderr).toContain('b.test.ts');
+      expect(resultChangedWithAncestors.stderr).toContain('a-nested.test.ts');
+      expect(resultChangedWithAncestors.stderr).toContain('a.test.ts');
+      expect(resultChangedWithAncestors.stderr).toContain('e-nested.test.ts');
+      expect(resultChangedWithAncestors.stderr).toContain('e.test.ts');
     });
   });
 
@@ -195,7 +173,7 @@ describe('Modular test command', () => {
 
     beforeEach(() => {
       // Create random dir
-      randomOutputFolder = tmp.dirSync({ unsafeCleanup: true }).name;
+      randomOutputFolder = createModularTestContext();
       fs.copySync(fixturesFolder, randomOutputFolder);
       execa.sync('yarn', {
         cwd: randomOutputFolder,
@@ -209,64 +187,69 @@ describe('Modular test command', () => {
         'test b c',
         'true',
       );
-      expect(resultPackages.stderr).toContain(
-        'packages/c/src/__tests__/utils/c-nested.test.ts',
-      );
-      expect(resultPackages.stderr).toContain(
-        'packages/c/src/__tests__/c.test.ts',
-      );
-      expect(resultPackages.stderr).toContain(
-        'packages/b/src/__tests__/utils/b-nested.test.ts',
-      );
-      expect(resultPackages.stderr).toContain(
-        'packages/b/src/__tests__/b.test.ts',
-      );
+      expect(resultPackages.stderr).toContain('c-nested.test.ts');
+      expect(resultPackages.stderr).toContain('c.test.ts');
+      expect(resultPackages.stderr).toContain('b-nested.test.ts');
+      expect(resultPackages.stderr).toContain('b.test.ts');
 
       const resultPackagesWithAncestors = runModularPipeLogs(
         randomOutputFolder,
         'test b c --ancestors',
         'true',
       );
-      expect(resultPackagesWithAncestors.stderr).toContain(
-        'packages/c/src/__tests__/utils/c-nested.test.ts',
+      expect(resultPackagesWithAncestors.stderr).toContain('c-nested.test.ts');
+      expect(resultPackagesWithAncestors.stderr).toContain('c.test.ts');
+      expect(resultPackagesWithAncestors.stderr).toContain('b-nested.test.ts');
+      expect(resultPackagesWithAncestors.stderr).toContain('b.test.ts');
+      expect(resultPackagesWithAncestors.stderr).toContain('a-nested.test.ts');
+      expect(resultPackagesWithAncestors.stderr).toContain('a.test.ts');
+      expect(resultPackagesWithAncestors.stderr).toContain('e-nested.test.ts');
+      expect(resultPackagesWithAncestors.stderr).toContain('e.test.ts');
+
+      const resultPackagesWithDescendants = runModularPipeLogs(
+        randomOutputFolder,
+        'test b c --descendants',
+        'true',
       );
-      expect(resultPackagesWithAncestors.stderr).toContain(
-        'packages/c/src/__tests__/c.test.ts',
+      expect(resultPackagesWithDescendants.stderr).toContain(
+        'c-nested.test.ts',
       );
-      expect(resultPackagesWithAncestors.stderr).toContain(
-        'packages/b/src/__tests__/utils/b-nested.test.ts',
+      expect(resultPackagesWithDescendants.stderr).toContain('c.test.ts');
+      expect(resultPackagesWithDescendants.stderr).toContain(
+        'd-nested.test.ts',
       );
-      expect(resultPackagesWithAncestors.stderr).toContain(
-        'packages/b/src/__tests__/b.test.ts',
+      expect(resultPackagesWithDescendants.stderr).toContain('d.test.ts');
+      expect(resultPackagesWithDescendants.stderr).toContain(
+        'b-nested.test.ts',
       );
-      expect(resultPackagesWithAncestors.stderr).toContain(
-        'packages/a/src/__tests__/utils/a-nested.test.ts',
+
+      const resultPackagesWithMixedRegex = runModularPipeLogs(
+        randomOutputFolder,
+        'test b c --descendants --regex a-nested.test.ts',
+        'true',
       );
-      expect(resultPackagesWithAncestors.stderr).toContain(
-        'packages/a/src/__tests__/a.test.ts',
-      );
-      expect(resultPackagesWithAncestors.stderr).toContain(
-        'packages/e/src/__tests__/utils/e-nested.test.ts',
-      );
-      expect(resultPackagesWithAncestors.stderr).toContain(
-        'packages/e/src/__tests__/e.test.ts',
-      );
+      expect(resultPackagesWithMixedRegex.stderr).toContain('c-nested.test.ts');
+      expect(resultPackagesWithMixedRegex.stderr).toContain('c.test.ts');
+      expect(resultPackagesWithMixedRegex.stderr).toContain('d-nested.test.ts');
+      expect(resultPackagesWithMixedRegex.stderr).toContain('d.test.ts');
+      expect(resultPackagesWithMixedRegex.stderr).toContain('b-nested.test.ts');
+      expect(resultPackagesWithMixedRegex.stderr).toContain('a-nested.test.ts');
+      expect(resultPackagesWithMixedRegex.stderr).not.toContain('a.test.ts');
     });
   });
 
   describe('test command has error states', () => {
     // Run in a single test, serially for performance reasons (the setup time is quite long)
 
-    it('errors when specifying a non-existing workspace', async () => {
-      let capturedError;
-      try {
-        await runYarnModular(modularRoot, 'test non-existing');
-      } catch (error) {
-        capturedError = error as ExecaError;
-      }
-      expect(capturedError?.exitCode).toBe(1);
-      expect(capturedError?.stderr).toContain(
-        `Package non-existing was specified, but Modular couldn't find it`,
+    it('does not error when specifying a non-existing workspace', async () => {
+      const capturedResult = await runYarnModular(
+        modularRoot,
+        'test non-existing',
+      );
+
+      expect(capturedResult?.exitCode).toBe(0);
+      expect(capturedResult?.stdout).toContain(
+        `No workspaces found in selection`,
       );
     });
 

--- a/packages/modular-scripts/src/build/index.ts
+++ b/packages/modular-scripts/src/build/index.ts
@@ -38,6 +38,7 @@ import {
 import { getDependencyInfo } from '../utils/getDependencyInfo';
 import { isReactNewApi } from '../utils/isReactNewApi';
 import { getConfig } from '../utils/config';
+import { getAllWorkspaces } from '../utils/getAllWorkspaces';
 
 async function buildStandalone(
   target: string,
@@ -262,7 +263,7 @@ async function buildStandalone(
 }
 
 async function build({
-  packagePaths: targets,
+  packagePaths,
   preserveModules = true,
   private: includePrivate,
   ancestors,
@@ -280,6 +281,14 @@ async function build({
   compareBranch?: string;
   dangerouslyIgnoreCircularDependencies: boolean;
 }): Promise<void> {
+  const isSelective =
+    changed || ancestors || descendants || packagePaths.length;
+
+  // targets are either the set of what's specified in the selective options or all the packages in the monorepo
+  const targets = isSelective
+    ? packagePaths
+    : [...(await getAllWorkspaces())[0].keys()];
+
   const selectedTargets = await selectBuildableWorkspaces({
     targets,
     changed,

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -174,6 +174,11 @@ program
     false,
   )
   .option(
+    '--descendants',
+    'Additionally run tests for workspaces that directly or indirectly depend on the specified packages (can be combined with --changed)',
+    false,
+  )
+  .option(
     '--debug',
     'Setup node.js debugger on the test process - equivalent of setting --inspect-brk on a node.js process',
     false,
@@ -216,7 +221,6 @@ program
   .allowUnknownOption()
   .description('Run tests over the codebase')
   .action(async (packages: string[], options: CLITestOptions) => {
-    console.log(options, packages);
     if (options.compareBranch && !options.changed) {
       process.stderr.write(
         "Option --compareBranch doesn't make sense without option --changed\n",

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -227,18 +227,6 @@ program
       );
       process.exit(1);
     }
-    if (options.changed && options.regex?.length) {
-      process.stderr.write(
-        'Option --changed conflicts with supplied test regex\n',
-      );
-      process.exit(1);
-    }
-    if (packages.length && options.regex?.length) {
-      process.stderr.write(
-        'Option --package conflicts with supplied test regex\n',
-      );
-      process.exit(1);
-    }
 
     const { default: test } = await import('./test');
 

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -167,7 +167,7 @@ interface CLITestOptions extends TestOptions {
 }
 
 program
-  .command('test [regexes...]')
+  .command('test [packages...]')
   .option(
     '--ancestors',
     'Additionally run tests for workspaces that depend on workspaces that have changed',
@@ -186,7 +186,10 @@ program
     '--compareBranch <branch>',
     "Specifies the branch to use with the --changed flag. If not specified, Modular will use the repo's default branch",
   )
-  .option('--package <packages...>', 'Specifies one or more packages to test')
+  .option(
+    '--regex <regexes...>',
+    'Specifies one or more test name regular expression',
+  )
   .option('--coverage', testOptions.coverage.description)
   .option('--forceExit', testOptions.forceExit.description)
   .option('--env <env>', testOptions.env.description, 'jsdom')
@@ -212,32 +215,21 @@ program
   .option('--no-cache', testOptions.cache.description)
   .allowUnknownOption()
   .description('Run tests over the codebase')
-  .action(async (regexes: string[], options: CLITestOptions) => {
-    if (options.ancestors && !options.changed && !options.package) {
-      process.stderr.write(
-        "Option --ancestors doesn't make sense without option --changed or option --package\n",
-      );
-      process.exit(1);
-    }
-    if (options.package && options.changed) {
-      process.stderr.write(
-        'Option --package conflicts with option --changed\n',
-      );
-      process.exit(1);
-    }
+  .action(async (packages: string[], options: CLITestOptions) => {
+    console.log(options, packages);
     if (options.compareBranch && !options.changed) {
       process.stderr.write(
         "Option --compareBranch doesn't make sense without option --changed\n",
       );
       process.exit(1);
     }
-    if (options.changed && regexes.length) {
+    if (options.changed && options.regex?.length) {
       process.stderr.write(
         'Option --changed conflicts with supplied test regex\n',
       );
       process.exit(1);
     }
-    if (options.package && regexes.length) {
+    if (packages.length && options.regex?.length) {
       process.stderr.write(
         'Option --package conflicts with supplied test regex\n',
       );
@@ -250,7 +242,7 @@ program
     const { U, ...testOptions } = options;
     testOptions.updateSnapshot = !!(options.updateSnapshot || U);
 
-    return test(testOptions, regexes);
+    return test(testOptions, packages);
   });
 
 program

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -128,11 +128,6 @@ program
         ? logger.log('Building changed packages')
         : logger.log('Building packages at:', packagePaths.join(', '));
 
-      if (!packagePaths.length && !options.changed) {
-        process.stderr.write("error: missing required argument 'packages'");
-        process.exit(1);
-      }
-
       if (options.compareBranch && !options.changed) {
         process.stderr.write(
           "Option --compareBranch doesn't make sense without option --changed\n",

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -29,11 +29,11 @@ export interface TestOptions {
   logHeapUsage: boolean;
   maxWorkers: number;
   'no-cache': boolean;
+  regex: string[] | undefined;
   reporters: string[] | undefined;
   runInBand: boolean;
   onlyChanged: boolean;
   outputFile: string;
-  package: string[] | undefined;
   silent: boolean;
   testResultsProcessor: string | undefined;
   updateSnapshot: boolean;
@@ -67,14 +67,11 @@ function resolveJestDefaultEnvironment(name: string) {
   });
 }
 
-async function test(
-  options: TestOptions,
-  userRegexes?: string[],
-): Promise<void> {
+async function test(options: TestOptions, packages?: string[]): Promise<void> {
   const {
     ancestors,
     changed,
-    package: packages,
+    regex: userRegexes,
     compareBranch,
     debug,
     env,
@@ -141,6 +138,8 @@ async function test(
     );
     process.exit(0);
   }
+
+  console.log({ regexes });
 
   if (regexes?.length) {
     regexes.forEach((reg) => {

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -180,6 +180,12 @@ async function test(options: TestOptions, packages?: string[]): Promise<void> {
     ];
   }
 
+  logger.debug(
+    `Running ${testBin} with cwd: ${getModularRoot()} and args: ${JSON.stringify(
+      testArgs,
+    )}`,
+  );
+
   try {
     await execAsync(testBin, testArgs, {
       cwd: getModularRoot(),

--- a/packages/modular-scripts/src/utils/packageTypes.ts
+++ b/packages/modular-scripts/src/utils/packageTypes.ts
@@ -24,10 +24,8 @@ const packageTypeDefinitions: PackageTypeDefinitions = {
   source: { buildable: false, testable: true, startable: false },
 };
 
-export const packageTypes = Object.keys(packageTypeDefinitions);
-
 export const ModularTypes: ModularType[] = (
-  packageTypes as ModularType[]
+  Object.keys(packageTypeDefinitions) as ModularType[]
 ).concat(['root']);
 
 export function getModularType(dir: string): ModularType | undefined {
@@ -52,9 +50,9 @@ export function isValidModularType(type: string): boolean {
 }
 
 export function isBuildableModularType(type: PackageType): boolean {
-  return packageTypeDefinitions[type].buildable;
+  return Boolean(packageTypeDefinitions[type]?.buildable);
 }
 
 export function isStartableModularType(type: PackageType): boolean {
-  return packageTypeDefinitions[type].startable;
+  return Boolean(packageTypeDefinitions[type]?.startable);
 }


### PR DESCRIPTION
- `modular test` now accepts package names as arguments, and regexes behind the `--regex` option flag
- `modular test` now accepts any combination of `[packages...]`, `--regex`, `--changed`, `--ancestors`, `--descendants`
- `modular build` builds all packages when invoked without selective arguments / options

- [x] Remove `--package` and accept it as an argument
- [x] Create `--regex` and accept it as a variadic option
- [x] Use `selectWorkspaces` to unify interface
- [x] Merge regexes discovered with packages
- [x] `yarn build` with no args builds all packages
  - [x] Tests for build
  - [x] Docs for build
- [x] `yarn test` verbose log
- [x] Check that `yarn test` without selective args has the same behaviour of Modular 3
- [x] Write docs
- [x] Improve `test.test.ts`