### PR TITLE
Fix Snapshots post release, remove unnecessary hashing

### DIFF
--- a/docs/releases/4.0.x.md
+++ b/docs/releases/4.0.x.md
@@ -9,7 +9,7 @@ title: 4.0.x
 
 - Node 18 Support
 - Added support for TypeScript 4.5.3 and above
-- Updated Jest to [^29.3.1](https://github.com/facebook/jest/releases)
+- Updated Jest to [29.3](https://github.com/facebook/jest/releases)
 - Support for a dedicated [Modular configuration file](../configuration.md)
 - Overhauled [`modular build`](../commands/build.md) command to now support
   `--decendant` and `--ancestor` flags that can be combined with existing flags

--- a/packages/create-modular-react-app/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/packages/create-modular-react-app/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -2,63 +2,64 @@
 
 exports[`Creating a new modular app via the CLI should create the right tree 1`] = `
 "new-modular-app
-├─ .editorconfig #1p4gvuw
-├─ .eslintignore #1ot2bpo
-├─ .gitignore #175wbq
-├─ .prettierignore #10uqwgj
+├─ .editorconfig
+├─ .eslintignore
+├─ .gitignore
+├─ .prettierignore
 ├─ .vscode
-│  ├─ extensions.json #1i4584r
-│  ├─ launch.json #1kk1omt
-│  └─ settings.json #xes41c
-├─ .yarnrc #1orkcoz
-├─ README.md #5vircs
+│  ├─ extensions.json
+│  ├─ launch.json
+│  └─ settings.json
+├─ .yarnrc
+├─ README.md
 ├─ modular
-│  ├─ setupEnvironment.ts #m0s4vb
-│  └─ setupTests.ts #bnjknz
+│  ├─ setupEnvironment.ts
+│  └─ setupTests.ts
 ├─ package.json
 ├─ packages
-│  ├─ README.md #11apaz5
+│  ├─ README.md
 │  └─ app
+│     ├─ README.md
 │     ├─ package.json
 │     ├─ public
-│     │  ├─ favicon.ico #6pu3rg
-│     │  ├─ index.html #1m6toxd
-│     │  ├─ logo192.png #1nez7vk
-│     │  ├─ logo512.png #1hwqvcc
-│     │  ├─ manifest.json #19gah8o
-│     │  └─ robots.txt #1sjb8b3
+│     │  ├─ favicon.ico
+│     │  ├─ index.html
+│     │  ├─ logo192.png
+│     │  ├─ logo512.png
+│     │  ├─ manifest.json
+│     │  └─ robots.txt
 │     ├─ src
-│     │  ├─ App.css #1o0zosm
-│     │  ├─ App.tsx #c80ven
+│     │  ├─ App.css
+│     │  ├─ App.tsx
 │     │  ├─ __tests__
-│     │  │  └─ App.test.tsx #16urcos
-│     │  ├─ index.css #o7sk21
-│     │  ├─ index.tsx #zdn6mw
-│     │  ├─ logo.svg #1okqmlj
-│     │  └─ react-app-env.d.ts #t4ygcy
-│     └─ tsconfig.json #6rw46b
-├─ tsconfig.json #1h72lkd
+│     │  │  └─ App.test.tsx
+│     │  ├─ index.css
+│     │  ├─ index.tsx
+│     │  ├─ logo.svg
+│     │  └─ react-app-env.d.ts
+│     └─ tsconfig.json
+├─ tsconfig.json
 └─ yarn.lock"
 `;
 
 exports[`Creating a new modular app via the CLI with --empty should create the right tree 1`] = `
 "another-new-modular-app
-├─ .editorconfig #1p4gvuw
-├─ .eslintignore #1ot2bpo
-├─ .gitignore #175wbq
-├─ .prettierignore #10uqwgj
+├─ .editorconfig
+├─ .eslintignore
+├─ .gitignore
+├─ .prettierignore
 ├─ .vscode
-│  ├─ extensions.json #1i4584r
-│  ├─ launch.json #1kk1omt
-│  └─ settings.json #xes41c
-├─ .yarnrc #1orkcoz
-├─ README.md #5vircs
+│  ├─ extensions.json
+│  ├─ launch.json
+│  └─ settings.json
+├─ .yarnrc
+├─ README.md
 ├─ modular
-│  ├─ setupEnvironment.ts #m0s4vb
-│  └─ setupTests.ts #bnjknz
+│  ├─ setupEnvironment.ts
+│  └─ setupTests.ts
 ├─ package.json
 ├─ packages
-│  └─ README.md #11apaz5
-├─ tsconfig.json #1h72lkd
+│  └─ README.md
+├─ tsconfig.json
 └─ yarn.lock"
 `;

--- a/packages/create-modular-react-app/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/create-modular-react-app/src/__tests__/__snapshots__/index.test.ts.snap
@@ -144,83 +144,45 @@ exports[`create-modular-react-app WHEN it sets up a project with prefer Offline 
 }
 `;
 
-exports[`create-modular-react-app WHEN it sets up a project with prefer Offline should create a project with prefer offline: 
-        "test-repo
-        ├─ .editorconfig #1p4gvuw
-        ├─ .eslintignore #1ot2bpo
-        ├─ .gitignore #175wbq
-        ├─ .prettierignore #10uqwgj
-        ├─ .vscode
-        │  ├─ extensions.json #1i4584r
-        │  ├─ launch.json #1kk1omt
-        │  └─ settings.json #xes41c
-        ├─ .yarnrc #1orkcoz
-        ├─ README.md #1nksyzj
-        ├─ modular
-        │  ├─ setupEnvironment.ts #m0s4vb
-        │  └─ setupTests.ts #bnjknz
-        ├─ package.json
-        ├─ packages
-        │  ├─ README.md #14bthrh
-        │  └─ app
-        │     ├─ package.json
-        │     ├─ public
-        │     │  ├─ favicon.ico #6pu3rg
-        │     │  ├─ index.html #1m6toxd
-        │     │  ├─ logo192.png #1nez7vk
-        │     │  ├─ logo512.png #1hwqvcc
-        │     │  ├─ manifest.json #19gah8o
-        │     │  └─ robots.txt #1sjb8b3
-        │     ├─ src
-        │     │  ├─ App.css #1o0zosm
-        │     │  ├─ App.tsx #c80ven
-        │     │  ├─ __tests__
-        │     │  │  └─ App.test.tsx #16urcos
-        │     │  ├─ index.css #o7sk21
-        │     │  ├─ index.tsx #zdn6mw
-        │     │  ├─ logo.svg #1okqmlj
-        │     │  └─ react-app-env.d.ts #t4ygcy
-        │     └─ tsconfig.json #6rw46b
-        ├─ tsconfig.json #1h72lkd
-        └─ yarn.lock"
-       1`] = `
+exports[`create-modular-react-app WHEN it sets up a project with prefer Offline should create a project with prefer offline 1`] = `
 "test-repo
-├─ .editorconfig #1p4gvuw
-├─ .eslintignore #1ot2bpo
-├─ .gitignore #175wbq
-├─ .prettierignore #10uqwgj
+├─ .editorconfig
+├─ .eslintignore
+├─ .gitignore
+├─ .prettierignore
 ├─ .vscode
-│  ├─ extensions.json #1i4584r
-│  ├─ launch.json #1kk1omt
-│  └─ settings.json #xes41c
-├─ .yarnrc #1orkcoz
-├─ README.md #5vircs
+│  ├─ extensions.json
+│  ├─ launch.json
+│  └─ settings.json
+├─ .yarnrc
+├─ README.md
 ├─ modular
-│  ├─ setupEnvironment.ts #m0s4vb
-│  └─ setupTests.ts #bnjknz
+│  ├─ setupEnvironment.ts
+│  └─ setupTests.ts
 ├─ package.json
 ├─ packages
-│  ├─ README.md #11apaz5
+│  ├─ README.md
 │  └─ app
+│     ├─ README.md
 │     ├─ package.json
 │     ├─ public
-│     │  ├─ favicon.ico #6pu3rg
-│     │  ├─ index.html #1m6toxd
-│     │  ├─ logo192.png #1nez7vk
-│     │  ├─ logo512.png #1hwqvcc
-│     │  ├─ manifest.json #19gah8o
-│     │  └─ robots.txt #1sjb8b3
+│     │  ├─ favicon.ico
+│     │  ├─ index.html
+│     │  ├─ logo192.png
+│     │  ├─ logo512.png
+│     │  ├─ manifest.json
+│     │  └─ robots.txt
 │     ├─ src
-│     │  ├─ App.css #1o0zosm
-│     │  ├─ App.tsx #c80ven
+│     │  ├─ App.css
+│     │  ├─ App.tsx
 │     │  ├─ __tests__
-│     │  │  └─ App.test.tsx #16urcos
-│     │  ├─ index.css #o7sk21
-│     │  ├─ index.tsx #zdn6mw
-│     │  ├─ logo.svg #1okqmlj
-│     │  └─ react-app-env.d.ts #t4ygcy
-│     └─ tsconfig.json #6rw46b
-├─ tsconfig.json #1h72lkd
+│     │  │  └─ App.test.tsx
+│     │  ├─ index.css
+│     │  ├─ index.tsx
+│     │  ├─ logo.svg
+│     │  └─ react-app-env.d.ts
+│     └─ tsconfig.json
+├─ tsconfig.json
 └─ yarn.lock"
 `;
 
@@ -368,82 +330,44 @@ exports[`create-modular-react-app WHEN setting a project with defaults Sets up t
 }
 `;
 
-exports[`create-modular-react-app WHEN setting a project with defaults should create a project with defaults: 
-          "test-repo
-          ├─ .editorconfig #1p4gvuw
-          ├─ .eslintignore #1ot2bpo
-          ├─ .gitignore #175wbq
-          ├─ .prettierignore #10uqwgj
-          ├─ .vscode
-          │  ├─ extensions.json #1i4584r
-          │  ├─ launch.json #1kk1omt
-          │  └─ settings.json #xes41c
-          ├─ .yarnrc #1orkcoz
-          ├─ README.md #1nksyzj
-          ├─ modular
-          │  ├─ setupEnvironment.ts #m0s4vb
-          │  └─ setupTests.ts #bnjknz
-          ├─ package.json
-          ├─ packages
-          │  ├─ README.md #14bthrh
-          │  └─ app
-          │     ├─ package.json
-          │     ├─ public
-          │     │  ├─ favicon.ico #6pu3rg
-          │     │  ├─ index.html #1m6toxd
-          │     │  ├─ logo192.png #1nez7vk
-          │     │  ├─ logo512.png #1hwqvcc
-          │     │  ├─ manifest.json #19gah8o
-          │     │  └─ robots.txt #1sjb8b3
-          │     ├─ src
-          │     │  ├─ App.css #1o0zosm
-          │     │  ├─ App.tsx #c80ven
-          │     │  ├─ __tests__
-          │     │  │  └─ App.test.tsx #16urcos
-          │     │  ├─ index.css #o7sk21
-          │     │  ├─ index.tsx #zdn6mw
-          │     │  ├─ logo.svg #1okqmlj
-          │     │  └─ react-app-env.d.ts #t4ygcy
-          │     └─ tsconfig.json #6rw46b
-          ├─ tsconfig.json #1h72lkd
-          └─ yarn.lock"
-         1`] = `
+exports[`create-modular-react-app WHEN setting a project with defaults should create a project with defaults 1`] = `
 "test-repo
-├─ .editorconfig #1p4gvuw
-├─ .eslintignore #1ot2bpo
-├─ .gitignore #175wbq
-├─ .prettierignore #10uqwgj
+├─ .editorconfig
+├─ .eslintignore
+├─ .gitignore
+├─ .prettierignore
 ├─ .vscode
-│  ├─ extensions.json #1i4584r
-│  ├─ launch.json #1kk1omt
-│  └─ settings.json #xes41c
-├─ .yarnrc #1orkcoz
-├─ README.md #5vircs
+│  ├─ extensions.json
+│  ├─ launch.json
+│  └─ settings.json
+├─ .yarnrc
+├─ README.md
 ├─ modular
-│  ├─ setupEnvironment.ts #m0s4vb
-│  └─ setupTests.ts #bnjknz
+│  ├─ setupEnvironment.ts
+│  └─ setupTests.ts
 ├─ package.json
 ├─ packages
-│  ├─ README.md #11apaz5
+│  ├─ README.md
 │  └─ app
+│     ├─ README.md
 │     ├─ package.json
 │     ├─ public
-│     │  ├─ favicon.ico #6pu3rg
-│     │  ├─ index.html #1m6toxd
-│     │  ├─ logo192.png #1nez7vk
-│     │  ├─ logo512.png #1hwqvcc
-│     │  ├─ manifest.json #19gah8o
-│     │  └─ robots.txt #1sjb8b3
+│     │  ├─ favicon.ico
+│     │  ├─ index.html
+│     │  ├─ logo192.png
+│     │  ├─ logo512.png
+│     │  ├─ manifest.json
+│     │  └─ robots.txt
 │     ├─ src
-│     │  ├─ App.css #1o0zosm
-│     │  ├─ App.tsx #c80ven
+│     │  ├─ App.css
+│     │  ├─ App.tsx
 │     │  ├─ __tests__
-│     │  │  └─ App.test.tsx #16urcos
-│     │  ├─ index.css #o7sk21
-│     │  ├─ index.tsx #zdn6mw
-│     │  ├─ logo.svg #1okqmlj
-│     │  └─ react-app-env.d.ts #t4ygcy
-│     └─ tsconfig.json #6rw46b
-├─ tsconfig.json #1h72lkd
+│     │  │  └─ App.test.tsx
+│     │  ├─ index.css
+│     │  ├─ index.tsx
+│     │  ├─ logo.svg
+│     │  └─ react-app-env.d.ts
+│     └─ tsconfig.json
+├─ tsconfig.json
 └─ yarn.lock"
 `;

--- a/packages/create-modular-react-app/src/__tests__/cli.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/cli.test.ts
@@ -2,7 +2,7 @@ import execa from 'execa';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as tmp from 'tmp';
-import tree from 'tree-view-for-tests';
+import { hashlessTree } from 'tree-view-for-tests';
 
 describe('Creating a new modular app via the CLI', () => {
   let cwd: string;
@@ -22,7 +22,7 @@ describe('Creating a new modular app via the CLI', () => {
   });
 
   it('should create the right tree', () => {
-    expect(tree(cwd)).toMatchSnapshot();
+    expect(hashlessTree(cwd)).toMatchSnapshot();
   });
 });
 
@@ -44,6 +44,6 @@ describe('Creating a new modular app via the CLI with --empty', () => {
   });
 
   it('should create the right tree', () => {
-    expect(tree(cwd)).toMatchSnapshot();
+    expect(hashlessTree(cwd)).toMatchSnapshot();
   });
 });

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import createModularApp from '../';
 import fs from 'fs-extra';
 import path from 'path';
-import tree from 'tree-view-for-tests';
+import { hashlessTree } from 'tree-view-for-tests';
 import tmp from 'tmp';
 
 // We want to omit any information that makes our snapshots
@@ -64,46 +64,7 @@ describe('create-modular-react-app', () => {
     });
 
     it('should create a project with defaults', () => {
-      expect(tree(destination)).toMatchSnapshot(`
-          "test-repo
-          ├─ .editorconfig #1p4gvuw
-          ├─ .eslintignore #1ot2bpo
-          ├─ .gitignore #175wbq
-          ├─ .prettierignore #10uqwgj
-          ├─ .vscode
-          │  ├─ extensions.json #1i4584r
-          │  ├─ launch.json #1kk1omt
-          │  └─ settings.json #xes41c
-          ├─ .yarnrc #1orkcoz
-          ├─ README.md #1nksyzj
-          ├─ modular
-          │  ├─ setupEnvironment.ts #m0s4vb
-          │  └─ setupTests.ts #bnjknz
-          ├─ package.json
-          ├─ packages
-          │  ├─ README.md #14bthrh
-          │  └─ app
-          │     ├─ package.json
-          │     ├─ public
-          │     │  ├─ favicon.ico #6pu3rg
-          │     │  ├─ index.html #1m6toxd
-          │     │  ├─ logo192.png #1nez7vk
-          │     │  ├─ logo512.png #1hwqvcc
-          │     │  ├─ manifest.json #19gah8o
-          │     │  └─ robots.txt #1sjb8b3
-          │     ├─ src
-          │     │  ├─ App.css #1o0zosm
-          │     │  ├─ App.tsx #c80ven
-          │     │  ├─ __tests__
-          │     │  │  └─ App.test.tsx #16urcos
-          │     │  ├─ index.css #o7sk21
-          │     │  ├─ index.tsx #zdn6mw
-          │     │  ├─ logo.svg #1okqmlj
-          │     │  └─ react-app-env.d.ts #t4ygcy
-          │     └─ tsconfig.json #6rw46b
-          ├─ tsconfig.json #1h72lkd
-          └─ yarn.lock"
-        `);
+      expect(hashlessTree(destination)).toMatchSnapshot();
     });
 
     it('Sets up the package.json correctly', async () => {
@@ -201,46 +162,7 @@ describe('create-modular-react-app', () => {
       });
     });
     it('should create a project with prefer offline', () => {
-      expect(tree(destination)).toMatchSnapshot(`
-        "test-repo
-        ├─ .editorconfig #1p4gvuw
-        ├─ .eslintignore #1ot2bpo
-        ├─ .gitignore #175wbq
-        ├─ .prettierignore #10uqwgj
-        ├─ .vscode
-        │  ├─ extensions.json #1i4584r
-        │  ├─ launch.json #1kk1omt
-        │  └─ settings.json #xes41c
-        ├─ .yarnrc #1orkcoz
-        ├─ README.md #1nksyzj
-        ├─ modular
-        │  ├─ setupEnvironment.ts #m0s4vb
-        │  └─ setupTests.ts #bnjknz
-        ├─ package.json
-        ├─ packages
-        │  ├─ README.md #14bthrh
-        │  └─ app
-        │     ├─ package.json
-        │     ├─ public
-        │     │  ├─ favicon.ico #6pu3rg
-        │     │  ├─ index.html #1m6toxd
-        │     │  ├─ logo192.png #1nez7vk
-        │     │  ├─ logo512.png #1hwqvcc
-        │     │  ├─ manifest.json #19gah8o
-        │     │  └─ robots.txt #1sjb8b3
-        │     ├─ src
-        │     │  ├─ App.css #1o0zosm
-        │     │  ├─ App.tsx #c80ven
-        │     │  ├─ __tests__
-        │     │  │  └─ App.test.tsx #16urcos
-        │     │  ├─ index.css #o7sk21
-        │     │  ├─ index.tsx #zdn6mw
-        │     │  ├─ logo.svg #1okqmlj
-        │     │  └─ react-app-env.d.ts #t4ygcy
-        │     └─ tsconfig.json #6rw46b
-        ├─ tsconfig.json #1h72lkd
-        └─ yarn.lock"
-      `);
+      expect(hashlessTree(destination)).toMatchSnapshot();
     });
 
     it('SHOULD setup an package.json correctly', async () => {

--- a/packages/tree-view-for-tests/src/index.ts
+++ b/packages/tree-view-for-tests/src/index.ts
@@ -30,12 +30,13 @@ interface Options {
   hashIgnores?: string[];
 }
 
-function tree(
+function generateTree(
   _path: string,
   options: Options = {
     ignores: defaultIgnores,
     hashIgnores: defaultHashIgnores,
   },
+  noHash?: boolean,
   level = 1,
 ): string {
   const stat = fs.statSync(_path);
@@ -46,12 +47,14 @@ function tree(
     // todo - handle symlinks, etc
     return `${times('#', level)}${dir}\n${children
       .filter((child: string) => !options.ignores?.includes(child))
-      .map((child: string) => tree(path.join(_path, child), options, level + 1))
+      .map((child: string) =>
+        generateTree(path.join(_path, child), options, noHash, level + 1),
+      )
       .join('\n')}`;
   } else {
     return [
       `${times('#', level)}${path.basename(_path)}`,
-      options.hashIgnores?.includes(path.basename(_path))
+      noHash || options.hashIgnores?.includes(path.basename(_path))
         ? undefined
         : `#${hash(fs.readFileSync(_path, 'utf8').replace(/\r/gm, ''))}`,
     ]
@@ -60,6 +63,11 @@ function tree(
   }
 }
 
-export default function generate(_path: string, options?: Options): string {
-  return asciiTree.generate(tree(_path, options));
+export default function tree(_path: string, options?: Options): string {
+  return asciiTree.generate(generateTree(_path, options));
+}
+
+export function hashlessTree(_path: string): string {
+  console.log('this is being used');
+  return asciiTree.generate(generateTree(_path, undefined, true));
 }


### PR DESCRIPTION
CMRA tests run the latest version of modular-scripts available on NPM and thus the snapshots need to be updated post release.
- Removed the unnecessary hashing from the snapshots 
- Updated the snapshots
- Removed snapshot content left in the .matchSnapshot() function when a previous PR had changed it from matchInlineSnapshot()
- Fixed Jest link in Docs not rendering correctly 