### PR TITLE
Deprecate Node 14 Support & add Node 20 & switch to es2017

### DIFF
--- a/.changeset/spotty-hornets-hug.md
+++ b/.changeset/spotty-hornets-hug.md
@@ -1,0 +1,7 @@
+---
+'create-modular-react-app': major
+'eslint-config-modular-app': major
+'modular-scripts': major
+---
+
+Dropped Node 14 support, added Node 20 support. Changed target to ES2017

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: ['14.18.0', '16.x', '18.x']
+        node-version: ['16.x', '18.x']
         yarn-version: ['1.22.19', '3.5.0']
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: ['16.x', '18.x']
+        node-version: ['16.x', '18.x', '20.x']
         yarn-version: ['1.22.19', '3.5.0']
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3.3.0
         with:
-          node-version: '14.18.0'
+          node-version: '18.x'
           registry-url: https://registry.npmjs.org/
           cache: 'yarn'
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3.3.0
         with:
-          node-version: '14.18.0'
+          node-version: '18.x'
           cache: 'yarn'
 
       - name: 'Install Dependencies'

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        node-version: ['14.18.0', '16.x', '18.x']
+        node-version: ['16.x', '18.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        node-version: ['16.x', '18.x']
+        node-version: ['16.x', '18.x', '20.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: ['16.x', '18.x']
+        node-version: ['16.x', '18.x', '20.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: ['14.18.0', '16.x', '18.x']
+        node-version: ['16.x', '18.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 14
+      - name: Use Node.js 18
         uses: actions/setup-node@v3.3.0
         with:
-          node-version: 14
+          node-version: 18
           cache: 'yarn'
       - name: Install Dependencies
         run: yarn --frozen-lockfile

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,7 @@ module.exports = (api) => {
         {
           targets: {
             // TODO: can we get this to read from package.json somehow..?
-            node: '14',
+            node: '16',
           },
         },
       ],

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -38,17 +38,16 @@ If you find any example of v3 features which cause Modular to fail, please
 
 ### Yarn v4 and beyond
 
-We aim to support future versions of Yarn, and we've sucessuflly useds Modular
+We aim to support future versions of Yarn, and we've successfully used Modular
 with an unstable release candidate of Yarn 4. If there's something we don't
 support properly, please
 [let us know](https://github.com/jpmorganchase/modular/issues).
 
 ## Node versions
 
-Modular is tested on the latest three
-[Long Term Support versions of Node.js (v14, v16 and v18)](https://github.com/nodejs/release#release-schedule).
-Node.js v14 is supported from version `14.18.0` onwards, while Node 16 is
-supported from version `16.10.0` onwards.
+Modular is tested on the current
+[Long Term Support versions of Node.js: v16, v18 and v20](https://github.com/nodejs/release#release-schedule).
+Node 16 is supported from version `16.10.0` onwards.
 
 ## Platforms
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "packages/**"
   ],
   "engines": {
-    "node": "^14.18.0 || >=16.10.0 || >=18.0.0"
+    "node": ">=16.10.0 || >=18.0.0 || >=20.0.0"
   },
   "repository": "https://github.com/jpmorganchase/modular.git",
   "scripts": {

--- a/packages/create-modular-react-app/package.json
+++ b/packages/create-modular-react-app/package.json
@@ -11,7 +11,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": "^14.18.0 || >=16.10.0 || >=18.0.0"
+    "node": ">=16.10.0 || >=18.0.0 || >=20.0.0"
   },
   "scripts": {
     "create-modular-react-app": "ts-node src/cli.ts",

--- a/packages/eslint-config-modular-app/package.json
+++ b/packages/eslint-config-modular-app/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "main": "index.js",
   "engines": {
-    "node": "^14.18.0 || >=16.10.0 || >=18.0.0"
+    "node": ">=16.10.0 || >=18.0.0 || >=20.0.0"
   },
   "exports": {
     ".": "./index.js",

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -18,7 +18,7 @@
     "./tsconfig.json": "./tsconfig.json"
   },
   "engines": {
-    "node": "^14.18.0 || >=16.10.0 || >=18.0.0"
+    "node": ">=16.10.0 || >=18.0.0 || >=20.0.0"
   },
   "scripts": {
     "modular": "ts-node src/cli.ts",

--- a/packages/modular-scripts/src/__tests__/build.test.ts
+++ b/packages/modular-scripts/src/__tests__/build.test.ts
@@ -36,7 +36,7 @@ describe('WHEN building with preserve modules', () => {
       {
         "dependencies": {},
         "engines": {
-          "node": "^14.18.0 || >=16.10.0 || >=18.0.0",
+          "node": ">=16.10.0 || >=18.0.0 || >=20.0.0",
         },
         "files": [
           "dist-cjs",

--- a/packages/modular-scripts/src/__tests__/index.test.ts
+++ b/packages/modular-scripts/src/__tests__/index.test.ts
@@ -209,7 +209,7 @@ describe('modular-scripts', () => {
             "react": "17.0.2",
           },
           "engines": {
-            "node": "^14.18.0 || >=16.10.0 || >=18.0.0",
+            "node": ">=16.10.0 || >=18.0.0 || >=20.0.0",
           },
           "files": [
             "dist-cjs",
@@ -364,7 +364,7 @@ describe('modular-scripts', () => {
         {
           "dependencies": {},
           "engines": {
-            "node": "^14.18.0 || >=16.10.0 || >=18.0.0",
+            "node": ">=16.10.0 || >=18.0.0 || >=20.0.0",
           },
           "files": [
             "dist-cjs",
@@ -448,7 +448,7 @@ describe('modular-scripts', () => {
         {
           "dependencies": {},
           "engines": {
-            "node": "^14.18.0 || >=16.10.0 || >=18.0.0",
+            "node": ">=16.10.0 || >=18.0.0 || >=20.0.0",
           },
           "files": [
             "dist-cjs",

--- a/packages/modular-scripts/src/test/config.ts
+++ b/packages/modular-scripts/src/test/config.ts
@@ -63,7 +63,7 @@ export function createJestConfig(
               module: { type: 'commonjs', strictMode: true, noInterop: false },
               jsc: {
                 externalHelpers: false,
-                target: 'es2016',
+                target: 'es2017',
                 parser: {
                   syntax: 'typescript',
                   tsx: true,

--- a/packages/modular-scripts/tsconfig.json
+++ b/packages/modular-scripts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2017",
     "downlevelIteration": true,
     "lib": ["dom", "dom.iterable", "esnext", "WebWorker"],
     "allowJs": true,


### PR DESCRIPTION
- [x] Remove Node 14 from tests
- [x] Add Node 20 to tests
- [x] Remove Node 14 from engines
- [x] Add Node 20 to engines
- [x] Remove Node 14 from docs
- [x] Add Node 20 to docs
- [x] Switch target to ES2017 from ES2016