### PR TITLE
Do not throw with non-modular packages and exclude them from selection

### DIFF
--- a/.changeset/bright-flies-cheer.md
+++ b/.changeset/bright-flies-cheer.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": minor
+---
+
+Allow non-modular packages without errors

--- a/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
@@ -5,7 +5,7 @@ exports[`getWorkspaceInfo 1`] = `
   "location": "packages/create-modular-react-app",
   "mismatchedWorkspaceDependencies": [],
   "public": true,
-  "type": "package",
+  "type": "unknown",
   "version": Any<String>,
   "workspaceDependencies": [],
 }
@@ -16,7 +16,7 @@ exports[`getWorkspaceInfo 2`] = `
   "location": "packages/eslint-config-modular-app",
   "mismatchedWorkspaceDependencies": [],
   "public": true,
-  "type": "package",
+  "type": "unknown",
   "version": Any<String>,
   "workspaceDependencies": [],
 }
@@ -27,7 +27,7 @@ exports[`getWorkspaceInfo 3`] = `
   "location": "packages/modular-scripts",
   "mismatchedWorkspaceDependencies": [],
   "public": true,
-  "type": "package",
+  "type": "unknown",
   "version": Any<String>,
   "workspaceDependencies": [
     "@modular-scripts/modular-types",
@@ -107,7 +107,7 @@ exports[`getWorkspaceInfo 10`] = `
   "location": "packages/modular-types",
   "mismatchedWorkspaceDependencies": [],
   "public": true,
-  "type": "package",
+  "type": "unknown",
   "version": Any<String>,
   "workspaceDependencies": [],
 }
@@ -118,7 +118,7 @@ exports[`getWorkspaceInfo 11`] = `
   "location": "packages/modular-views.macro",
   "mismatchedWorkspaceDependencies": [],
   "public": true,
-  "type": "package",
+  "type": "unknown",
   "version": Any<String>,
   "workspaceDependencies": [],
 }
@@ -126,10 +126,10 @@ exports[`getWorkspaceInfo 11`] = `
 
 exports[`getWorkspaceInfo 12`] = `
 {
-  "location": "packages/tree-view-for-tests",
+  "location": "packages/sample-app",
   "mismatchedWorkspaceDependencies": [],
   "public": false,
-  "type": "package",
+  "type": "app",
   "version": Any<String>,
   "workspaceDependencies": [],
 }
@@ -137,10 +137,21 @@ exports[`getWorkspaceInfo 12`] = `
 
 exports[`getWorkspaceInfo 13`] = `
 {
+  "location": "packages/tree-view-for-tests",
+  "mismatchedWorkspaceDependencies": [],
+  "public": false,
+  "type": "unknown",
+  "version": Any<String>,
+  "workspaceDependencies": [],
+}
+`;
+
+exports[`getWorkspaceInfo 14`] = `
+{
   "location": "packages/workspace-resolver",
   "mismatchedWorkspaceDependencies": [],
   "public": true,
-  "type": "package",
+  "type": "unknown",
   "version": Any<String>,
   "workspaceDependencies": [
     "@modular-scripts/modular-types",

--- a/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
@@ -139,17 +139,6 @@ exports[`getWorkspaceInfo 12`] = `
 
 exports[`getWorkspaceInfo 13`] = `
 {
-  "location": "packages/sample-app",
-  "mismatchedWorkspaceDependencies": [],
-  "public": false,
-  "type": "app",
-  "version": Any<String>,
-  "workspaceDependencies": [],
-}
-`;
-
-exports[`getWorkspaceInfo 14`] = `
-{
   "location": "packages/tree-view-for-tests",
   "mismatchedWorkspaceDependencies": [],
   "public": false,

--- a/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
+++ b/packages/modular-scripts/src/__tests__/utils/__snapshots__/getWorkspaceInfo.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getWorkspaceInfo 1`] = `
 {
-  "location": "packages/create-modular-react-app",
+  "location": "packages/modular-types",
   "mismatchedWorkspaceDependencies": [],
   "public": true,
   "type": "unknown",
@@ -13,6 +13,30 @@ exports[`getWorkspaceInfo 1`] = `
 
 exports[`getWorkspaceInfo 2`] = `
 {
+  "location": "packages/workspace-resolver",
+  "mismatchedWorkspaceDependencies": [],
+  "public": true,
+  "type": "unknown",
+  "version": Any<String>,
+  "workspaceDependencies": [
+    "@modular-scripts/modular-types",
+  ],
+}
+`;
+
+exports[`getWorkspaceInfo 3`] = `
+{
+  "location": "packages/create-modular-react-app",
+  "mismatchedWorkspaceDependencies": [],
+  "public": true,
+  "type": "unknown",
+  "version": Any<String>,
+  "workspaceDependencies": [],
+}
+`;
+
+exports[`getWorkspaceInfo 4`] = `
+{
   "location": "packages/eslint-config-modular-app",
   "mismatchedWorkspaceDependencies": [],
   "public": true,
@@ -22,7 +46,7 @@ exports[`getWorkspaceInfo 2`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 3`] = `
+exports[`getWorkspaceInfo 5`] = `
 {
   "location": "packages/modular-scripts",
   "mismatchedWorkspaceDependencies": [],
@@ -36,7 +60,7 @@ exports[`getWorkspaceInfo 3`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 4`] = `
+exports[`getWorkspaceInfo 6`] = `
 {
   "location": "packages/modular-template-app",
   "mismatchedWorkspaceDependencies": [],
@@ -47,7 +71,7 @@ exports[`getWorkspaceInfo 4`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 5`] = `
+exports[`getWorkspaceInfo 7`] = `
 {
   "location": "packages/modular-template-esm-view",
   "mismatchedWorkspaceDependencies": [],
@@ -58,7 +82,7 @@ exports[`getWorkspaceInfo 5`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 6`] = `
+exports[`getWorkspaceInfo 8`] = `
 {
   "location": "packages/modular-template-node-env-app",
   "mismatchedWorkspaceDependencies": [],
@@ -69,7 +93,7 @@ exports[`getWorkspaceInfo 6`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 7`] = `
+exports[`getWorkspaceInfo 9`] = `
 {
   "location": "packages/modular-template-package",
   "mismatchedWorkspaceDependencies": [],
@@ -80,7 +104,7 @@ exports[`getWorkspaceInfo 7`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 8`] = `
+exports[`getWorkspaceInfo 10`] = `
 {
   "location": "packages/modular-template-source",
   "mismatchedWorkspaceDependencies": [],
@@ -91,7 +115,7 @@ exports[`getWorkspaceInfo 8`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 9`] = `
+exports[`getWorkspaceInfo 11`] = `
 {
   "location": "packages/modular-template-view",
   "mismatchedWorkspaceDependencies": [],
@@ -102,18 +126,7 @@ exports[`getWorkspaceInfo 9`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 10`] = `
-{
-  "location": "packages/modular-types",
-  "mismatchedWorkspaceDependencies": [],
-  "public": true,
-  "type": "unknown",
-  "version": Any<String>,
-  "workspaceDependencies": [],
-}
-`;
-
-exports[`getWorkspaceInfo 11`] = `
+exports[`getWorkspaceInfo 12`] = `
 {
   "location": "packages/modular-views.macro",
   "mismatchedWorkspaceDependencies": [],
@@ -124,7 +137,7 @@ exports[`getWorkspaceInfo 11`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 12`] = `
+exports[`getWorkspaceInfo 13`] = `
 {
   "location": "packages/sample-app",
   "mismatchedWorkspaceDependencies": [],
@@ -135,7 +148,7 @@ exports[`getWorkspaceInfo 12`] = `
 }
 `;
 
-exports[`getWorkspaceInfo 13`] = `
+exports[`getWorkspaceInfo 14`] = `
 {
   "location": "packages/tree-view-for-tests",
   "mismatchedWorkspaceDependencies": [],
@@ -143,18 +156,5 @@ exports[`getWorkspaceInfo 13`] = `
   "type": "unknown",
   "version": Any<String>,
   "workspaceDependencies": [],
-}
-`;
-
-exports[`getWorkspaceInfo 14`] = `
-{
-  "location": "packages/workspace-resolver",
-  "mismatchedWorkspaceDependencies": [],
-  "public": true,
-  "type": "unknown",
-  "version": Any<String>,
-  "workspaceDependencies": [
-    "@modular-scripts/modular-types",
-  ],
 }
 `;

--- a/packages/modular-scripts/src/__tests__/utils/getWorkspaceInfo.test.ts
+++ b/packages/modular-scripts/src/__tests__/utils/getWorkspaceInfo.test.ts
@@ -2,7 +2,11 @@ import { getWorkspaceInfo } from '../../utils/getWorkspaceInfo';
 
 test('getWorkspaceInfo', async () => {
   const workspace = await getWorkspaceInfo();
-  Object.values(workspace).forEach((pkg) => {
-    expect(pkg).toMatchSnapshot({ version: expect.any(String) as unknown });
-  });
+  Object.entries(workspace)
+    .sort(([packageA], [packageB]) =>
+      packageA < packageB ? -1 : packageA > packageB ? 1 : 0,
+    )
+    .forEach(([, pkg]) => {
+      expect(pkg).toMatchSnapshot({ version: expect.any(String) as unknown });
+    });
 });

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -124,10 +124,6 @@ program
     ) => {
       const { default: build } = await import('./build');
 
-      options.changed
-        ? logger.log('Building changed packages')
-        : logger.log('Building packages at:', packagePaths.join(', '));
-
       if (options.compareBranch && !options.changed) {
         process.stderr.write(
           "Option --compareBranch doesn't make sense without option --changed\n",

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -219,6 +219,7 @@ async function computeRegexesFromPackageNames(
 ): Promise<string[]> {
   const allWorkspaces = await getAllWorkspaces(getModularRoot());
   return targets
+    .filter((packageName) => allWorkspaces[0].get(packageName)?.type)
     .map((packageName) => allWorkspaces[0].get(packageName)?.location)
     .filter(Boolean) as string[];
 }

--- a/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
+++ b/packages/modular-scripts/src/utils/getWorkspaceInfo.ts
@@ -31,7 +31,7 @@ export async function getWorkspaceInfo(
       }
       const { rawPackageJson } = workspace;
 
-      const type = rawPackageJson.modular?.type || ('package' as ModularType);
+      const type = rawPackageJson.modular?.type || 'unknown';
       workspaceInfo[packageName] = {
         ...packageInfo,
         type,

--- a/packages/modular-scripts/src/utils/packageTypes.ts
+++ b/packages/modular-scripts/src/utils/packageTypes.ts
@@ -26,7 +26,7 @@ const packageTypeDefinitions: PackageTypeDefinitions = {
 
 export const ModularTypes: ModularType[] = (
   Object.keys(packageTypeDefinitions) as ModularType[]
-).concat(['root']);
+).concat(['root', 'unknown']);
 
 export function getModularType(dir: string): ModularType | undefined {
   const packageJsonPath = path.join(dir, 'package.json');


### PR DESCRIPTION
- [x] Make `check` pass in presence of non-modular packages
- [x] Show non-modular packages as `unknown` type in `workspace`
- [x] Do not try to test non-Modular packages 
- [x] Fix wording in `build`
- [x] ~Show correct data in `analyze`~