### PR TITLE
Enable "strict" compiler option

### DIFF
--- a/.changeset/plenty-hounds-judge.md
+++ b/.changeset/plenty-hounds-judge.md
@@ -1,0 +1,5 @@
+---
+"modular-scripts": minor
+---
+
+Enable "strict" compiler option in the [typecheck allowlist](https://modular.js.org/commands/typecheck/#configuration)

--- a/docs/commands/typecheck.md
+++ b/docs/commands/typecheck.md
@@ -42,6 +42,7 @@ brings certain advantages:
 There are certain exceptions for practical use cases. The current allowlist is:
 
 - [jsx](https://www.typescriptlang.org/tsconfig#jsx)
+- [strict](https://www.typescriptlang.org/tsconfig#strict)
 
 Some use cases may warrant new exceptions. If this is you, please file an issue
 with the project for consideration.

--- a/packages/modular-scripts/src/typecheck.ts
+++ b/packages/modular-scripts/src/typecheck.ts
@@ -19,7 +19,7 @@ export interface TypecheckOptions {
   compareBranch: string;
 }
 
-const COMPILER_OPTIONS_ALLOW_LIST: string[] = ['jsx'];
+const COMPILER_OPTIONS_ALLOW_LIST: string[] = ['jsx', 'strict'];
 const DEFAULT_COMPILER_OPTIONS: CompilerOptions = {
   noEmit: true,
 };

--- a/packages/modular-scripts/src/typecheck.ts
+++ b/packages/modular-scripts/src/typecheck.ts
@@ -8,7 +8,10 @@ import actionPreflightCheck from './utils/actionPreflightCheck';
 import { getAllWorkspaces } from './utils/getAllWorkspaces';
 import { selectWorkspaces } from './utils/selectWorkspaces';
 
-import type { JSONSchemaForTheTypeScriptCompilerSConfigurationFile as TSConfig } from '@schemastore/tsconfig';
+import type {
+  JSONSchemaForTheTypeScriptCompilerSConfigurationFile as TSConfig,
+  CompilerOptionsDefinition,
+} from '@schemastore/tsconfig';
 
 type CompilerOptions = TSConfig['compilerOptions'];
 
@@ -19,7 +22,10 @@ export interface TypecheckOptions {
   compareBranch: string;
 }
 
-const COMPILER_OPTIONS_ALLOW_LIST: string[] = ['jsx', 'strict'];
+const COMPILER_OPTIONS_ALLOW_LIST: (keyof CompilerOptionsDefinition)[] = [
+  'jsx',
+  'strict',
+];
 const DEFAULT_COMPILER_OPTIONS: CompilerOptions = {
   noEmit: true,
 };
@@ -55,7 +61,7 @@ function restrictUserTsconfig(
 
   // Where the user has defined allowlist-supported compiler options, apply them
   for (const item of COMPILER_OPTIONS_ALLOW_LIST) {
-    if (compilerOptions && compilerOptions[item]) {
+    if (compilerOptions?.[item] !== undefined) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       combinedCompilerOptions[item] = compilerOptions[item];
     }


### PR DESCRIPTION
- Enable `strict`
- Support falsy values in configuration
- Slightly better typing