### PR TITLE
Support public assets for esm-views

### DIFF
--- a/.changeset/cyan-peaches-visit.md
+++ b/.changeset/cyan-peaches-visit.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": minor
+---
+
+Support public assets for esm-views

--- a/packages/modular-scripts/src/build/buildStandalone.ts
+++ b/packages/modular-scripts/src/build/buildStandalone.ts
@@ -64,11 +64,13 @@ export async function buildStandalone(
   logger.log('Creating an optimized production build...');
 
   await fs.emptyDir(paths.appBuild);
-  await fs.copy(paths.appPublic, paths.appBuild, {
-    dereference: true,
-    filter: (file) => file !== paths.appHtml,
-    overwrite: true,
-  });
+  if (await fs.pathExists(paths.appPublic)) {
+    await fs.copy(paths.appPublic, paths.appBuild, {
+      dereference: true,
+      filter: (file) => file !== paths.appHtml,
+      overwrite: true,
+    });
+  }
 
   let assets: Asset[];
   logger.debug('Extracting dependency info from source code...');

--- a/packages/modular-scripts/src/build/buildStandalone.ts
+++ b/packages/modular-scripts/src/build/buildStandalone.ts
@@ -63,7 +63,7 @@ export async function buildStandalone(
 
   logger.log('Creating an optimized production build...');
 
-  // Build assets from public/ to the dist/, execept for the index
+  // Copy assets from public/ to dist/, execept for index.html
   await fs.emptyDir(paths.appBuild);
   if (await fs.pathExists(paths.appPublic)) {
     await fs.copy(paths.appPublic, paths.appBuild, {

--- a/packages/modular-scripts/src/build/buildStandalone.ts
+++ b/packages/modular-scripts/src/build/buildStandalone.ts
@@ -64,14 +64,11 @@ export async function buildStandalone(
   logger.log('Creating an optimized production build...');
 
   await fs.emptyDir(paths.appBuild);
-
-  if (isApp) {
-    await fs.copy(paths.appPublic, paths.appBuild, {
-      dereference: true,
-      filter: (file) => file !== paths.appHtml,
-      overwrite: true,
-    });
-  }
+  await fs.copy(paths.appPublic, paths.appBuild, {
+    dereference: true,
+    filter: (file) => file !== paths.appHtml,
+    overwrite: true,
+  });
 
   let assets: Asset[];
   logger.debug('Extracting dependency info from source code...');

--- a/packages/modular-scripts/src/build/buildStandalone.ts
+++ b/packages/modular-scripts/src/build/buildStandalone.ts
@@ -63,6 +63,7 @@ export async function buildStandalone(
 
   logger.log('Creating an optimized production build...');
 
+  // Build assets from public/ to the dist/, execept for the index
   await fs.emptyDir(paths.appBuild);
   if (await fs.pathExists(paths.appPublic)) {
     await fs.copy(paths.appPublic, paths.appBuild, {


### PR DESCRIPTION
Support referencing assets in the `public` directory within `esm-view`s.

---

- [x] Copy `public/` assets to `dist/` when `build`ing
  - [x] Webpack
  - [x] esbuild
- [x] Ensure that this works when `public/` doesn't exist
- [x] Copy assets when `start`ing