### PR TITLE
Add a prepublish script for remote-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test": "yarn modular test --watchAll false --runInBand --env node",
     "build": "yarn workspace @modular-scripts/workspace-resolver build && yarn workspace create-modular-react-app build && yarn workspace modular-scripts build && yarn workspace modular-views.macro build && yarn modular build @modular-scripts/remote-view && yarn prepare:remote-view",
     "prepare": "is-ci || husky install",
-    "prepare:remote-view": "cp -R dist/modular-scripts-remote-view packages/remote-view/dist",
+    "prepare:remote-view:copy": "cp -R dist/modular-scripts-remote-view packages/remote-view/dist",
+    "prepare:remote-view:prepublish": "node scripts/remote-view-prepublish.js",
+    "prepare:remote-view": "yarn prepare:remote-view:copy && yarn prepare:remote-view:prepublish",
     "postinstall": "patch-package",
     "typecheck": "yarn modular typecheck",
     "validate-lockfile": "node scripts/validate-lockfile.js"

--- a/scripts/remote-view-prepublish.js
+++ b/scripts/remote-view-prepublish.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { writeFileSync } = require('fs');
+const { resolve } = require('path');
+
+/**
+ * Removes the `publishConfig` block from a built Modular package.
+ * This expects the build output to have been copied to `packages/<dir>/dist`.
+ */
+
+const DIRS_TO_PREPARE = ['remote-view'];
+
+function writeNewPackageJson(src, content) {
+  writeFileSync(src, JSON.stringify(content, null, 2));
+}
+
+function removePublishConfig(src) {
+  const { publishConfig, ...pkg } = require(src);
+
+  return {
+    ...pkg,
+  };
+}
+
+DIRS_TO_PREPARE.forEach((dirName) => {
+  const src = resolve(
+    __dirname,
+    `../packages/${dirName}`,
+    'dist',
+    'package.json',
+  );
+  const content = removePublishConfig(src);
+  writeNewPackageJson(src, content);
+  console.log(
+    `Package at dir packages/${dirName}/dist was updated to remove publishConfig`,
+  );
+});


### PR DESCRIPTION
Previously, the `@modular-scripts/remote-view` package, upon being built and copied into `packages/remote-view/dist`, contained all fields including the `publishConfig` field. This appears to confuse the changesets release action (or possibly the npm publish command) and it attempts to publish `dist/dist ...`.

This prepublish script runs after building and copying the `@modular-scripts/remote-view` package, removing the `publishConfig`.