### PR TITLE
Inherit package.json's engines field when building

### DIFF
--- a/.changeset/good-brooms-poke.md
+++ b/.changeset/good-brooms-poke.md
@@ -1,0 +1,6 @@
+---
+'modular-scripts': minor
+---
+
+`modular build` now includes the 'engines' field in the dist package.json when
+provided in the workspace or root package.json

--- a/packages/modular-scripts/src/__tests__/build.test.ts
+++ b/packages/modular-scripts/src/__tests__/build.test.ts
@@ -35,6 +35,9 @@ describe('WHEN building with preserve modules', () => {
     ).toMatchInlineSnapshot(`
       {
         "dependencies": {},
+        "engines": {
+          "node": "^14.18.0 || >=16.10.0 || >=18.0.0",
+        },
         "files": [
           "dist-cjs",
           "dist-es",

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -208,6 +208,9 @@ describe('modular-scripts', () => {
           "dependencies": {
             "react": "17.0.2",
           },
+          "engines": {
+            "node": "^14.18.0 || >=16.10.0 || >=18.0.0",
+          },
           "files": [
             "dist-cjs",
             "dist-es",
@@ -360,6 +363,9 @@ describe('modular-scripts', () => {
       ).toMatchInlineSnapshot(`
         {
           "dependencies": {},
+          "engines": {
+            "node": "^14.18.0 || >=16.10.0 || >=18.0.0",
+          },
           "files": [
             "dist-cjs",
             "dist-es",
@@ -441,6 +447,9 @@ describe('modular-scripts', () => {
       ).toMatchInlineSnapshot(`
         {
           "dependencies": {},
+          "engines": {
+            "node": "^14.18.0 || >=16.10.0 || >=18.0.0",
+          },
           "files": [
             "dist-cjs",
             "dist-es",

--- a/packages/modular-scripts/src/build-scripts/build-package/makeBundle.ts
+++ b/packages/modular-scripts/src/build-scripts/build-package/makeBundle.ts
@@ -39,7 +39,6 @@ export async function makeBundle(
   const {
     rootPackageWorkspaceDefinitions,
     rootPackageJsonDependencies,
-    rootPackageJsonEngines,
     packageJsons,
     packageJsonsByPackagePath,
     packageNames,
@@ -56,11 +55,6 @@ export async function makeBundle(
   const logger = getPrefixedLogger(packageName);
 
   const packageJson = packageJsonsByPackagePath[packagePath];
-
-  // If engines field is not defined in the package's package.json, inherit it from the root package.json
-  if (!packageJson.engines) {
-    packageJson.engines = rootPackageJsonEngines;
-  }
 
   const main = await getPackageEntryPoints(packagePath, includePrivate);
 

--- a/packages/modular-scripts/src/build-scripts/build-package/makeBundle.ts
+++ b/packages/modular-scripts/src/build-scripts/build-package/makeBundle.ts
@@ -39,6 +39,7 @@ export async function makeBundle(
   const {
     rootPackageWorkspaceDefinitions,
     rootPackageJsonDependencies,
+    rootPackageJsonEngines,
     packageJsons,
     packageJsonsByPackagePath,
     packageNames,
@@ -55,6 +56,11 @@ export async function makeBundle(
   const logger = getPrefixedLogger(packageName);
 
   const packageJson = packageJsonsByPackagePath[packagePath];
+
+  // If engines field is not defined in the package's package.json, inherit it from the root package.json
+  if (!packageJson.engines) {
+    packageJson.engines = rootPackageJsonEngines;
+  }
 
   const main = await getPackageEntryPoints(packagePath, includePrivate);
 

--- a/packages/modular-scripts/src/build-scripts/buildStandalone.ts
+++ b/packages/modular-scripts/src/build-scripts/buildStandalone.ts
@@ -26,6 +26,7 @@ import { getDependencyInfo } from '../utils/getDependencyInfo';
 import { isReactNewApi } from '../utils/isReactNewApi';
 import { getConfig } from '../utils/config';
 import buildWebpack from './webpack-scripts/buildWebpack';
+import getModularRoot from '../utils/getModularRoot';
 
 export async function buildStandalone(
   target: string,
@@ -176,6 +177,11 @@ export async function buildStandalone(
   const targetPackageJson = (await fs.readJSON(
     path.join(targetDirectory, 'package.json'),
   )) as ModularPackageJson;
+
+  const rootPackageJson = (await fs.readJSON(
+    path.join(getModularRoot(), 'package.json'),
+  )) as ModularPackageJson;
+
   // Copy selected fields of package.json over
   await fs.writeJson(
     path.join(paths.appBuild, 'package.json'),
@@ -191,6 +197,7 @@ export async function buildStandalone(
       module: jsEntryPoint ? paths.publicUrlOrPath + jsEntryPoint : undefined,
       style: cssEntryPoint ? paths.publicUrlOrPath + cssEntryPoint : undefined,
       styleImports: styleImports?.size ? [...styleImports] : undefined,
+      engines: targetPackageJson.engines ?? rootPackageJson.engines,
     },
     { spaces: 2 },
   );

--- a/packages/modular-scripts/src/utils/getPackageMetadata.ts
+++ b/packages/modular-scripts/src/utils/getPackageMetadata.ts
@@ -33,6 +33,9 @@ async function getPackageMetadata() {
   // dependencies defined at the root
   const rootPackageJsonDependencies = rootPackageJson.dependencies || {};
 
+  // engines defined at the root
+  const rootPackageJsonEngines = rootPackageJson.engines;
+
   // let's populate the above three
   const [workspaces] = await getAllWorkspaces();
 
@@ -106,6 +109,7 @@ async function getPackageMetadata() {
     packageNames,
     rootPackageWorkspaceDefinitions,
     rootPackageJsonDependencies,
+    rootPackageJsonEngines,
     packageJsons,
     typescriptConfig,
     packageJsonsByPackagePath,

--- a/packages/modular-scripts/src/utils/getPackageMetadata.ts
+++ b/packages/modular-scripts/src/utils/getPackageMetadata.ts
@@ -48,6 +48,10 @@ async function getPackageMetadata() {
 
   Array.from(workspaces).forEach(([packageName, workspace]) => {
     packageJsons[packageName] = workspace.rawPackageJson;
+    if (!packageJsons[packageName].engines) {
+      // If engines field is not defined in the package's package.json, inherit it from the root package.json
+      packageJsons[packageName].engines = rootPackageJsonEngines;
+    }
     packageJsonsByPackagePath[workspace.location] = workspace.rawPackageJson;
   });
 


### PR DESCRIPTION
- [x] Inherit engines filed from workspace's package.json when building a package/app/esm-view/view
- [x] Use the root's package.json's engines field if not specified in workspace
- [x] Update test snapshots
