### PR TITLE
jest option to bypass modular behaviour  

### DIFF
--- a/.changeset/shiny-rings-hunt.md
+++ b/.changeset/shiny-rings-hunt.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+Added --jest flag to bypass modular test behaviour

--- a/__fixtures__/ghost-testing/packages/a/src/__tests__/a.test.ts
+++ b/__fixtures__/ghost-testing/packages/a/src/__tests__/a.test.ts
@@ -1,5 +1,5 @@
 import add from '../index';
 
-test('it should add two numbers', () => {
+test('it should add two numbers unique', () => {
   expect(add(5, 5)).toEqual(10);
 });

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -59,6 +59,10 @@ empty, Modular will write a message to `stdout` and exit with code `0`.
 
 ### Modular-specific options
 
+`--jest`: Bypass Modular selective behaviour and flags, and send all provided
+flags and options directly to the Jest process with Modular configuration.
+Useful when running `modular test` from IntelliJ.
+
 `--ancestors`: Take the packages specified by the user via arguments or options
 and add their ancestors (i.e. the packages that have a direct or indirect
 dependency on them) to the test list.
@@ -92,6 +96,21 @@ underlying Jest process.
 
 `modular test` additionally supports passing
 [Jest CLI options](https://jestjs.io/docs/cli) to the underlying Jest process.
+
+## Configuring IntelliJ
+
+IntelliJ and `modular test` aren't compatible out of the box. To make it work,
+modify the IntelliJ test configuration to use `modular test` with the `--jest`
+flag.
+
+The following is an example IntelliJ Jest configuration that uses
+`modular test`:
+
+- Jest package: `absolute_repo_path/node_modules/modular_scripts`
+
+- Working directory: `absolute_repo_path/`
+
+- Jest options: `test --jest`
 
 ## Escape Hatches
 

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -59,7 +59,7 @@ empty, Modular will write a message to `stdout` and exit with code `0`.
 
 ### Modular-specific options
 
-`--jest`: Bypass Modular selective behaviour and flags, and send all provided
+`--bypass`: Bypass Modular selective behaviour and flags, and send all provided
 flags and options directly to the Jest process with Modular configuration.
 Useful when running `modular test` from IntelliJ.
 
@@ -100,7 +100,7 @@ underlying Jest process.
 ## Configuring IntelliJ
 
 IntelliJ and `modular test` aren't compatible out of the box. To make it work,
-modify the IntelliJ test configuration to use `modular test` with the `--jest`
+modify the IntelliJ test configuration to use `modular test` with the `--bypass`
 flag.
 
 The following is an example IntelliJ Jest configuration that uses
@@ -110,7 +110,7 @@ The following is an example IntelliJ Jest configuration that uses
 
 - Working directory: `absolute_repo_path/`
 
-- Jest options: `test --jest`
+- Jest options: `test --bypass`
 
 ## Escape Hatches
 

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modular-scripts",
-  "version": "99999.0.0",
+  "version": "999999.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modular-scripts",
-  "version": "99.0.0",
+  "version": "999.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modular-scripts",
-  "version": "9999999.0.0",
+  "version": "99999999.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modular-scripts",
-  "version": "999.0.0",
+  "version": "9999.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modular-scripts",
-  "version": "9999.0.0",
+  "version": "99999.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modular-scripts",
-  "version": "999999.0.0",
+  "version": "9999999.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modular-scripts",
-  "version": "99999999.0.0",
+  "version": "4.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modular-scripts",
-  "version": "4.2.0",
+  "version": "99.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -174,6 +174,11 @@ interface CLITestOptions extends TestOptions {
 program
   .command('test [packages...]')
   .option(
+    '--jest',
+    'Bypass all modular specific selective behaviour and pass all flags and options directly to Jest. Ensures modular test behaves exactly like calling Jest directly, but with Modular configuration applied. Use with IntelliJ Jest configurations.',
+    false,
+  )
+  .option(
     '--ancestors',
     'Additionally run tests for workspaces that depend on workspaces that have changed',
     false,

--- a/packages/modular-scripts/src/program.ts
+++ b/packages/modular-scripts/src/program.ts
@@ -174,7 +174,7 @@ interface CLITestOptions extends TestOptions {
 program
   .command('test [packages...]')
   .option(
-    '--jest',
+    '--bypass',
     'Bypass all modular specific selective behaviour and pass all flags and options directly to Jest. Ensures modular test behaves exactly like calling Jest directly, but with Modular configuration applied. Use with IntelliJ Jest configurations.',
     false,
   )

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -15,7 +15,7 @@ import {
 } from '../utils/unobtrusiveModular';
 
 export interface TestOptions {
-  jest: boolean;
+  bypass: boolean;
   ancestors: boolean;
   descendants: boolean;
   bail: boolean;
@@ -70,7 +70,7 @@ function resolveJestDefaultEnvironment(name: string) {
 
 async function test(options: TestOptions, packages?: string[]): Promise<void> {
   const {
-    jest,
+    bypass,
     ancestors,
     descendants,
     changed,
@@ -113,7 +113,7 @@ async function test(options: TestOptions, packages?: string[]): Promise<void> {
   let nonModularTargets;
   let modularTargets;
 
-  if (jest) {
+  if (bypass) {
     // pass on all options
     cleanArgv.push(
       ...Object.entries(options)

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -241,7 +241,7 @@ async function test(options: TestOptions, packages?: string[]): Promise<void> {
   }
 
   // First run Modular tests with Jest. We're not iterating, but providing arguments to Jest, so we do this only if we have Modular test to run
-  if (regexes?.length || jest) {
+  if (regexes?.length || bypass) {
     logger.debug(
       `Running ${testBin} with cwd: ${getModularRoot()} and args: ${JSON.stringify(
         testArgs,

--- a/packages/modular-scripts/src/test/index.ts
+++ b/packages/modular-scripts/src/test/index.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils/unobtrusiveModular';
 
 export interface TestOptions {
+  jest: boolean;
   ancestors: boolean;
   descendants: boolean;
   bail: boolean;
@@ -69,6 +70,7 @@ function resolveJestDefaultEnvironment(name: string) {
 
 async function test(options: TestOptions, packages?: string[]): Promise<void> {
   const {
+    jest,
     ancestors,
     descendants,
     changed,
@@ -107,94 +109,121 @@ async function test(options: TestOptions, packages?: string[]): Promise<void> {
   const testEnvironment = resolvedEnv || env;
   cleanArgv.push(`--env=${testEnvironment}`);
 
-  // pass on all programatic options
-  const jestArgv = Object.entries(jestOptions).map(([key, v]) => {
-    const booleanValue = /^(true)$/.exec(String(v));
-    return `--${key}${!!booleanValue ? '' : `=${String(v)}`}`;
-  });
+  let regexes: string[] = [];
+  let nonModularTargets;
+  let modularTargets;
 
-  cleanArgv.push(...jestArgv);
+  if (jest) {
+    // pass on all options
+    cleanArgv.push(
+      ...Object.entries(options)
+        .filter(([key, v]) => {
+          return key !== 'jest' && key !== 'env';
+        })
+        .map(([key, v]) => {
+          const booleanValue = /^(true)$/.exec(String(v));
+          return `--${key}${!!booleanValue ? '' : `=${String(v)}`}`;
+        }),
+    );
 
-  const additionalOptions: string[] = [];
-  const cleanRegexes: string[] = [];
-
-  const cleanPackages: string[] = [];
-
-  // Commander seems to read options (--option) passed to the modular test command as
-  // arguments (in this case packages), so we filter them out and pass them to jest
-  if (packages) {
-    extractOptions(packages, cleanPackages, additionalOptions);
-  }
-
-  const [workspaceMap] = await getAllWorkspaces(getModularRoot());
-  const isSelective =
-    changed ||
-    ancestors ||
-    descendants ||
-    userRegexes?.length ||
-    cleanPackages.length;
-
-  let selectedTargets: string[];
-
-  if (!isSelective) {
-    // If no package and no selector is specified, all packages are specified
-    selectedTargets = [...workspaceMap.keys()];
+    // Get the options that have been incorrectly placed in packages[]
+    if (packages) {
+      const additionalOptions: string[] = [];
+      const cleanPackages: string[] = [];
+      extractOptions(packages, cleanPackages, additionalOptions);
+      cleanArgv.push(...additionalOptions);
+    }
   } else {
-    // Otherwise, calculate which packages are selected
-    selectedTargets = await selectWorkspaces({
-      targets: cleanPackages,
-      changed,
-      ancestors,
-      descendants,
-      compareBranch,
+    // pass on jest programatic options
+    const jestArgv = Object.entries(jestOptions).map(([key, v]) => {
+      const booleanValue = /^(true)$/.exec(String(v));
+      return `--${key}${!!booleanValue ? '' : `=${String(v)}`}`;
     });
+
+    cleanArgv.push(...jestArgv);
+    const additionalOptions: string[] = [];
+    const cleanRegexes: string[] = [];
+
+    const cleanPackages: string[] = [];
+
+    // Commander seems to read options (--option) passed to the modular test command as
+    // arguments (in this case packages), so we filter them out and pass them to jest
+    if (packages) {
+      extractOptions(packages, cleanPackages, additionalOptions);
+    }
+
+    const [workspaceMap] = await getAllWorkspaces(getModularRoot());
+    const isSelective =
+      changed ||
+      ancestors ||
+      descendants ||
+      userRegexes?.length ||
+      cleanPackages.length;
+
+    let selectedTargets: string[];
+
+    if (!isSelective) {
+      // If no package and no selector is specified, all packages are specified
+      selectedTargets = [...workspaceMap.keys()];
+    } else {
+      // Otherwise, calculate which packages are selected
+      selectedTargets = await selectWorkspaces({
+        targets: cleanPackages,
+        changed,
+        ancestors,
+        descendants,
+        compareBranch,
+      });
+    }
+
+    // Split packages into modular and non-modular testable. Make sure that "root" is not there.
+    [modularTargets, nonModularTargets] = partitionPackages(
+      selectedTargets,
+      workspaceMap,
+      'test',
+    );
+    // Compute patterns to pass Jest for the packages that we want to test
+    const packageRegexes = await computeRegexesFromPackageNames(modularTargets);
+
+    // Merge and dedupe selective regexes + user-specified regexes
+    regexes = [...new Set([...packageRegexes, ...(userRegexes ?? [])])];
+
+    if (regexes?.length) {
+      extractOptions(regexes, cleanRegexes, additionalOptions);
+    }
+
+    logger.debug(
+      `Modular package targets for tests are ${JSON.stringify(
+        modularTargets,
+      )}.`,
+    );
+    logger.debug(
+      `Non-modular targets selected and eligible for tests are: ${JSON.stringify(
+        nonModularTargets,
+      )}.`,
+    );
+    logger.debug(
+      `Regexes generated from Modular targets are: ${JSON.stringify(
+        packageRegexes,
+      )}.`,
+    );
+    logger.debug(`User-provided regexes are: ${JSON.stringify(userRegexes)}.`);
+    logger.debug(
+      `Final regexes to pass to Jest are: ${JSON.stringify(regexes)}.`,
+    );
+
+    // If we computed no regexes and there are no non-modular packages to test, bail out
+    if (!regexes?.length && !nonModularTargets.length) {
+      process.stdout.write('No workspaces found in selection\n');
+      process.exit(0);
+    }
+
+    // Push any additional options passed in by debugger or other processes
+    cleanArgv.push(...additionalOptions);
+
+    // Finally add the script regexes to run
+    cleanArgv.push(...cleanRegexes);
   }
-
-  // Split packages into modular and non-modular testable. Make sure that "root" is not there.
-  const [modularTargets, nonModularTargets] = partitionPackages(
-    selectedTargets,
-    workspaceMap,
-    'test',
-  );
-  // Compute patterns to pass Jest for the packages that we want to test
-  const packageRegexes = await computeRegexesFromPackageNames(modularTargets);
-
-  // Merge and dedupe selective regexes + user-specified regexes
-  const regexes = [...new Set([...packageRegexes, ...(userRegexes ?? [])])];
-
-  if (regexes?.length) {
-    extractOptions(regexes, cleanRegexes, additionalOptions);
-  }
-
-  logger.debug(
-    `Modular package targets for tests are ${JSON.stringify(modularTargets)}.`,
-  );
-  logger.debug(
-    `Non-modular targets selected and eligible for tests are: ${JSON.stringify(
-      nonModularTargets,
-    )}.`,
-  );
-  logger.debug(
-    `Regexes generated from Modular targets are: ${JSON.stringify(
-      packageRegexes,
-    )}.`,
-  );
-  logger.debug(`User-provided regexes are: ${JSON.stringify(userRegexes)}.`);
-  logger.debug(
-    `Final regexes to pass to Jest are: ${JSON.stringify(regexes)}.`,
-  );
-
-  // If we computed no regexes and there are no non-modular packages to test, bail out
-  if (!regexes?.length && !nonModularTargets.length) {
-    process.stdout.write('No workspaces found in selection\n');
-    process.exit(0);
-  }
-
-  // Push any additional options passed in by debugger or other processes
-  cleanArgv.push(...additionalOptions);
-
-  // Finally add the script regexes to run
-  cleanArgv.push(...cleanRegexes);
 
   const jestBin = await resolveAsBin('jest-cli');
   let testBin = jestBin,
@@ -212,7 +241,7 @@ async function test(options: TestOptions, packages?: string[]): Promise<void> {
   }
 
   // First run Modular tests with Jest. We're not iterating, but providing arguments to Jest, so we do this only if we have Modular test to run
-  if (regexes.length) {
+  if (regexes?.length || jest) {
     logger.debug(
       `Running ${testBin} with cwd: ${getModularRoot()} and args: ${JSON.stringify(
         testArgs,
@@ -235,17 +264,18 @@ async function test(options: TestOptions, packages?: string[]): Promise<void> {
       throw new Error('\u2715 Modular test did not pass');
     }
   }
-
-  // ...Then run non-Modular (if there are any) tests by running the tests script for each package
-  for (const target of nonModularTargets) {
-    try {
-      await execAsync(`yarn`, ['workspace', target, 'test'], {
-        cwd: getModularRoot(),
-        log: false,
-      });
-    } catch (err) {
-      logger.debug((err as ExecaError).message);
-      throw new Error('\u2715 Modular test did not pass');
+  if (nonModularTargets) {
+    // ...Then run non-Modular (if there are any) tests by running the tests script for each package
+    for (const target of nonModularTargets) {
+      try {
+        await execAsync(`yarn`, ['workspace', target, 'test'], {
+          cwd: getModularRoot(),
+          log: false,
+        });
+      } catch (err) {
+        logger.debug((err as ExecaError).message);
+        throw new Error('\u2715 Modular test did not pass');
+      }
     }
   }
 }

--- a/packages/modular-scripts/src/test/utils.ts
+++ b/packages/modular-scripts/src/test/utils.ts
@@ -223,7 +223,7 @@ export function runModularForTests(
     path.join(modularRoot, '/node_modules/.bin/ts-node'),
     [
       path.join(modularRoot, '/packages/modular-scripts/src/cli.ts'),
-      ...args.split(' '),
+      ...args.split(/ +(?=(?:(?:[^"]*"){2})*[^"]*$)/g),
     ],
     {
       cwd,


### PR DESCRIPTION
- [x] Add flag to `modular test` which sends all flags directly to Jest 
- [x] Add documentation with instructions to configure IntelliJ for modular-test
- [ ] ~~Fix jest logs not appearing in IntelliJ~~