### PR TITLE
`modular build` builds in concurrent batches

### DIFF
--- a/.changeset/old-fans-invent.md
+++ b/.changeset/old-fans-invent.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": minor
+---
+
+`modular build` can build concurrently; `--concurrencyLevel` command added

--- a/__fixtures__/ghost-building/packages/f/package.json
+++ b/__fixtures__/ghost-building/packages/f/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "f",
+  "private": false,
+  "modular": {
+    "type": "package"
+  },
+  "main": "./src/index.ts",
+  "version": "1.0.0"
+}

--- a/__fixtures__/ghost-building/packages/f/src/index.ts
+++ b/__fixtures__/ghost-building/packages/f/src/index.ts
@@ -1,0 +1,3 @@
+export default function add(a: number, b: number): number {
+  return a + b;
+}

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -15,7 +15,10 @@ Search workspaces based on their `name` field in the `package.json` and build:
   [workspace](https://classic.yarnpkg.com/en/docs/cli/workspace).
 
 Packages are always built in order of dependency (e.g. if a package `a` depends
-on a package `b`, `b` is built first).
+on a package `b`, `b` is built first). Packages may be built concurrently when
+possible. The maximum concurrency level defaults to the number of CPUs available
+on the machine, but can be set by the user (see the `--concurrencyLevel`
+option).
 
 The output directory for built artifacts is `dist/`, which has a flat structure
 of modular package names. Each built app/view/package is added to the `dist/` as
@@ -45,9 +48,9 @@ changed. Files that have changed are calculated comparing the current state of
 the repository with the branch specified by `compareBranch` or, if
 `compareBranch` is not set, with the default git branch.
 
-`--compareBranch`: Specify the comparison branch used to determine which files
-have changed when using the `changed` option. If this option is used without
-`changed`, the command will fail.
+`--compareBranch <branchName>`: Specify the comparison branch used to determine
+which files have changed when using the `changed` option. If this option is used
+without `changed`, the command will fail.
 
 `--descendants`: Build the packages specified by the `[packages...]` argument
 and/or the `--changed` option and additionally build all their descendants (i.e.
@@ -57,6 +60,12 @@ the packages they directly or indirectly depend on) in dependency order.
 and/or the `--changed` option and additionally build all their ancestors (i.e.
 the packages that have a direct or indirect dependency on them) in dependency
 order.
+
+`--concurrencyLevel <level>`: Limit the concurrency of build processes that are
+executed in different processes within build batches. 0 or 1 means no
+concurrency. If not specified, this option defaults to
+[the number of logical CPUs](https://nodejs.org/api/os.html#oscpus) available on
+the machine, or 1 if that information is not available.
 
 ## Dependency selection and build order examples
 

--- a/packages/modular-scripts/src/__tests__/select.test.ts
+++ b/packages/modular-scripts/src/__tests__/select.test.ts
@@ -155,7 +155,7 @@ describe('select', () => {
     const result = runModularPipeLogs(tempModularRepo, 'select');
 
     expect(result.stderr).toBeFalsy();
-    expect(result.stdout).toContain(format(['a', 'b', 'c', 'd', 'e']));
+    expect(result.stdout).toContain(format(['a', 'b', 'c', 'd', 'e', 'f']));
   });
 });
 
@@ -307,7 +307,7 @@ describe('select in buildable order', () => {
 
     expect(result.stderr).toBeFalsy();
     expect(result.stdout).toContain(
-      format([['d'], ['c'], ['b'], ['a'], ['e']]),
+      format([['d'], ['c'], ['b'], ['a'], ['e', 'f']]),
     );
   });
 });

--- a/packages/modular-scripts/src/__tests__/selectiveBuild.test.ts
+++ b/packages/modular-scripts/src/__tests__/selectiveBuild.test.ts
@@ -144,7 +144,62 @@ describe('--changed builds all the changed packages in order', () => {
     const result = runModularPipeLogs(tempModularRepo, 'build');
 
     expect(result.stderr).toBeFalsy();
-    expect(getBuildOrder(result.stdout)).toEqual(['d', 'c', 'b', 'a', 'e']);
+    expect(getBuildOrder(result.stdout)).toEqual([
+      'd',
+      'c',
+      'b',
+      'a',
+      'f',
+      'e',
+    ]);
+  });
+
+  it('builds packages concurrently with a certain concurrencyLevel', () => {
+    const result = runModularPipeLogs(
+      tempModularRepo,
+      'build --verbose --concurrencyLevel 2',
+    );
+
+    expect(result.stderr).toBeFalsy();
+    expect(result.stdout).toContain(
+      'runBatch is running a batch of length 2: ["e","f"]',
+    );
+  });
+
+  it('removes concurrency with concurrencyLevel = 0', () => {
+    const result = runModularPipeLogs(
+      tempModularRepo,
+      'build --verbose --concurrencyLevel 0',
+    );
+
+    expect(result.stderr).toBeFalsy();
+    expect(result.stdout).not.toContain(
+      'runBatch is running a batch of length 2',
+    );
+    expect(result.stdout).toContain(
+      'runBatch is running a batch of length 1: ["e"]',
+    );
+    expect(result.stdout).toContain(
+      'runBatch is running a batch of length 1: ["f"]',
+    );
+  });
+
+  it('removes concurrency with concurrencyLevel = 1', () => {
+    const result = runModularPipeLogs(
+      tempModularRepo,
+      'build --verbose --concurrencyLevel 0',
+    );
+
+    expect(result.stderr).toBeFalsy();
+    expect(result.stdout).not.toContain(
+      'runBatch is running a batch of length 2',
+    );
+    expect(result.stdout).toContain(
+      'runBatch is running a batch of length 1: ["e"]',
+    );
+    expect(result.stdout).toContain(
+      'runBatch is running a batch of length 1: ["f"]',
+    );
   });
 });
 

--- a/packages/modular-scripts/src/__tests__/unobtrusiveModular.test.ts
+++ b/packages/modular-scripts/src/__tests__/unobtrusiveModular.test.ts
@@ -46,7 +46,7 @@ describe('When there is a non-Modular package with a build script', () => {
     expect(result.stderr).toBeFalsy();
     expect(result.stdout).toContain('\nnon-modular-buildable was built\n');
     expect(result.stdout).toContain(
-      'Building the following workspaces in order: ["non-modular-buildable","app"]',
+      'Building the following workspaces in order: [["non-modular-buildable"],["app"]]',
     );
     expect(result.stdout).toContain('Compiled successfully.');
   });

--- a/packages/modular-scripts/src/build-scripts/index.ts
+++ b/packages/modular-scripts/src/build-scripts/index.ts
@@ -3,11 +3,12 @@ import { buildPackage } from './build-package';
 import * as logger from '../utils/logger';
 import actionPreflightCheck from '../utils/actionPreflightCheck';
 import getWorkspaceLocation from '../utils/getLocation';
-import { selectBuildableWorkspaces } from '../utils/selectWorkspaces';
+import { selectParallellyBuildableWorkspaces } from '../utils/selectWorkspaces';
 import { setupEnvForDirectory } from '../utils/setupEnv';
 import { getAllWorkspaces } from '../utils/getAllWorkspaces';
 import getModularRoot from '../utils/getModularRoot';
 import execAsync from '../utils/execAsync';
+import type { ModularWorkspacePackage } from '@modular-scripts/modular-types';
 
 async function build({
   packagePaths,
@@ -18,6 +19,7 @@ async function build({
   changed,
   compareBranch,
   dangerouslyIgnoreCircularDependencies,
+  concurrencyLevel,
 }: {
   packagePaths: string[];
   preserveModules: boolean;
@@ -27,6 +29,7 @@ async function build({
   changed: boolean;
   compareBranch?: string;
   dangerouslyIgnoreCircularDependencies: boolean;
+  concurrencyLevel: number;
 }): Promise<void> {
   const isSelective =
     changed || ancestors || descendants || packagePaths.length;
@@ -37,7 +40,7 @@ async function build({
   // targets are either the set of what's specified in the selective options or all the packages in the monorepo
   const targets = isSelective ? packagePaths : [...allWorkspacePackages.keys()];
 
-  const selectedTargets = await selectBuildableWorkspaces({
+  const selectedTargets = await selectParallellyBuildableWorkspaces({
     targets,
     changed,
     compareBranch,
@@ -57,38 +60,82 @@ async function build({
     )}`,
   );
 
-  for (const target of selectedTargets) {
-    const packageInfo = allWorkspacePackages.get(target);
+  console.log(selectedTargets);
 
-    try {
-      const targetDirectory = await getWorkspaceLocation(target);
-      await setupEnvForDirectory(targetDirectory);
-      if (packageInfo?.modular) {
-        // If it's modular, build with Modular
-        const targetType = packageInfo.modular.type;
-        if (!targetType)
-          throw new Error(`modular.type missing in ${target} package.json`);
-
-        logger.log('\nBuilding', targetType, target);
-
-        if (targetType === 'app' || targetType === 'esm-view') {
-          await buildStandalone(target, targetType);
-        } else {
-          await buildPackage(target, preserveModules, includePrivate);
-        }
-      } else {
-        // Otherwise, build by running the workspace's build script
-        // We're sure it's here because selectBuildableWorkspaces returns only buildable workspaces.
-        logger.log('\nBuilding non-modular package', target);
-        await execAsync(`yarn`, ['workspace', target, 'build'], {
-          cwd: modularRoot,
-          log: false,
-        });
+  for (const batch of selectedTargets) {
+    const jobBatch = batch.map((target) => {
+      const packageInfo = allWorkspacePackages.get(target);
+      if (!packageInfo) {
+        throw new Error(
+          `building ${target} failed - pacakge ${target} has no package info.`,
+        );
       }
-    } catch (err) {
-      logger.error(`building ${target} failed`);
-      throw err;
+      return () => {
+        console.log(`*** RUNNING job for ${packageInfo.name}`);
+        return runBuildJob({
+          packageInfo,
+          preserveModules,
+          includePrivate,
+          cwd: modularRoot,
+        });
+      };
+    });
+    await runBatch(jobBatch, concurrencyLevel);
+  }
+}
+
+type Job = (...args: unknown[]) => Promise<void>;
+interface BuildParameters {
+  packageInfo: ModularWorkspacePackage;
+  preserveModules: boolean;
+  includePrivate: boolean;
+  cwd: string;
+}
+
+async function runBuildJob({
+  packageInfo,
+  preserveModules,
+  includePrivate,
+  cwd,
+}: BuildParameters) {
+  const target = packageInfo?.name;
+  try {
+    const targetDirectory = await getWorkspaceLocation(target);
+    await setupEnvForDirectory(targetDirectory);
+    if (packageInfo?.modular) {
+      // If it's modular, build with Modular
+      const targetType = packageInfo.modular.type;
+      if (!targetType)
+        throw new Error(`modular.type missing in ${target} package.json`);
+
+      logger.log('\nBuilding', targetType, target);
+
+      if (targetType === 'app' || targetType === 'esm-view') {
+        await buildStandalone(target, targetType);
+      } else {
+        await buildPackage(target, preserveModules, includePrivate);
+      }
+    } else {
+      // Otherwise, build by running the workspace's build script
+      // We're sure it's here because selectParallellyBuildableWorkspaces returns only buildable workspaces.
+      logger.log('\nBuilding non-modular package', target);
+      await execAsync(`yarn`, ['workspace', target, 'build'], {
+        cwd,
+        log: false,
+      });
     }
+  } catch (err) {
+    logger.error(`building ${target} failed`);
+    throw err;
+  }
+}
+
+async function runBatch<T extends Job>(functions: T[], concurrency: number) {
+  console.log(
+    `*** running batch of ${functions.length} with concurrency ${concurrency}`,
+  );
+  while (functions.length) {
+    await Promise.all(functions.splice(0, concurrency || 1).map((f) => f()));
   }
 }
 

--- a/packages/modular-scripts/src/build-scripts/index.ts
+++ b/packages/modular-scripts/src/build-scripts/index.ts
@@ -61,7 +61,7 @@ async function build({
   );
 
   for (const batch of selectedTargets) {
-    logger.log(
+    logger.debug(
       `Building batch: ${JSON.stringify(
         batch,
       )} with concurrency ${concurrencyLevel}`,
@@ -134,6 +134,8 @@ async function runBuildJob({
 
 async function runBatch<T extends Job>(functions: T[], concurrency: number) {
   while (functions.length) {
+    // It's not Promise.all that starts the functions, but the act of invoking them, so we need to defer invocation until it's needed.
+    // Councurrency = [0|1] means no concurrency in a user-friendly way. Since 0 would spin forever, it's defaulted to 1.
     await Promise.all(functions.splice(0, concurrency || 1).map((f) => f()));
   }
 }

--- a/packages/modular-scripts/src/build-scripts/index.ts
+++ b/packages/modular-scripts/src/build-scripts/index.ts
@@ -60,9 +60,12 @@ async function build({
     )}`,
   );
 
-  console.log(selectedTargets);
-
   for (const batch of selectedTargets) {
+    logger.log(
+      `Building batch: ${JSON.stringify(
+        batch,
+      )} with concurrency ${concurrencyLevel}`,
+    );
     const jobBatch = batch.map((target) => {
       const packageInfo = allWorkspacePackages.get(target);
       if (!packageInfo) {
@@ -71,7 +74,6 @@ async function build({
         );
       }
       return () => {
-        console.log(`*** RUNNING job for ${packageInfo.name}`);
         return runBuildJob({
           packageInfo,
           preserveModules,
@@ -131,9 +133,6 @@ async function runBuildJob({
 }
 
 async function runBatch<T extends Job>(functions: T[], concurrency: number) {
-  console.log(
-    `*** running batch of ${functions.length} with concurrency ${concurrency}`,
-  );
   while (functions.length) {
     await Promise.all(functions.splice(0, concurrency || 1).map((f) => f()));
   }

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -7,7 +7,10 @@ import commander, { Option } from 'commander';
 import { testOptions } from './test/jestOptions';
 import actionPreflightCheck from './utils/actionPreflightCheck';
 import * as logger from './utils/logger';
-import { validateCompareOptions } from './utils/validateOptions';
+import {
+  validateCompareOptions,
+  computeConcurrencyOption,
+} from './utils/validateOptions';
 
 import type { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 import type { TestOptions } from './test';
@@ -111,6 +114,10 @@ program
     "Ignore circular dependency checks if your graph has one or more circular dependencies involving 'source' types, then warn. The build will still fail if circular dependencies involve more than one buildable package. Circular dependencies can be always refactored to remove cycles. This switch is dangerous and should be used sparingly and only temporarily.",
     false,
   )
+  .option(
+    '--concurrencyLevel <level>',
+    'Limit the concurrency of build processes that are executed in parallel within batches. 0 or 1 means no concurrency. Default is the number of logical CPUs.',
+  )
   .action(
     async (
       packagePaths: string[],
@@ -122,11 +129,20 @@ program
         ancestors: boolean;
         descendants: boolean;
         dangerouslyIgnoreCircularDependencies: boolean;
+        concurrencyLevel?: string;
       },
     ) => {
       const { default: build } = await import('./build-scripts');
 
       validateCompareOptions(options.compareBranch, options.changed);
+
+      const concurrencyLevel = computeConcurrencyOption(
+        options.concurrencyLevel,
+      );
+
+      logger.debug(
+        `Running buil with a concurrency level of ${concurrencyLevel}`,
+      );
 
       if (options.dangerouslyIgnoreCircularDependencies) {
         // Warn. Users should never use this, but if they use it, they should have cycles limited to "source" packages
@@ -146,6 +162,7 @@ program
         descendants: options.descendants,
         dangerouslyIgnoreCircularDependencies:
           options.dangerouslyIgnoreCircularDependencies,
+        concurrencyLevel,
       });
     },
   );

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -10,7 +10,7 @@ import * as logger from './utils/logger';
 import {
   validateCompareOptions,
   computeConcurrencyOption,
-} from './utils/validateOptions';
+} from './utils/options';
 
 import type { JSONSchemaForNPMPackageJsonFiles as PackageJson } from '@schemastore/package';
 import type { TestOptions } from './test';

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -141,7 +141,7 @@ program
       );
 
       logger.debug(
-        `Running buil with a concurrency level of ${concurrencyLevel}`,
+        `Running build with a concurrency level of ${concurrencyLevel}`,
       );
 
       if (options.dangerouslyIgnoreCircularDependencies) {

--- a/packages/modular-scripts/src/utils/options.ts
+++ b/packages/modular-scripts/src/utils/options.ts
@@ -18,7 +18,7 @@ export function validateCompareOptions(
 }
 
 /**
- * Validates and conver concurrency option to number.
+ * Validates and converts concurrency option to number.
  *
  * Throws and exits when invalid value is detected.
  */

--- a/packages/modular-scripts/src/utils/options.ts
+++ b/packages/modular-scripts/src/utils/options.ts
@@ -27,6 +27,7 @@ export function computeConcurrencyOption(
 ): number {
   if (!concurrencyLevel) {
     // If concurrencyLevel is not supplied, default to the number of CPUs. If the number of CPUs is 0 (/proc or equivalent is unavailable), default to no concurrency.
+    // TODO: Conditionally use os.availableParallelism() when it lands in a supported LTS that we can update types to: https://nodejs.org/api/os.html#osavailableparallelism
     return os.cpus().length || 1;
   }
 

--- a/packages/modular-scripts/src/utils/selectWorkspaces.ts
+++ b/packages/modular-scripts/src/utils/selectWorkspaces.ts
@@ -46,26 +46,6 @@ export async function selectWorkspaces(
 }
 
 /**
- * Select buildable target packages in build order, optionally including changed, ancestors and descendant packages. The result is returned as an array of package names.
- *
- * Please note that the build order algorithm can't calculate build order if there's a cycle in the dependency graph,
- * so circular dependencies will throw unless they only involve packages that don't get built (i.e. "source" `modular.type`s).
- * Please also note that circular dependencies can always be fixed by creating an additional package that contains the common parts,
- * and that they are considered a code smell + a source of many issues (e.g. https://nodejs.org/api/modules.html#modules_cycles)
- * and they make your code fragile towards refactoring, so please don't introduce them in your monorepository.
- *
- * @param  {SelectBuildableOptions} options The target options to configure selection
- * @return {Promise<string[]>} A distinct list of selected buildable package names, in build order
- */
-
-export async function selectBuildableWorkspaces(
-  options: SelectBuildableOptions,
-): Promise<string[]> {
-  // Flatten the subarrays to make an ordered serial sequence. This loses parallelism.
-  return (await selectParallellyBuildableWorkspaces(options)).flat();
-}
-
-/**
  * Select buildable target packages in build order, optionally including changed, ancestors and descendant packages. The result is returned as a 1-level nested array of package names, where sub-arrays can be built parallely
  *
  * Please note that the build order algorithm can't calculate build order if there's a cycle in the dependency graph,

--- a/packages/modular-scripts/src/utils/selectWorkspaces.ts
+++ b/packages/modular-scripts/src/utils/selectWorkspaces.ts
@@ -126,6 +126,8 @@ export async function selectParallellyBuildableWorkspaces(
         acc[level] ? acc[level].push(pkg) : (acc[level] = [pkg]);
         return acc;
       }, [])
+      // The previous reduction can leave holes in the array, let's remove them.
+      .filter(Boolean)
       // Reverse in actual build order
       .reverse()
   );

--- a/packages/modular-scripts/src/utils/validateOptions.ts
+++ b/packages/modular-scripts/src/utils/validateOptions.ts
@@ -1,3 +1,5 @@
+import os from 'os';
+
 /**
  * Validates comparison options in combination.
  *
@@ -13,4 +15,31 @@ export function validateCompareOptions(
     );
     process.exit(1);
   }
+}
+
+/**
+ * Validates and conver concurrency option to number.
+ *
+ * Throws and exits when invalid value is detected.
+ */
+export function computeConcurrencyOption(
+  concurrencyLevel: string | undefined,
+): number {
+  // If not supplied, default to the number of CPUs. If the number of CPUs is 0 (/proc or equivalent is unavailable), default to no concurrency.
+  if (!concurrencyLevel) {
+    return os.cpus().length || 1;
+  }
+
+  // Otherwise, try to parse it
+  const concurrency = parseInt(concurrencyLevel, 10);
+
+  // If it's invalid, bail out.
+  if (isNaN(concurrency) || concurrency < 0) {
+    process.stderr.write(
+      `--currencyLevel must be a number greater or equal than 0. You specified "${concurrencyLevel}" instead.`,
+    );
+    process.exit(1);
+  }
+
+  return concurrency;
 }

--- a/packages/modular-scripts/src/utils/validateOptions.ts
+++ b/packages/modular-scripts/src/utils/validateOptions.ts
@@ -25,15 +25,15 @@ export function validateCompareOptions(
 export function computeConcurrencyOption(
   concurrencyLevel: string | undefined,
 ): number {
-  // If not supplied, default to the number of CPUs. If the number of CPUs is 0 (/proc or equivalent is unavailable), default to no concurrency.
   if (!concurrencyLevel) {
+    // If concurrencyLevel is not supplied, default to the number of CPUs. If the number of CPUs is 0 (/proc or equivalent is unavailable), default to no concurrency.
     return os.cpus().length || 1;
   }
 
   // Otherwise, try to parse it
   const concurrency = parseInt(concurrencyLevel, 10);
 
-  // If it's invalid, bail out.
+  // If not a number or a negative number, bail out with an error.
   if (isNaN(concurrency) || concurrency < 0) {
     process.stderr.write(
       `--currencyLevel must be a number greater or equal than 0. You specified "${concurrencyLevel}" instead.`,


### PR DESCRIPTION
Enables batched algorithms for `modular build` with a custom max concurrency level. Build jobs that can be parallelised are executed in consecutive `--concurrencyLevel`-long job parallel batches, that are run one after the other until exhaustion. `--concurrencyLevel` level is a new user option that defaults to the number of logical CPUS in the machine.

This also fixes a bug in `modular select` where the parallel dependency array can sometimes have holes.

---

- [x] Implement batched algo
- [x] Tests
- [x] Docs