### PR TITLE
Implement selective typecheck

### DIFF
--- a/.changeset/tiny-parents-invent.md
+++ b/.changeset/tiny-parents-invent.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+Add selective options to typecheck

--- a/__fixtures__/selective-typecheck-example/package.json
+++ b/__fixtures__/selective-typecheck-example/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "selective-typecheck-example",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "Sam Brown <sam.brown@jpmorgan.com>",
+  "license": "MIT",
+  "private": true,
+  "workspaces": [
+    "packages/**"
+  ],
+  "modular": {
+    "type": "root"
+  },
+  "scripts": {
+    "start": "modular start",
+    "build": "modular build",
+    "test": "modular test",
+    "lint": "eslint . --ext .js,.ts,.tsx",
+    "prettier": "prettier --write ."
+  },
+  "eslintConfig": {
+    "extends": "modular-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all",
+    "printWidth": 80,
+    "proseWrap": "always"
+  },
+  "dependencies": {
+    "@testing-library/dom": "^8.20.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^9.5.0",
+    "@testing-library/user-event": "^7.2.1",
+    "@types/jest": "^29.4.0",
+    "@types/node": "^18.14.6",
+    "@types/react": "^18.0.9",
+    "@types/react-dom": "^18.0.8",
+    "eslint-config-modular-app": "^4.0.0",
+    "modular-scripts": "^4.1.0",
+    "modular-template-app": "^1.2.0",
+    "modular-template-source": "^1.1.0",
+    "prettier": "^2.8.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^4.8.3"
+  }
+}

--- a/__fixtures__/selective-typecheck-example/packages/common-module/package.json
+++ b/__fixtures__/selective-typecheck-example/packages/common-module/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "selective-typecheck-common-module",
+  "private": false,
+  "modular": {
+    "type": "source"
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/selective-typecheck-example/packages/common-module/src/index.ts
+++ b/__fixtures__/selective-typecheck-example/packages/common-module/src/index.ts
@@ -1,0 +1,12 @@
+/* eslint-disable */
+
+// The following TS nocheck flag gets removed in test
+// @ts-nocheck
+
+export default function add(a: number, b: number): number {
+  return a + b + 'c';
+}
+
+export function otherThing(input) {
+  return typeof input;
+}

--- a/__fixtures__/selective-typecheck-example/packages/esbuild-app/.modular.js
+++ b/__fixtures__/selective-typecheck-example/packages/esbuild-app/.modular.js
@@ -1,0 +1,3 @@
+module.exports = {
+  useModularEsbuild: true,
+};

--- a/__fixtures__/selective-typecheck-example/packages/esbuild-app/package.json
+++ b/__fixtures__/selective-typecheck-example/packages/esbuild-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app",
+  "private": true,
+  "modular": {
+    "type": "app"
+  },
+  "version": "1.0.0",
+  "dependencies": {
+    "selective-typecheck-common-module": "*"
+  }
+}

--- a/__fixtures__/selective-typecheck-example/packages/esbuild-app/src/App.tsx
+++ b/__fixtures__/selective-typecheck-example/packages/esbuild-app/src/App.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+import './App.css';
+
+function App(): JSX.Element {
+  return (
+    <div className="App">
+      <header className="App-header">
+        <p>
+          Edit <code>src/App.tsx</code> and save to reload.
+        </p>
+        <a
+          className="App-link"
+          href="https://reactjs.org"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn React
+        </a>
+      </header>
+    </div>
+  );
+}
+
+export default App;

--- a/__fixtures__/selective-typecheck-example/packages/webpack-app/package.json
+++ b/__fixtures__/selective-typecheck-example/packages/webpack-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "webpack-app",
+  "private": true,
+  "modular": {
+    "type": "app"
+  },
+  "version": "1.0.0",
+  "dependencies": {
+    "selective-typecheck-common-module": "*"
+  }
+}

--- a/__fixtures__/selective-typecheck-example/packages/webpack-app/src/App.tsx
+++ b/__fixtures__/selective-typecheck-example/packages/webpack-app/src/App.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import './App.css';
+
+function App(): JSX.Element {
+  return (
+    <div className="App">
+      <header className="App-header">
+        <p>
+          Edit <code>src/App.tsx</code> and save to reload.
+        </p>
+        <a
+          className="App-link"
+          href="https://reactjs.org"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn React
+        </a>
+      </header>
+    </div>
+  );
+}
+
+export default App;

--- a/docs/commands/typecheck.md
+++ b/docs/commands/typecheck.md
@@ -6,13 +6,64 @@ title: modular typecheck
 # `modular typecheck [options]`
 
 `modular typecheck` will programmatically report the semantic, syntactic, and
-declaration type errors found in your code, based on your tsconfig.json.
+declaration type errors found in your code, based on your `tsconfig.json`.
 
 In a CI environment, it will print condensed errors if they are present.
 
 In non-CI environments, it will print the full details of the error, line, and
 small snapshot of the offending line in question.
 
+## Configuration
+
+`modular typecheck` will respect the root `tsconfig.json`, but most
+`compilerOptions` are ignored. Individual `tsconfig.json` files within packages
+are ignored.
+
+It should be noted that `modular typecheck` does not support package-level
+`tsconfig.json` files, for backwards compatibility. Your IDE may still consume
+these, but it is recommended to keep your TypeScript configuration in the root
+`tsconfig.json`.
+
+_Why does Modular restrict compilerOptions?_
+
+`modular typecheck` aims to verify that the project's types are passing without
+errors. Certain TypeScript features such as emitting output are not useful in
+this scenario, so Modular has always applied a restricted set of
+`compilerOptions`.
+
+Although this approach has limited flexibility, it fits with Modular's goals and
+brings certain advantages:
+
+- Configuration is kept minimal and simple where possible
+- The possibility of incompatible or conflicting `compilerOptions` between
+  packages is avoided
+- It enables the use of selective `modular typecheck` (i.e. supply package names
+  and using flags such as `--ancestors`)
+
+There are certain exceptions for practical use cases. The current allowlist is:
+
+- [jsx](https://www.typescriptlang.org/tsconfig#jsx)
+
+Some use cases may warrant new exceptions. If this is you, please file an issue
+with the project for consideration.
+
 ## Options:
 
 `--verbose`: Enables verbose logging within modular
+
+`--descendants`: Typecheck the packages specified by the `[packages...]`
+argument and/or the `--changed` option and additionally typecheck all their
+descendants (i.e. the packages they directly or indirectly depend on).
+
+`--ancestors`: Typecheck the packages specified by the `[packages...]` argument
+and/or the `--changed` option and additionally typecheck all their ancestors
+(i.e. the packages that have a direct or indirect dependency on them).
+
+`--changed`: Typecheck only the packages whose workspaces contain files that
+have changed. Files that have changed are calculated comparing the current state
+of the repository with the branch specified by `compareBranch` or, if
+`compareBranch` is not set, with the default git branch.
+
+`--compareBranch`: Specify the comparison branch used to determine which files
+have changed when using the `changed` option. If this option is used without
+`changed`, the command will fail.

--- a/docs/commands/typecheck.md
+++ b/docs/commands/typecheck.md
@@ -3,7 +3,7 @@ parent: Commands
 title: modular typecheck
 ---
 
-# `modular typecheck [options]`
+# `modular typecheck [options] [packages...]`
 
 `modular typecheck` will programmatically report the semantic, syntactic, and
 declaration type errors found in your code, based on your `tsconfig.json`.
@@ -16,8 +16,7 @@ small snapshot of the offending line in question.
 ## Configuration
 
 `modular typecheck` will respect the root `tsconfig.json`, but most
-`compilerOptions` are ignored. Individual `tsconfig.json` files within packages
-are ignored.
+`compilerOptions` are ignored.
 
 It should be noted that `modular typecheck` does not support package-level
 `tsconfig.json` files, for backwards compatibility. Your IDE may still consume

--- a/packages/modular-scripts/src/__tests__/typecheck.test.ts
+++ b/packages/modular-scripts/src/__tests__/typecheck.test.ts
@@ -1,31 +1,51 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import execa from 'execa';
-import { createModularTestContext, runYarnModular } from '../test/utils';
-import getModularRoot from '../utils/getModularRoot';
+import {
+  createModularTestContext,
+  getRealModularRootInTest,
+} from '../test/utils';
 
-const modularRoot = getModularRoot();
+const modularRoot = getRealModularRootInTest();
 const fixturesFolder = path.join(__dirname, '__fixtures__', 'typecheck');
-const relativeFixturePath = fixturesFolder.replace(modularRoot, '');
 
 describe('Modular typecheck', () => {
   describe('when there are type errors', () => {
     let tempModularRepo: string;
     let tempFixturesFolder: string;
+
     beforeEach(() => {
+      jest.resetModules();
       tempModularRepo = createModularTestContext();
-      tempFixturesFolder = path.join(tempModularRepo, relativeFixturePath);
+      tempFixturesFolder = path.join(tempModularRepo, 'packages', 'app', 'src');
       fs.mkdirsSync(tempFixturesFolder);
+      const invalidTsContent = fs
+        .readFileSync(path.join(fixturesFolder, 'InvalidTyping.ts'))
+        .toString()
+        .replaceAll('@ts-nocheck', '');
       fs.writeFileSync(
         path.join(tempFixturesFolder, 'InvalidTyping.ts'),
-        fs
-          .readFileSync(path.join(fixturesFolder, 'InvalidTyping.ts'), 'utf-8')
-          .replace('//@ts-nocheck', '//'),
+        invalidTsContent,
       );
       fs.copyFileSync(
-        path.join(modularRoot, 'packages', 'modular-scripts', 'tsconfig.json'),
+        path.join(modularRoot, 'tsconfig.json'),
         path.join(tempModularRepo, 'tsconfig.json'),
       );
+
+      jest.doMock('../utils/actionPreflightCheck', () => {
+        return {
+          __esModule: true,
+          default: (fn: (...args: unknown[]) => Promise<void>) => {
+            return fn;
+          },
+        };
+      });
+
+      jest.doMock('../utils/getModularRoot', () => {
+        return {
+          __esModule: true,
+          default: () => tempModularRepo,
+        };
+      });
     });
 
     describe('when in CI', () => {
@@ -36,59 +56,44 @@ describe('Modular typecheck', () => {
         process.env.CI = undefined;
       });
       it('should display truncated errors', async () => {
-        let tsc = '';
+        const typecheck = await import('../typecheck');
+        let caughtError: Error | undefined;
+        const expectedErrorText = [
+          "Cannot find module 'foo' or its corresponding type declarations",
+          "A function whose declared type is neither 'void' nor 'any' must return a value.",
+        ];
         try {
-          await execa('tsc', ['--noEmit', '--pretty', 'false'], {
-            all: true,
-            cleanup: true,
-            cwd: tempModularRepo,
-          });
-        } catch ({ stdout }) {
-          tsc = stdout as string;
+          await typecheck.default({}, []);
+        } catch (e) {
+          caughtError = e as Error;
+        } finally {
+          expect(caughtError).toBeTruthy();
+          for (const msg of expectedErrorText) {
+            expect(caughtError?.message.includes(msg)).toBe(true);
+          }
         }
-        let modularStdErr = '';
-        try {
-          await runYarnModular(tempModularRepo, 'typecheck');
-        } catch ({ stderr }) {
-          modularStdErr = stderr as string;
-        }
-        const tscErrors = tsc.split('\n');
-        const modularErrors = modularStdErr.split('\n');
-        tscErrors.forEach((errorMessage: string, i: number) => {
-          expect(modularErrors[i]).toMatch(errorMessage);
-        });
       });
     });
+
     describe('when not in CI', () => {
       it('should match display full error logs', async () => {
-        let tsc = '';
+        const typecheck = await import('../typecheck');
+        let caughtError: Error | undefined;
+        const expectedErrorText = [
+          "Cannot find module 'foo' or its corresponding type declarations",
+          "A function whose declared type is neither 'void' nor 'any' must return a value.",
+        ];
         try {
-          await execa('tsc', ['--noEmit'], {
-            all: true,
-            cleanup: true,
-            cwd: tempModularRepo,
-          });
-        } catch ({ stdout }) {
-          tsc = stdout as string;
+          await typecheck.default({}, []);
+        } catch (e) {
+          caughtError = e as Error;
+        } finally {
+          expect(caughtError).toBeTruthy();
+          for (const msg of expectedErrorText) {
+            expect(caughtError?.message.includes(msg)).toBe(true);
+          }
         }
-        let modularStdErr = '';
-        try {
-          await runYarnModular(tempModularRepo, 'typecheck');
-        } catch ({ stderr }) {
-          modularStdErr = stderr as string;
-        }
-        const tscErrors = tsc.split('\n');
-        const modularErrors = modularStdErr.split('\n');
-        tscErrors.forEach((errorMessage: string, i: number) => {
-          expect(modularErrors[i]).toMatch(errorMessage);
-        });
       });
-    });
-  });
-  describe('when there are no type errors', () => {
-    it('should print a one line success message', async () => {
-      const result = await runYarnModular(modularRoot, 'typecheck');
-      expect(result.stdout).toMatch('\u2713 Typecheck passed');
     });
   });
 });

--- a/packages/modular-scripts/src/__tests__/typecheck.test.ts
+++ b/packages/modular-scripts/src/__tests__/typecheck.test.ts
@@ -7,20 +7,25 @@ import {
 } from '../test/utils';
 
 const modularRoot = getRealModularRootInTest();
-const fixturesFolder = path.join(__dirname, '__fixtures__', 'typecheck');
 
 // Skip preflight in tests (faster, avoids the need to mock getModularRoot statically)
 jest.mock('../utils/actionPreflightCheck', () => mockPreflightImplementation);
 
 describe('Modular typecheck', () => {
-  describe('when there are type errors', () => {
+  describe('when there are type errors (non-selective)', () => {
     let tempModularRepo: string;
     let tempFixturesFolder: string;
 
     beforeEach(() => {
+      /**
+       * - Set up a temp modular repo
+       * - Copy the `typecheck` fixture into it
+       * - Remove a `ts-nocheck` statement so that errors will happen as expected
+       */
       tempModularRepo = createModularTestContext();
       tempFixturesFolder = path.join(tempModularRepo, 'packages', 'app', 'src');
       fs.mkdirsSync(tempFixturesFolder);
+      const fixturesFolder = path.join(__dirname, '__fixtures__', 'typecheck');
       const invalidTsContent = fs
         .readFileSync(path.join(fixturesFolder, 'InvalidTyping.ts'))
         .toString()
@@ -91,6 +96,94 @@ describe('Modular typecheck', () => {
           }
         }
       });
+    });
+  });
+
+  describe('when there are type errors (selective)', () => {
+    let tempModularRepo: string;
+
+    beforeEach(() => {
+      // Required to achieve consistency when using `jest.doMock` in tests
+      jest.resetModules();
+
+      /**
+       * - Set up a temp modular repo
+       * - Copy the `selective-typecheck-example` fixture into it (3 packages within)
+       * - Remove a `ts-nocheck` statement so that errors will happen as expected
+       */
+      tempModularRepo = createModularTestContext();
+      fs.copySync(
+        path.join(
+          modularRoot,
+          '__fixtures__',
+          'selective-typecheck-example',
+          'packages',
+        ),
+        path.join(tempModularRepo, 'packages'),
+      );
+      const invalidTsContent = fs
+        .readFileSync(
+          path.join(
+            modularRoot,
+            '__fixtures__',
+            'selective-typecheck-example',
+            'packages',
+            'common-module',
+            'src',
+            'index.ts',
+          ),
+        )
+        .toString()
+        .replaceAll('@ts-nocheck', '');
+      fs.writeFileSync(
+        path.join(
+          tempModularRepo,
+          'packages',
+          'common-module',
+          'src',
+          'index.ts',
+        ),
+        invalidTsContent,
+      );
+
+      // Mock the modular root per temporary modular repo
+      jest.doMock('../utils/getModularRoot', () => {
+        return {
+          __esModule: true,
+          default: () => tempModularRepo,
+        };
+      });
+    });
+
+    it('should test descendants and throw', async () => {
+      const { default: typecheck } = await import('../typecheck');
+      let caughtError: Error | undefined;
+      const expectedErrorText = [
+        "Type 'string' is not assignable to type 'number'.",
+        "Parameter 'input' implicitly has an 'any' type.",
+      ];
+      try {
+        await typecheck({ descendants: true }, ['webpack-app']);
+      } catch (e) {
+        caughtError = e as Error;
+      } finally {
+        expect(caughtError).toBeTruthy();
+        for (const msg of expectedErrorText) {
+          expect(caughtError?.message.includes(msg)).toBe(true);
+        }
+      }
+    });
+
+    it('should not test descendants and not error', async () => {
+      const { default: typecheck } = await import('../typecheck');
+      let caughtError: Error | undefined;
+      try {
+        await typecheck({ descendants: false }, ['webpack-app']);
+      } catch (e) {
+        caughtError = e as Error;
+      } finally {
+        expect(caughtError).toBeUndefined();
+      }
     });
   });
 });

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -4,13 +4,15 @@ import * as fs from 'fs-extra';
 import isCI from 'is-ci';
 import chalk from 'chalk';
 import commander, { Option } from 'commander';
+import { testOptions } from './test/jestOptions';
+import actionPreflightCheck from './utils/actionPreflightCheck';
+import * as logger from './utils/logger';
+import { validateCompareOptions } from './utils/validateOptions';
+
 import type { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 import type { TestOptions } from './test';
 import type { LintOptions } from './lint';
-import { testOptions } from './test/jestOptions';
-
-import actionPreflightCheck from './utils/actionPreflightCheck';
-import * as logger from './utils/logger';
+import type { TypecheckOptions } from './typecheck';
 
 const program = new commander.Command('modular');
 program.version(
@@ -124,12 +126,7 @@ program
     ) => {
       const { default: build } = await import('./build-scripts');
 
-      if (options.compareBranch && !options.changed) {
-        process.stderr.write(
-          "Option --compareBranch doesn't make sense without option --changed\n",
-        );
-        process.exit(1);
-      }
+      validateCompareOptions(options.compareBranch, options.changed);
 
       if (options.dangerouslyIgnoreCircularDependencies) {
         // Warn. Users should never use this, but if they use it, they should have cycles limited to "source" packages
@@ -212,12 +209,7 @@ program
   .allowUnknownOption()
   .description('Run tests over the codebase')
   .action(async (packages: string[], options: CLITestOptions) => {
-    if (options.compareBranch && !options.changed) {
-      process.stderr.write(
-        "Option --compareBranch doesn't make sense without option --changed\n",
-      );
-      process.exit(1);
-    }
+    validateCompareOptions(options.compareBranch, options.changed);
 
     const { default: test } = await import('./test');
 
@@ -289,12 +281,32 @@ program
   });
 
 program
-  .command('typecheck')
+  .command('typecheck [packages...]')
   .description('Typechecks the entire project')
   .option('--verbose', 'Enables verbose logging within modular.')
-  .action(async () => {
+  .option(
+    '--ancestors',
+    'Additionally run typecheck for workspaces that depend on workspaces that have changed',
+    false,
+  )
+  .option(
+    '--descendants',
+    'Additionally run typecheck for workspaces that directly or indirectly depend on the specified packages (can be combined with --changed)',
+    false,
+  )
+  .option(
+    '--changed',
+    'Run typecheck only for workspaces that have changed compared to the branch specified in --compareBranch',
+  )
+  .option(
+    '--compareBranch <branch>',
+    "Specifies the branch to use with the --changed flag. If not specified, Modular will use the repo's default branch",
+  )
+  .action(async (packages: string[], options: TypecheckOptions) => {
+    validateCompareOptions(options.compareBranch, options.changed);
+
     const { default: typecheck } = await import('./typecheck');
-    await typecheck();
+    await typecheck(options, packages);
   });
 
 interface ServeOptions {

--- a/packages/modular-scripts/src/test/utils.ts
+++ b/packages/modular-scripts/src/test/utils.ts
@@ -301,3 +301,10 @@ export async function runYarnModular(
     ...opts,
   });
 }
+
+export const mockPreflightImplementation = {
+  __esModule: true,
+  default: (fn: (...args: unknown[]) => Promise<void>) => {
+    return fn;
+  },
+};

--- a/packages/modular-scripts/src/typecheck.ts
+++ b/packages/modular-scripts/src/typecheck.ts
@@ -117,7 +117,7 @@ async function typecheck(
   const configParseResult = ts.parseJsonConfigFileContent(
     tsConfig,
     ts.sys,
-    getModularRoot(),
+    modularRoot,
   );
 
   if (configParseResult.errors.length > 0) {

--- a/packages/modular-scripts/src/utils/getPackageMetadata.ts
+++ b/packages/modular-scripts/src/utils/getPackageMetadata.ts
@@ -56,9 +56,10 @@ async function getPackageMetadata() {
   // validate tsconfig
   // Extract configuration from config file and parse JSON,
   // after removing comments. Just a fancier JSON.parse
+  const userTsConfigPath = path.join(modularRoot, typescriptConfigFilename);
   const result = ts.parseConfigFileTextToJson(
-    path.join(modularRoot, typescriptConfigFilename),
-    fse.readFileSync(typescriptConfigFilename, 'utf8').toString(),
+    userTsConfigPath,
+    fse.readFileSync(userTsConfigPath, 'utf8').toString(),
   );
 
   const configObject = result.config as TSConfig;

--- a/packages/modular-scripts/src/utils/validateOptions.ts
+++ b/packages/modular-scripts/src/utils/validateOptions.ts
@@ -1,0 +1,16 @@
+/**
+ * Validates comparison options in combination.
+ *
+ * Throws and exits when invalid combinations are detected.
+ */
+export function validateCompareOptions(
+  compareBranch: string | undefined,
+  changed: boolean,
+): void {
+  if (compareBranch && !changed) {
+    process.stderr.write(
+      "Option --compareBranch doesn't make sense without option --changed\n",
+    );
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Selective TypeCheck

- Implements selective typecheck, i.e adds the `--ancestors`, `--descendants`, `--changed` and `--compareBranch` options to `modular typecheck`
- Maintains backwards compatibility with the existing `modular typecheck`
- Adds new docs that describe how Modular currently treats `tsconfig.json` files, plus docs for the new options
- Updates the tests for `typecheck` to use a new approach, and cover new cases

## New unit testing approach: calling commands directly

A side mission during this PR was to call `typecheck()` directly from test code, instead of rely on `execa` as is very common in the project. The `execa` approach is (a) slow and (b) breaks the tracking of test coverage. `typecheck.test.ts` demonstrates a new approach:

- Call the command directly, avoiding the need for a child process, and fixing jest's ability to track test coverage
- Mock `getModularRoot` in tests, which is used extensively throughout the project
- Create a secondary `getModularRoot` clone called `getRealModularRootInTest` that is designed to be used in test code, i.e. avoid any mocks that might be applicable
- Avoid the `actionPreflightCheck`, which complicates the mocking (it contains a call to `getModularRoot`) and slows things down. Plus, this check has no value in test (it can be tested in isolation).

It should be noted that I've used `jest.doMock` which avoids jest's [default hoisting behaviour](https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options). In other words, it lets us mock the modular root just before importing and calling a modular command. To work with this approach, I dynamically import the `typecheck` command. It may also be possible to use a more static setup.

Not only is this approach faster and simpler, the coverage for the test command has gone from `0` to `>90%`.

TODO

- [x] New docs
- [x] Repoint PR to v4.3 or main when v4.2 is released
- [x] Tests
- [x] Changeset
