### PR TITLE
Selective `modular lint`

### DIFF
--- a/.changeset/fluffy-oranges-march.md
+++ b/.changeset/fluffy-oranges-march.md
@@ -1,0 +1,7 @@
+---
+"create-modular-react-app": major
+"eslint-config-modular-app": patch
+"modular-scripts": minor
+---
+
+Selective `modular lint`

--- a/.changeset/gorgeous-dancers-turn.md
+++ b/.changeset/gorgeous-dancers-turn.md
@@ -1,0 +1,7 @@
+---
+"eslint-config-modular-app": patch
+"modular-scripts": minor
+---
+
+`modular lint` supports selective options
+`eslint-config-modular-app` doesn't depend on eslint-config-react-app anymore

--- a/__fixtures__/custom-workspace-root/package.json
+++ b/__fixtures__/custom-workspace-root/package.json
@@ -15,7 +15,7 @@
     "start": "modular start",
     "build": "modular build",
     "test": "modular test",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write ."
   },
   "eslintConfig": {

--- a/__fixtures__/ghost-building/package.json
+++ b/__fixtures__/ghost-building/package.json
@@ -15,7 +15,7 @@
     "start": "modular start",
     "build": "modular build",
     "test": "modular test",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write ."
   },
   "eslintConfig": {

--- a/__fixtures__/ghost-testing/package.json
+++ b/__fixtures__/ghost-testing/package.json
@@ -14,7 +14,7 @@
     "start": "modular start",
     "build": "modular build",
     "test": "modular test",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write ."
   },
   "eslintConfig": {

--- a/__fixtures__/non-modular/package.json
+++ b/__fixtures__/non-modular/package.json
@@ -15,7 +15,7 @@
     "start": "modular start",
     "build": "modular build",
     "test": "modular test",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write ."
   },
   "eslintConfig": {

--- a/__fixtures__/selective-lint/.gitignore
+++ b/__fixtures__/selective-lint/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/__fixtures__/selective-lint/.yarnrc
+++ b/__fixtures__/selective-lint/.yarnrc
@@ -1,0 +1,1 @@
+disable-self-update-check true

--- a/__fixtures__/selective-lint/README.md
+++ b/__fixtures__/selective-lint/README.md
@@ -1,0 +1,1 @@
+This is the `README.md` for the whole monorepo.

--- a/__fixtures__/selective-lint/modular/setupTests.ts
+++ b/__fixtures__/selective-lint/modular/setupTests.ts
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom/extend-expect';

--- a/__fixtures__/selective-lint/package.json
+++ b/__fixtures__/selective-lint/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "ghost-tests-monorepo",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "workspaces": [
+    "packages/**"
+  ],
+  "modular": {
+    "type": "root"
+  },
+  "scripts": {
+    "start": "modular start",
+    "build": "modular build",
+    "test": "modular test",
+    "lint": "eslint . --ext .js,.ts,.tsx",
+    "prettier": "prettier --write ."
+  },
+  "eslintConfig": {
+    "extends": "modular-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all",
+    "printWidth": 80,
+    "proseWrap": "always"
+  },
+  "dependencies": {
+    "@testing-library/dom": "^8.16.1",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.3.0",
+    "@testing-library/user-event": "^7.2.1",
+    "@types/jest": "^28.1.6",
+    "@types/node": "^18.7.2",
+    "@types/react": "^18.0.17",
+    "@types/react-dom": "^18.0.6",
+    "eslint-config-modular-app": "^4.0.0",
+    "prettier": "^2.7.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": ">=4.2.1 <4.5.0"
+  }
+}

--- a/__fixtures__/selective-lint/package.json
+++ b/__fixtures__/selective-lint/package.json
@@ -14,7 +14,7 @@
     "start": "modular start",
     "build": "modular build",
     "test": "modular test",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write ."
   },
   "eslintConfig": {

--- a/__fixtures__/selective-lint/packages/README.md
+++ b/__fixtures__/selective-lint/packages/README.md
@@ -1,0 +1,1 @@
+This will be the readme inside /packages

--- a/__fixtures__/selective-lint/packages/alpha-lint/package.json
+++ b/__fixtures__/selective-lint/packages/alpha-lint/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "alpha-lint",
+  "private": false,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "beta-lint": "1.0.0",
+    "gamma-lint": "1.0.0"
+  }
+}

--- a/__fixtures__/selective-lint/packages/alpha-lint/src/index.ts
+++ b/__fixtures__/selective-lint/packages/alpha-lint/src/index.ts
@@ -1,0 +1,4 @@
+export default function add(a: number, b: number): number {
+  //test
+  return a + b;
+}

--- a/__fixtures__/selective-lint/packages/beta-lint/package.json
+++ b/__fixtures__/selective-lint/packages/beta-lint/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "beta-lint",
+  "private": false,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "gamma-lint": "1.0.0"
+  }
+}

--- a/__fixtures__/selective-lint/packages/beta-lint/src/index.ts
+++ b/__fixtures__/selective-lint/packages/beta-lint/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/__fixtures__/selective-lint/packages/delta-lint/package.json
+++ b/__fixtures__/selective-lint/packages/delta-lint/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "delta-lint",
+  "private": false,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/selective-lint/packages/delta-lint/src/index.ts
+++ b/__fixtures__/selective-lint/packages/delta-lint/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/__fixtures__/selective-lint/packages/epsilon-lint/package.json
+++ b/__fixtures__/selective-lint/packages/epsilon-lint/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "epsilon-lint",
+  "private": false,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "alpha-lint": "1.0.0"
+  }
+}

--- a/__fixtures__/selective-lint/packages/epsilon-lint/src/index.ts
+++ b/__fixtures__/selective-lint/packages/epsilon-lint/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/__fixtures__/selective-lint/packages/gamma-lint/package.json
+++ b/__fixtures__/selective-lint/packages/gamma-lint/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gamma-lint",
+  "private": false,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "delta-lint": "1.0.0"
+  }
+}

--- a/__fixtures__/selective-lint/packages/gamma-lint/src/index.ts
+++ b/__fixtures__/selective-lint/packages/gamma-lint/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/__fixtures__/selective-lint/tsconfig.json
+++ b/__fixtures__/selective-lint/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "modular-scripts/tsconfig.json",
+  "include": ["modular", "packages/**/src"]
+}

--- a/__fixtures__/source-type/package.json
+++ b/__fixtures__/source-type/package.json
@@ -15,7 +15,7 @@
     "start": "modular start",
     "build": "modular build",
     "test": "modular test",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write ."
   },
   "eslintConfig": {

--- a/docs/commands/lint.md
+++ b/docs/commands/lint.md
@@ -5,24 +5,55 @@ title: modular lint
 
 # `modular lint [options] [regexes...]`
 
-`modular lint` will check the diff between the current branch and your remote
-origin default branch (i.e. `master` or `main`) and only lint the `.ts`, `.tsx`,
-`.js`, `.jsx` files that have changes.
+`modular lint` without arguments or options will check the diff between the
+current branch and your remote origin default branch (i.e. `master` or `main`)
+and only lint the `.ts`, `.tsx`, `.js`, `.jsx` files that have changes. When in
+CI or when `--all` is provided, it will default to lint the entire codebase.
+Wneh `--staged` is provided, it will only lint the files staged on git.
+
+Alternatively, when it is invoked with one or more selective options
+(`--packages`, `--ancestors`, `--descendants` or `--changed`), it will lint all
+the source code files in the provided `--packages`, optionally agumenting the
+set of packages by adding their ancestors (`--ancestors`), their descendants
+(`--descendants`) or the files that have changed (`--changed`), calculated
+comparing the current state of the git repository with the branch specified by
+`compareBranch` or, if `compareBranch` is not set, with the default branch.
 
 It uses your project eslint config to lint and jest runner to report on the lint
 status of each file (`PASS` or `FAIL`). If a file has a lint warning, the
 command will be marked as failed, with printed eslint errors for each
 warning/error.
 
-When in CI, it will default to lint the entire codebase. When not in CI, it will
-default to only lint the diffed files.
-
 ## Options:
 
-`--all`: Lints the entire codebase
+`--all`: Lints the entire codebase (not compatible with `--staged` and with the
+Selective Options)
 
-`--staged`: Lints only files staged on git (not compatible with `--all`)
+`--staged`: Lints only files staged on git (not compatible with `--all` and with
+the Selective Options)
 
 `--fix`: Allows eslint to fix the errors and warnings that do not require manual
 intervention wherever possible. Restages any fixed files that were previously
 staged when used in combination with `--staged`.
+
+### Selective Options
+
+`--packages [packages...]`: A list of one or more packages to lint. Can be
+combined with all the other selective options.
+
+`--ancestors`: Take the packages specified via `--packages` or `--changed` and
+add their ancestors (i.e. the packages that have a direct or indirect dependency
+on them) to the lint list.
+
+`--descendants`: Take the packages specified via `--packages` or `--changed` and
+add their descendants (i.e. the packages they directly or indirectly depend on)
+to the lint list.
+
+`--changed`: Add all the packages whose workspaces contain files that have
+changed, calculated comparing the current state of the git repository with the
+branch specified by `compareBranch` or, if `compareBranch` is not set, with the
+default branch.
+
+`--compareBranch <branch>`: Specify the comparison branch used to determine
+which files have changed when using the `changed` option. If this option is used
+without `changed`, the command will fail.

--- a/docs/commands/lint.md
+++ b/docs/commands/lint.md
@@ -9,7 +9,7 @@ title: modular lint
 current branch and your remote origin default branch (i.e. `master` or `main`)
 and only lint the `.ts`, `.tsx`, `.js`, `.jsx` files that have changes. When in
 CI without arguments or options or when the `--all` option is provided, it will
-lint the entire codebase. Wneh `--staged` is provided, it will only lint the
+lint the entire codebase. When `--staged` is provided, it will only lint the
 files staged on git.
 
 Alternatively, when it is invoked with one or more selective options
@@ -18,7 +18,7 @@ the source code files in the provided `--packages`, optionally agumenting the
 set of packages by adding their ancestors (`--ancestors`), their descendants
 (`--descendants`) or the files that have changed (`--changed`), calculated
 comparing the current state of the git repository with the branch specified by
-`compareBranch` or, if `compareBranch` is not set, with the default branch.
+`--compareBranch` or, if `--compareBranch` is not set, with the default branch.
 
 It uses your project eslint config to lint and jest runner to report on the lint
 status of each file (`PASS` or `FAIL`). If a file has a lint warning, the

--- a/docs/commands/lint.md
+++ b/docs/commands/lint.md
@@ -33,8 +33,6 @@ warning/error.
   origin's default branch when not in CI
 - default to lint everything (essentially like `--all`) when in CI
 
-codebase (like `--all`)
-
 ## Options:
 
 `--all`: Lints the entire codebase (not compatible with `--staged` and with the

--- a/docs/commands/lint.md
+++ b/docs/commands/lint.md
@@ -8,8 +8,9 @@ title: modular lint
 `modular lint` without arguments or options will check the diff between the
 current branch and your remote origin default branch (i.e. `master` or `main`)
 and only lint the `.ts`, `.tsx`, `.js`, `.jsx` files that have changes. When in
-CI or when `--all` is provided, it will default to lint the entire codebase.
-Wneh `--staged` is provided, it will only lint the files staged on git.
+CI without arguments or options or when the `--all` option is provided, it will
+lint the entire codebase. Wneh `--staged` is provided, it will only lint the
+files staged on git.
 
 Alternatively, when it is invoked with one or more selective options
 (`--packages`, `--ancestors`, `--descendants` or `--changed`), it will lint all
@@ -23,6 +24,16 @@ It uses your project eslint config to lint and jest runner to report on the lint
 status of each file (`PASS` or `FAIL`). If a file has a lint warning, the
 command will be marked as failed, with printed eslint errors for each
 warning/error.
+
+## Default behaviour
+
+`modular lint` without arguments or options will:
+
+- default to lint the `git diff` between the current branch and the remote
+  origin's default branch when not in CI
+- default to lint everything (essentially like `--all`) when in CI
+
+codebase (like `--all`)
 
 ## Options:
 

--- a/packages/create-modular-react-app/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/create-modular-react-app/src/__tests__/__snapshots__/index.test.ts.snap
@@ -72,7 +72,7 @@ exports[`create-modular-react-app WHEN it sets up a project with prefer Offline 
           "private": true,
           "scripts": Object {
             "build": "modular build",
-            "lint": "eslint . --ext .js,.ts,.tsx",
+            "lint": "modular lint",
             "prettier": "prettier --write .",
             "start": "modular start",
             "test": "modular test",
@@ -132,7 +132,7 @@ exports[`create-modular-react-app WHEN it sets up a project with prefer Offline 
   "private": true,
   "scripts": {
     "build": "modular build",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write .",
     "start": "modular start",
     "test": "modular test",
@@ -258,7 +258,7 @@ exports[`create-modular-react-app WHEN setting a project with defaults Sets up t
             "private": true,
             "scripts": Object {
               "build": "modular build",
-              "lint": "eslint . --ext .js,.ts,.tsx",
+              "lint": "modular lint",
               "prettier": "prettier --write .",
               "start": "modular start",
               "test": "modular test",
@@ -318,7 +318,7 @@ exports[`create-modular-react-app WHEN setting a project with defaults Sets up t
   "private": true,
   "scripts": {
     "build": "modular build",
-    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint": "modular lint",
     "prettier": "prettier --write .",
     "start": "modular start",
     "test": "modular test",

--- a/packages/create-modular-react-app/src/__tests__/index.test.ts
+++ b/packages/create-modular-react-app/src/__tests__/index.test.ts
@@ -119,7 +119,7 @@ describe('create-modular-react-app', () => {
             "private": true,
             "scripts": Object {
               "build": "modular build",
-              "lint": "eslint . --ext .js,.ts,.tsx",
+              "lint": "modular lint",
               "prettier": "prettier --write .",
               "start": "modular start",
               "test": "modular test",
@@ -217,7 +217,7 @@ describe('create-modular-react-app', () => {
           "private": true,
           "scripts": Object {
             "build": "modular build",
-            "lint": "eslint . --ext .js,.ts,.tsx",
+            "lint": "modular lint",
             "prettier": "prettier --write .",
             "start": "modular start",
             "test": "modular test",

--- a/packages/create-modular-react-app/src/index.ts
+++ b/packages/create-modular-react-app/src/index.ts
@@ -100,7 +100,7 @@ export default async function createModularApp(argv: {
       start: 'modular start',
       build: 'modular build',
       test: 'modular test',
-      lint: 'eslint . --ext .js,.ts,.tsx',
+      lint: 'modular lint',
       prettier: 'prettier --write .',
     },
     eslintConfig: {

--- a/packages/eslint-config-modular-app/base.js
+++ b/packages/eslint-config-modular-app/base.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// This file is based on https://github.com/facebook/create-react-app/tree/main/packages/eslint-config-react-app
+
+// Fix eslint shareable config (https://github.com/eslint/eslint/issues/3458)
+require('@rushstack/eslint-patch/modern-module-resolution');
+
+// This file contains the minimum ESLint configuration required for Create
+// React App support, and is used as the `baseConfig` for `eslint-loader`
+// to ensure that user-provided configs don't need this boilerplate.
+
+module.exports = {
+  root: true,
+
+  parser: '@babel/eslint-parser',
+
+  plugins: ['react'],
+
+  env: {
+    browser: true,
+    commonjs: true,
+    es6: true,
+    jest: true,
+    node: true,
+  },
+
+  parserOptions: {
+    sourceType: 'module',
+    requireConfigFile: false,
+    babelOptions: {
+      presets: [require.resolve('babel-preset-react-app/prod')],
+    },
+  },
+
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+
+  rules: {
+    'react/jsx-uses-vars': 'warn',
+    'react/jsx-uses-react': 'warn',
+  },
+};

--- a/packages/eslint-config-modular-app/index.js
+++ b/packages/eslint-config-modular-app/index.js
@@ -11,7 +11,7 @@ const WARN = 'warn';
 const OFF = 'off';
 
 module.exports = {
-  extends: ['react-app'],
+  extends: [require.resolve('./react-app')],
   parser: '@babel/eslint-parser',
   reportUnusedDisableDirectives: true,
   overrides: [

--- a/packages/eslint-config-modular-app/jest.js
+++ b/packages/eslint-config-modular-app/jest.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// This file is based on https://github.com/facebook/create-react-app/tree/main/packages/eslint-config-react-app
+// Fix eslint shareable config (https://github.com/eslint/eslint/issues/3458)
+require('@rushstack/eslint-patch/modern-module-resolution');
+
+// We use eslint-loader so even warnings are very visible.
+// This is why we prefer to use "WARNING" level for potential errors,
+// and we try not to use "ERROR" level at all.
+
+module.exports = {
+  plugins: ['jest', 'testing-library'],
+  overrides: [
+    {
+      files: ['**/__tests__/**/*', '**/*.{spec,test}.*'],
+      env: {
+        'jest/globals': true,
+      },
+      // A subset of the recommended rules:
+      rules: {
+        // https://github.com/jest-community/eslint-plugin-jest
+        'jest/no-conditional-expect': 'error',
+        'jest/no-identical-title': 'error',
+        'jest/no-interpolation-in-snapshots': 'error',
+        'jest/no-jasmine-globals': 'error',
+        'jest/no-jest-import': 'error',
+        'jest/no-mocks-import': 'error',
+        'jest/valid-describe-callback': 'error',
+        'jest/valid-expect': 'error',
+        'jest/valid-expect-in-promise': 'error',
+        'jest/valid-title': 'warn',
+
+        // https://github.com/testing-library/eslint-plugin-testing-library
+        'testing-library/await-async-query': 'error',
+        'testing-library/await-async-utils': 'error',
+        'testing-library/no-await-sync-query': 'error',
+        'testing-library/no-container': 'error',
+        'testing-library/no-debugging-utils': 'error',
+        'testing-library/no-dom-import': ['error', 'react'],
+        'testing-library/no-node-access': 'error',
+        'testing-library/no-promise-in-fire-event': 'error',
+        'testing-library/no-render-in-setup': 'error',
+        'testing-library/no-unnecessary-act': 'error',
+        'testing-library/no-wait-for-empty-callback': 'error',
+        'testing-library/no-wait-for-multiple-assertions': 'error',
+        'testing-library/no-wait-for-side-effects': 'error',
+        'testing-library/no-wait-for-snapshot': 'error',
+        'testing-library/prefer-find-by': 'error',
+        'testing-library/prefer-presence-queries': 'error',
+        'testing-library/prefer-query-by-disappearance': 'error',
+        'testing-library/prefer-screen-queries': 'error',
+        'testing-library/render-result-naming-convention': 'error',
+      },
+    },
+  ],
+};

--- a/packages/eslint-config-modular-app/package.json
+++ b/packages/eslint-config-modular-app/package.json
@@ -11,13 +11,16 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
+    "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "7.18.2",
     "@babel/plugin-syntax-flow": "^7.14.5",
     "@babel/plugin-transform-react-jsx": "^7.14.9",
+    "@rushstack/eslint-patch": "^1.1.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "babel-eslint": "10.1.0",
-    "eslint-config-react-app": "^7.0.0",
+    "babel-preset-react-app": "^10.0.1",
+    "confusing-browser-globals": "^1.0.11",
     "eslint-plugin-flowtype": "^8.0.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "^27.0.0",

--- a/packages/eslint-config-modular-app/react-app.js
+++ b/packages/eslint-config-modular-app/react-app.js
@@ -1,0 +1,287 @@
+'use strict';
+
+// This file is based on https://github.com/facebook/create-react-app/tree/main/packages/eslint-config-react-app
+
+// Inspired by https://github.com/airbnb/javascript but less opinionated.
+
+// We use eslint-loader so even warnings are very visible.
+// This is why we prefer to use "WARNING" level for potential errors,
+// and we try not to use "ERROR" level at all.
+
+// In the future, we might create a separate list of rules for production.
+// It would probably be more strict.
+
+// The ESLint browser environment defines all browser globals as valid,
+// even though most people don't know some of them exist (e.g. `name` or `status`).
+// This is dangerous as it hides accidentally undefined variables.
+// We blacklist the globals that we deem potentially confusing.
+// To use them, explicitly reference them, e.g. `window.name` or `window.status`.
+
+const restrictedGlobals = require('confusing-browser-globals');
+
+module.exports = {
+  extends: [require.resolve('./base')],
+
+  plugins: ['import', 'flowtype', 'jsx-a11y', 'react-hooks'],
+
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true,
+        },
+
+        // typescript-eslint specific options
+        warnOnUnsupportedTypeScriptVersion: true,
+      },
+      plugins: ['@typescript-eslint'],
+      // If adding a typescript-eslint version of an existing ESLint rule,
+      // make sure to disable the ESLint rule here.
+      rules: {
+        // TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
+        'default-case': 'off',
+        // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
+        'no-dupe-class-members': 'off',
+        // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
+        'no-undef': 'off',
+
+        // Add TypeScript specific rules (and turn off ESLint equivalents)
+        '@typescript-eslint/consistent-type-assertions': 'warn',
+        'no-array-constructor': 'off',
+        '@typescript-eslint/no-array-constructor': 'warn',
+        'no-redeclare': 'off',
+        '@typescript-eslint/no-redeclare': 'warn',
+        'no-use-before-define': 'off',
+        '@typescript-eslint/no-use-before-define': [
+          'warn',
+          {
+            functions: false,
+            classes: false,
+            variables: false,
+            typedefs: false,
+          },
+        ],
+        'no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': [
+          'error',
+          {
+            allowShortCircuit: true,
+            allowTernary: true,
+            allowTaggedTemplates: true,
+          },
+        ],
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': [
+          'warn',
+          {
+            args: 'none',
+            ignoreRestSiblings: true,
+          },
+        ],
+        'no-useless-constructor': 'off',
+        '@typescript-eslint/no-useless-constructor': 'warn',
+      },
+    },
+  ],
+
+  // NOTE: When adding rules here, you need to make sure they are compatible with
+  // `typescript-eslint`, as some rules such as `no-array-constructor` aren't compatible.
+  rules: {
+    // http://eslint.org/docs/rules/
+    'array-callback-return': 'warn',
+    'default-case': ['warn', { commentPattern: '^no default$' }],
+    'dot-location': ['warn', 'property'],
+    eqeqeq: ['warn', 'smart'],
+    'new-parens': 'warn',
+    'no-array-constructor': 'warn',
+    'no-caller': 'warn',
+    'no-cond-assign': ['warn', 'except-parens'],
+    'no-const-assign': 'warn',
+    'no-control-regex': 'warn',
+    'no-delete-var': 'warn',
+    'no-dupe-args': 'warn',
+    'no-dupe-class-members': 'warn',
+    'no-dupe-keys': 'warn',
+    'no-duplicate-case': 'warn',
+    'no-empty-character-class': 'warn',
+    'no-empty-pattern': 'warn',
+    'no-eval': 'warn',
+    'no-ex-assign': 'warn',
+    'no-extend-native': 'warn',
+    'no-extra-bind': 'warn',
+    'no-extra-label': 'warn',
+    'no-fallthrough': 'warn',
+    'no-func-assign': 'warn',
+    'no-implied-eval': 'warn',
+    'no-invalid-regexp': 'warn',
+    'no-iterator': 'warn',
+    'no-label-var': 'warn',
+    'no-labels': ['warn', { allowLoop: true, allowSwitch: false }],
+    'no-lone-blocks': 'warn',
+    'no-loop-func': 'warn',
+    'no-mixed-operators': [
+      'warn',
+      {
+        groups: [
+          ['&', '|', '^', '~', '<<', '>>', '>>>'],
+          ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+          ['&&', '||'],
+          ['in', 'instanceof'],
+        ],
+        allowSamePrecedence: false,
+      },
+    ],
+    'no-multi-str': 'warn',
+    'no-global-assign': 'warn',
+    'no-unsafe-negation': 'warn',
+    'no-new-func': 'warn',
+    'no-new-object': 'warn',
+    'no-new-symbol': 'warn',
+    'no-new-wrappers': 'warn',
+    'no-obj-calls': 'warn',
+    'no-octal': 'warn',
+    'no-octal-escape': 'warn',
+    'no-redeclare': 'warn',
+    'no-regex-spaces': 'warn',
+    'no-restricted-syntax': ['warn', 'WithStatement'],
+    'no-script-url': 'warn',
+    'no-self-assign': 'warn',
+    'no-self-compare': 'warn',
+    'no-sequences': 'warn',
+    'no-shadow-restricted-names': 'warn',
+    'no-sparse-arrays': 'warn',
+    'no-template-curly-in-string': 'warn',
+    'no-this-before-super': 'warn',
+    'no-throw-literal': 'warn',
+    'no-undef': 'error',
+    'no-restricted-globals': ['error'].concat(restrictedGlobals),
+    'no-unreachable': 'warn',
+    'no-unused-expressions': [
+      'error',
+      {
+        allowShortCircuit: true,
+        allowTernary: true,
+        allowTaggedTemplates: true,
+      },
+    ],
+    'no-unused-labels': 'warn',
+    'no-unused-vars': [
+      'warn',
+      {
+        args: 'none',
+        ignoreRestSiblings: true,
+      },
+    ],
+    'no-use-before-define': [
+      'warn',
+      {
+        functions: false,
+        classes: false,
+        variables: false,
+      },
+    ],
+    'no-useless-computed-key': 'warn',
+    'no-useless-concat': 'warn',
+    'no-useless-constructor': 'warn',
+    'no-useless-escape': 'warn',
+    'no-useless-rename': [
+      'warn',
+      {
+        ignoreDestructuring: false,
+        ignoreImport: false,
+        ignoreExport: false,
+      },
+    ],
+    'no-with': 'warn',
+    'no-whitespace-before-property': 'warn',
+    'react-hooks/exhaustive-deps': 'warn',
+    'require-yield': 'warn',
+    'rest-spread-spacing': ['warn', 'never'],
+    strict: ['warn', 'never'],
+    'unicode-bom': ['warn', 'never'],
+    'use-isnan': 'warn',
+    'valid-typeof': 'warn',
+    'no-restricted-properties': [
+      'error',
+      {
+        object: 'require',
+        property: 'ensure',
+        message:
+          'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
+      },
+      {
+        object: 'System',
+        property: 'import',
+        message:
+          'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
+      },
+    ],
+    'getter-return': 'warn',
+
+    // https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules
+    'import/first': 'error',
+    'import/no-amd': 'error',
+    'import/no-anonymous-default-export': 'warn',
+    'import/no-webpack-loader-syntax': 'error',
+
+    // https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
+    'react/forbid-foreign-prop-types': ['warn', { allowInPropTypes: true }],
+    'react/jsx-no-comment-textnodes': 'warn',
+    'react/jsx-no-duplicate-props': 'warn',
+    'react/jsx-no-target-blank': 'warn',
+    'react/jsx-no-undef': 'error',
+    'react/jsx-pascal-case': [
+      'warn',
+      {
+        allowAllCaps: true,
+        ignore: [],
+      },
+    ],
+    'react/no-danger-with-children': 'warn',
+    // Disabled because of undesirable warnings
+    // See https://github.com/facebook/create-react-app/issues/5204 for
+    // blockers until its re-enabled
+    // 'react/no-deprecated': 'warn',
+    'react/no-direct-mutation-state': 'warn',
+    'react/no-is-mounted': 'warn',
+    'react/no-typos': 'error',
+    'react/require-render-return': 'error',
+    'react/style-prop-object': 'warn',
+
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
+    'jsx-a11y/alt-text': 'warn',
+    'jsx-a11y/anchor-has-content': 'warn',
+    'jsx-a11y/anchor-is-valid': [
+      'warn',
+      {
+        aspects: ['noHref', 'invalidHref'],
+      },
+    ],
+    'jsx-a11y/aria-activedescendant-has-tabindex': 'warn',
+    'jsx-a11y/aria-props': 'warn',
+    'jsx-a11y/aria-proptypes': 'warn',
+    'jsx-a11y/aria-role': ['warn', { ignoreNonDOM: true }],
+    'jsx-a11y/aria-unsupported-elements': 'warn',
+    'jsx-a11y/heading-has-content': 'warn',
+    'jsx-a11y/iframe-has-title': 'warn',
+    'jsx-a11y/img-redundant-alt': 'warn',
+    'jsx-a11y/no-access-key': 'warn',
+    'jsx-a11y/no-distracting-elements': 'warn',
+    'jsx-a11y/no-redundant-roles': 'warn',
+    'jsx-a11y/role-has-required-aria-props': 'warn',
+    'jsx-a11y/role-supports-aria-props': 'warn',
+    'jsx-a11y/scope': 'warn',
+
+    // https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks
+    'react-hooks/rules-of-hooks': 'error',
+
+    // https://github.com/gajus/eslint-plugin-flowtype
+    'flowtype/define-flow-type': 'warn',
+    'flowtype/require-valid-file-annotation': 'warn',
+    'flowtype/use-flow-type': 'warn',
+  },
+};

--- a/packages/modular-scripts/src/lint.ts
+++ b/packages/modular-scripts/src/lint.ts
@@ -10,7 +10,6 @@ import { addFiles, getDiffedFiles, getStagedFiles } from './utils/gitActions';
 import * as logger from './utils/logger';
 import { generateJestConfig } from './test/utils';
 import { getAllWorkspaces } from './utils/getAllWorkspaces';
-import { WorkspaceContent } from '@modular-scripts/modular-types';
 export interface LintOptions {
   all: boolean;
   fix: boolean;
@@ -25,50 +24,77 @@ async function lint(
   const { all = false, fix = false, staged = false, packages } = options;
   const modularRoot = getModularRoot();
   const lintExtensions = ['.ts', '.tsx', '.js', '.jsx'];
-  let targetedFiles = ['<rootDir>/**/src/**/*.{js,jsx,ts,tsx}'];
+  let runnerMatch = ['<rootDir>/**/src/**/*.{js,jsx,ts,tsx}'];
 
   console.log({ all, fix, staged, packages, regexes });
-  const workspaces = await getAllWorkspaces();
+  const [packageMap] = await getAllWorkspaces();
 
-  // --packages alone means "only the diffed files contained in these packages"
-  // --packages + --staged means "only the staged files contained in these packages"
-  // --packages + --all means "only the files contained in these packages"
-  const filterPackages = packages?.length
-    ? (p: string) => isPathInPackageList(p, packages, workspaces)
-    : () => true;
+  const selectiveOptionSpecified = packages?.length; // || ancestors etc.
 
-  if (!all && (!isCI || staged) && regexes.length === 0) {
-    const diffedFiles = staged ? getStagedFiles() : getDiffedFiles();
-
-    console.log({ diffedFiles });
-
-    if (diffedFiles.length === 0) {
-      logger.log(
-        'No diffed files detected. Use the `--all` option to lint the entire codebase',
-      );
-      return;
-    }
-    const targetExts = diffedFiles
-      .filter(filterPackages)
-      .filter((p: string) => lintExtensions.includes(path.extname(p)))
-      .map((p: string) => `<rootDir>/${p}`);
-
-    // if none of the diffed files meet the extension criteria, do not lint
-    // end the process early with a success
-    if (!targetExts.length) {
-      logger.debug('No diffed js,jsx,ts,tsx files found');
-      return;
-    }
-    targetedFiles = targetExts;
+  if (all && selectiveOptionSpecified) {
+    logger.warn(
+      'You specified --all already; selective options are redundant.',
+    );
+  }
+  if (staged && selectiveOptionSpecified) {
+    logger.error("Can't specify --staged along with selective options");
+    process.exit(-1);
   }
 
-  console.log({ targetedFiles });
+  if (!all && !isCI) {
+    if (selectiveOptionSpecified) {
+      // TODO: Calculate packages from selective options
+
+      // Calculate the match regexes for the selective options
+      const selectiveMatch = packages
+        .map((packageName) => {
+          const packageLocation = packageMap.get(packageName)?.location;
+          return packageLocation
+            ? `<rootDir>/${packageLocation}/src/**/*.{js,jsx,ts,tsx}`
+            : undefined;
+        })
+        .filter(Boolean) as string[];
+
+      // If there are no selective matches and no regexes are specified, there is nothing to test
+      if (!selectiveMatch.length && !regexes.length) {
+        logger.warn('No target files to lint with the provided selection');
+        return;
+      }
+      // Narrow the matches to the selection matches
+      runnerMatch = selectiveMatch;
+    } else {
+      // Not selective and not --all; calculate the file regexes of --diff or --staged
+      if (staged && regexes.length === 0) {
+        const diffedFiles = staged ? getStagedFiles() : getDiffedFiles();
+
+        console.log({ diffedFiles });
+
+        if (diffedFiles.length === 0) {
+          logger.log(
+            'No diffed files detected. Use the `--all` option to lint the entire codebase',
+          );
+          return;
+        }
+        const targetExts = diffedFiles
+          .filter((p: string) => lintExtensions.includes(path.extname(p)))
+          .map((p: string) => `<rootDir>/${p}`);
+
+        // if none of the diffed files meet the extension criteria, do not lint
+        // end the process early with a success
+        if (!targetExts.length) {
+          logger.warn('No diffed target files to lint found');
+          return;
+        }
+        runnerMatch = targetExts;
+      }
+    }
+  }
 
   const jestEslintConfig = {
     runner: require.resolve('modular-scripts/jest-runner-eslint'),
     displayName: 'lint',
     rootDir: modularRoot,
-    testMatch: targetedFiles,
+    testMatch: runnerMatch,
     testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   };
 
@@ -94,23 +120,14 @@ async function lint(
     });
 
     if (staged && fix) {
-      targetedFiles = targetedFiles.map((p) => p.replace('<rootDir>/', ''));
-      addFiles(targetedFiles);
+      runnerMatch = runnerMatch.map((p) => p.replace('<rootDir>/', ''));
+      addFiles(runnerMatch);
     }
   } catch (err) {
     logger.debug((err as ExecaError).message);
     // ✕ Modular lint did not pass
     throw new Error('\u2715 Modular lint did not pass');
   }
-}
-
-function isPathInPackageList(
-  p: string,
-  packages: string[],
-  workspaces: WorkspaceContent,
-) {
-  console.log('testing', { p, packages });
-  return false;
 }
 
 export default actionPreflightCheck(lint);

--- a/packages/modular-scripts/src/lint.ts
+++ b/packages/modular-scripts/src/lint.ts
@@ -40,7 +40,7 @@ async function lint(
   const lintExtensions = ['.ts', '.tsx', '.js', '.jsx'];
   let runnerMatch = ['<rootDir>/**/src/**/*.{js,jsx,ts,tsx}'];
 
-  console.log({ all, fix, staged, packages, regexes });
+  // console.log({ all, fix, staged, packages, regexes, isCI });
   const [packageMap] = await getAllWorkspaces();
 
   const selectiveOptionSpecified =
@@ -56,7 +56,7 @@ async function lint(
     process.exit(-1);
   }
 
-  if (!all && !isCI) {
+  if (!all) {
     if (selectiveOptionSpecified) {
       // If at least one of the selective options is specified, calculate target packages from selective options
       const targetPackages = await selectWorkspaces({
@@ -84,12 +84,12 @@ async function lint(
       }
       // Narrow the matches to the selection matches
       runnerMatch = selectiveMatch;
-    } else {
-      // Not selective and not --all; calculate the file regexes of --diff or --staged
+    } else if ((!isCI || staged) && regexes.length === 0) {
+      // Not selective, not --all and no regexes; calculate the file regexes of --diff or --staged
       if (staged && regexes.length === 0) {
         const diffedFiles = staged ? getStagedFiles() : getDiffedFiles();
 
-        console.log({ diffedFiles });
+        // console.log({ diffedFiles });
 
         if (diffedFiles.length === 0) {
           logger.log(
@@ -126,7 +126,7 @@ async function lint(
     generateJestConfig(jestEslintConfig),
   ];
 
-  console.log({ testArgs });
+  // console.log({ testArgs });
 
   const testBin = await resolveAsBin('jest-cli');
 

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -274,6 +274,24 @@ program
   )
   .option('--packages [packages...]', 'Only lint selected packages')
   .option(
+    '--ancestors',
+    'Lint workspaces that depend on workspaces that have changed',
+    false,
+  )
+  .option(
+    '--descendants',
+    'Lint workspaces that directly or indirectly depend on the specified packages',
+    false,
+  )
+  .option(
+    '--changed',
+    'Lint workspaces that have changed compared to the branch specified in --compareBranch',
+  )
+  .option(
+    '--compareBranch <branch>',
+    "Specifies the branch to use with the --changed flag. If not specified, Modular will use the repo's default branch",
+  )
+  .option(
     '--fix',
     `Fix the lint errors wherever possible, restages changes if run with ${lintStagedFlag}`,
   )

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -272,6 +272,7 @@ program
     '--all',
     'Only lint diffed files from your remote origin default branch (e.g. main or master)',
   )
+  .option('--packages [packages...]', 'Only lint selected packages')
   .option(
     '--fix',
     `Fix the lint errors wherever possible, restages changes if run with ${lintStagedFlag}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,15 +94,6 @@
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.0"
 
-"@babel/eslint-parser@^7.16.3":
-  version "7.19.1"
-  resolved "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz"
-  integrity sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==
-  dependencies:
-    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
-    eslint-visitor-keys "^2.1.0"
-    semver "^6.3.0"
-
 "@babel/generator@^7.17.9", "@babel/generator@^7.20.1", "@babel/generator@^7.20.2", "@babel/generator@^7.7.2":
   version "7.20.4"
   resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz"
@@ -1158,7 +1149,7 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.20.1"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz"
   integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
@@ -1920,13 +1911,6 @@
   version "2.1.8-no-fsevents.3"
   resolved "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz"
   integrity sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==
-
-"@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
-  version "5.1.1-v1"
-  resolved "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz"
-  integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
-  dependencies:
-    eslint-scope "5.1.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3170,7 +3154,7 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^5.0.0", "@typescript-eslint/eslint-plugin@^5.5.0":
+"@typescript-eslint/eslint-plugin@^5.0.0":
   version "5.44.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.44.0.tgz"
   integrity sha512-j5ULd7FmmekcyWeArx+i8x7sdRHzAtXTkmDPthE4amxZOWKFK7bomoJ4r7PJ8K7PoMzD16U8MmuZFAonr1ERvw==
@@ -3185,14 +3169,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@^5.0.0":
-  version "5.44.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.44.0.tgz"
-  integrity sha512-j8GLemAySe8oUCgILdUaT66pemdWSYcwUYG2Pb71O119hCdvkU+4q8sUTbnDg8NhlZEzSWG2N1v4IxT1kEZrGg==
-  dependencies:
-    "@typescript-eslint/utils" "5.44.0"
-
-"@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@^5.5.0":
+"@typescript-eslint/parser@^5.0.0":
   version "5.44.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.44.0.tgz"
   integrity sha512-H7LCqbZnKqkkgQHaKLGC6KUjt3pjJDx8ETDqmwncyb6PuoigYajyAwBGz08VU/l86dZWZgI4zm5k2VaKqayYyA==
@@ -3678,7 +3655,7 @@ array-flatten@^2.1.2:
   resolved "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
-array-includes@^3.1.4, array-includes@^3.1.5, array-includes@^3.1.6:
+array-includes@^3.1.4, array-includes@^3.1.5:
   version "3.1.6"
   resolved "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz"
   integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
@@ -3704,7 +3681,7 @@ array.prototype.flat@^1.2.3, array.prototype.flat@^1.2.5:
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
 
-array.prototype.flatmap@^1.3.0, array.prototype.flatmap@^1.3.1:
+array.prototype.flatmap@^1.3.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz"
   integrity sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==
@@ -3713,17 +3690,6 @@ array.prototype.flatmap@^1.3.0, array.prototype.flatmap@^1.3.1:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
-
-array.prototype.tosorted@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz"
-  integrity sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.4"
-    es-abstract "^1.20.4"
-    es-shim-unscopables "^1.0.0"
-    get-intrinsic "^1.1.3"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -3779,7 +3745,7 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axe-core@^4.3.5, axe-core@^4.4.3:
+axe-core@^4.3.5:
   version "4.5.2"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz"
   integrity sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==
@@ -5043,7 +5009,7 @@ csv@^5.5.0:
     csv-stringify "^5.6.5"
     stream-transform "^2.1.3"
 
-damerau-levenshtein@^1.0.7, damerau-levenshtein@^1.0.8:
+damerau-levenshtein@^1.0.7:
   version "1.0.8"
   resolved "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
@@ -5717,26 +5683,6 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-react-app@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz"
-  integrity sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==
-  dependencies:
-    "@babel/core" "^7.16.0"
-    "@babel/eslint-parser" "^7.16.3"
-    "@rushstack/eslint-patch" "^1.1.0"
-    "@typescript-eslint/eslint-plugin" "^5.5.0"
-    "@typescript-eslint/parser" "^5.5.0"
-    babel-preset-react-app "^10.0.1"
-    confusing-browser-globals "^1.0.11"
-    eslint-plugin-flowtype "^8.0.3"
-    eslint-plugin-import "^2.25.3"
-    eslint-plugin-jest "^25.3.0"
-    eslint-plugin-jsx-a11y "^6.5.1"
-    eslint-plugin-react "^7.27.1"
-    eslint-plugin-react-hooks "^4.3.0"
-    eslint-plugin-testing-library "^5.0.1"
-
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
   resolved "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz"
@@ -5752,7 +5698,7 @@ eslint-module-utils@^2.7.3:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-flowtype@^8.0.0, eslint-plugin-flowtype@^8.0.3:
+eslint-plugin-flowtype@^8.0.0:
   version "8.0.3"
   resolved "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz"
   integrity sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==
@@ -5760,7 +5706,7 @@ eslint-plugin-flowtype@^8.0.0, eslint-plugin-flowtype@^8.0.3:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
 
-eslint-plugin-import@2.26.0, eslint-plugin-import@^2.25.3:
+eslint-plugin-import@2.26.0:
   version "2.26.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz"
   integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
@@ -5788,13 +5734,6 @@ eslint-plugin-jest-dom@^4.0.0:
     "@testing-library/dom" "^8.11.1"
     requireindex "^1.2.0"
 
-eslint-plugin-jest@^25.3.0:
-  version "25.7.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.7.0.tgz"
-  integrity sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "^5.0.0"
-
 eslint-plugin-jest@^27.0.0:
   version "27.1.6"
   resolved "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.6.tgz"
@@ -5820,34 +5759,10 @@ eslint-plugin-jsx-a11y@6.5.1:
     language-tags "^1.0.5"
     minimatch "^3.0.4"
 
-eslint-plugin-jsx-a11y@^6.5.1:
-  version "6.6.1"
-  resolved "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz"
-  integrity sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==
-  dependencies:
-    "@babel/runtime" "^7.18.9"
-    aria-query "^4.2.2"
-    array-includes "^3.1.5"
-    ast-types-flow "^0.0.7"
-    axe-core "^4.4.3"
-    axobject-query "^2.2.0"
-    damerau-levenshtein "^1.0.8"
-    emoji-regex "^9.2.2"
-    has "^1.0.3"
-    jsx-ast-utils "^3.3.2"
-    language-tags "^1.0.5"
-    minimatch "^3.1.2"
-    semver "^6.3.0"
-
 eslint-plugin-react-hooks@4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz"
   integrity sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==
-
-eslint-plugin-react-hooks@^4.3.0:
-  version "4.6.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz"
-  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
 eslint-plugin-react@7.31.8:
   version "7.31.8"
@@ -5869,38 +5784,10 @@ eslint-plugin-react@7.31.8:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
-eslint-plugin-react@^7.27.1:
-  version "7.31.11"
-  resolved "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz"
-  integrity sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==
-  dependencies:
-    array-includes "^3.1.6"
-    array.prototype.flatmap "^1.3.1"
-    array.prototype.tosorted "^1.1.1"
-    doctrine "^2.1.0"
-    estraverse "^5.3.0"
-    jsx-ast-utils "^2.4.1 || ^3.0.0"
-    minimatch "^3.1.2"
-    object.entries "^1.1.6"
-    object.fromentries "^2.0.6"
-    object.hasown "^1.1.2"
-    object.values "^1.1.6"
-    prop-types "^15.8.1"
-    resolve "^2.0.0-next.3"
-    semver "^6.3.0"
-    string.prototype.matchall "^4.0.8"
-
 eslint-plugin-testing-library@5.7.0:
   version "5.7.0"
   resolved "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.7.0.tgz"
   integrity sha512-pI8LKtFiAflBpN4h14vTtfhKqLwtIW40TNhWyw0ckqHm0W/J0VmYtThoxpTAdHrvEWnkALSG1Z8ABBkIncMIHA==
-  dependencies:
-    "@typescript-eslint/utils" "^5.13.0"
-
-eslint-plugin-testing-library@^5.0.1:
-  version "5.9.1"
-  resolved "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.9.1.tgz"
-  integrity sha512-6BQp3tmb79jLLasPHJmy8DnxREe+2Pgf7L+7o09TSWPfdqqtQfRZmZNetr5mOs3yqZk/MRNxpN3RUpJe0wB4LQ==
   dependencies:
     "@typescript-eslint/utils" "^5.13.0"
 
@@ -8405,7 +8292,7 @@ jsonparse@^1.3.1:
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.2.1, jsx-ast-utils@^3.3.2:
+"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.2.1:
   version "3.3.3"
   resolved "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz"
   integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
@@ -9376,7 +9263,7 @@ object.assign@^4.1.3, object.assign@^4.1.4:
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
-object.entries@^1.1.5, object.entries@^1.1.6:
+object.entries@^1.1.5:
   version "1.1.6"
   resolved "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz"
   integrity sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==
@@ -9385,7 +9272,7 @@ object.entries@^1.1.5, object.entries@^1.1.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.fromentries@^2.0.5, object.fromentries@^2.0.6:
+object.fromentries@^2.0.5:
   version "2.0.6"
   resolved "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz"
   integrity sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==
@@ -9394,7 +9281,7 @@ object.fromentries@^2.0.5, object.fromentries@^2.0.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.hasown@^1.1.1, object.hasown@^1.1.2:
+object.hasown@^1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz"
   integrity sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==
@@ -9402,7 +9289,7 @@ object.hasown@^1.1.1, object.hasown@^1.1.2:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.values@^1.1.5, object.values@^1.1.6:
+object.values@^1.1.5:
   version "1.1.6"
   resolved "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz"
   integrity sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==
@@ -11717,7 +11604,7 @@ string-width@^5.0.0:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-string.prototype.matchall@^4.0.7, string.prototype.matchall@^4.0.8:
+string.prototype.matchall@^4.0.7:
   version "4.0.8"
   resolved "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz"
   integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==


### PR DESCRIPTION
Modular lint accepts selective options and now doesn't die (but defaults to `--all`) if called on a directory that's not a Git repository. This closes https://github.com/jpmorganchase/modular/pull/2208

- [x] Selective lint
- [x] Lint tests
- [x] Fork eslint config
- [x] Changeset
- [x] Docs